### PR TITLE
Delaying launching Rascal terminals until the language server is ready

### DIFF
--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -220,14 +220,15 @@ async function startTerminal(uri: vscode.Uri, ...extraArgs: string[]) {
         rascalClient = activateRascalLanguageClient();
     }
     console.log("Starting:" + uri + extraArgs);
-    await (await rascalClient).onReady();
-    const serverConfig = (await rascalClient).sendRequest<IDEServicesConfiguration>("rascal/supplyIDEServicesConfiguration");
-    const compilationPath = (await rascalClient).sendRequest<string[]>("rascal/supplyProjectCompilationClasspath", { uri: uri.toString() });
+    const rascal = await rascalClient;
+    await rascal.onReady();
+    const serverConfig = await rascal.sendRequest<IDEServicesConfiguration>("rascal/supplyIDEServicesConfiguration");
+    const compilationPath = await rascal.sendRequest<string[]>("rascal/supplyProjectCompilationClasspath", { uri: uri.toString() });
 
     const terminal = vscode.window.createTerminal({
         cwd: path.dirname(uri.fsPath),
         shellPath: await getJavaExecutable(),
-        shellArgs: buildShellArgs(await compilationPath, await serverConfig, ...extraArgs),
+        shellArgs: buildShellArgs(compilationPath, serverConfig, ...extraArgs),
         name: 'Rascal Terminal',
     });
 


### PR DESCRIPTION
Currently, if the Start Rascal Terminal command is issued while the Rascal server is not already running, no terminal appears. This change checks whether the language server is ready first.

I would not be surprised if there would be a somewhat less convoluted way to express this though.