### PR TITLE
Changing language mode of open editors for newly registered languages

### DIFF
--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -78,8 +78,15 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function registerLanguage(context: vscode.ExtensionContext, client:LanguageClient, lang:LanguageParameter) {
     // first we load the new language into the parametric server
-    client.sendRequest("rascal/sendRegisterLanguage", lang);
-
+    client.onReady().then(() => {
+        client.sendRequest("rascal/sendRegisterLanguage", lang).then(() => {
+            for (const editor of vscode.window.visibleTextEditors) {
+                if (editor.document.uri.path.endsWith(lang.extension)) {
+                    vscode.languages.setTextDocumentLanguage(editor.document, ALL_LANGUAGES_ID);
+                }
+            }
+        });
+    });
     if (lang.extension && lang.extension !== "") {
         registeredFileExtensions.add(lang.extension);
     }


### PR DESCRIPTION
When a language is registered, open editors are not automatically updated. This change checks whether there are active editors at registration time