### PR TITLE
Changing language mode of open editors for newly registered languages

### DIFF
--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -107,7 +107,13 @@ export function registerLanguage(lang:LanguageParameter) {
     }
     // first we load the new language into the parametric server
     parametricClient.onReady().then(() => {
-        parametricClient!.sendRequest("rascal/sendRegisterLanguage", lang);
+        parametricClient!.sendRequest("rascal/sendRegisterLanguage", lang).then(() => {
+            for (const editor of vscode.window.visibleTextEditors) {
+                if (editor.document.uri.path.endsWith(lang.extension)) {
+                    vscode.languages.setTextDocumentLanguage(editor.document, ALL_LANGUAGES_ID);
+                }
+            }
+        });
     });
     if (lang.extension && lang.extension !== "") {
         registeredFileExtensions.add(lang.extension);


### PR DESCRIPTION
When a language is registered, open editors are not automatically updated. This change checks whether there are active editors at registration time