### PR TITLE
Added inlay support to the rascal side

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
@@ -59,6 +59,8 @@ import org.rascalmpl.library.util.PathConfig.RascalConfigMode;
 import org.rascalmpl.shell.ShellEvaluatorFactory;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.vscode.lsp.extensions.InlayHint;
+import org.rascalmpl.vscode.lsp.extensions.ProvideInlayHintsParams;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.uri.ProjectURIResolver;
 import org.rascalmpl.vscode.lsp.uri.TargetURIResolver;
@@ -227,6 +229,11 @@ public abstract class BaseLanguageServer {
         @Override
         public CompletableFuture<Void> sendRegisterLanguage(LanguageParameter lang) {
             return CompletableFuture.runAsync(() -> lspDocumentService.registerLanguage(lang));
+        }
+
+        @Override
+        public CompletableFuture<List<? extends InlayHint>> provideInlayHints(ProvideInlayHintsParams params) {
+            return lspDocumentService.provideInlayHints(params);
         }
 
         @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseLanguageServerExtensions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseLanguageServerExtensions.java
@@ -26,10 +26,12 @@
  */
 package org.rascalmpl.vscode.lsp;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.rascalmpl.vscode.lsp.extensions.InlayHint;
+import org.rascalmpl.vscode.lsp.extensions.ProvideInlayHintsParams;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 
 public interface IBaseLanguageServerExtensions  extends LanguageServer, IRascalFileSystemServices {
@@ -45,6 +47,11 @@ public interface IBaseLanguageServerExtensions  extends LanguageServer, IRascalF
 
     @JsonRequest("rascal/supplyProjectCompilationClasspath")
     default CompletableFuture<String[]> supplyProjectCompilationClasspath(URIParameter projectFolder) {
+        throw new UnsupportedOperationException();
+    }
+
+    @JsonRequest("rascal/provideInlayHints")
+    default CompletableFuture<List<? extends InlayHint>> provideInlayHints(ProvideInlayHintsParams params) {
         throw new UnsupportedOperationException();
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -26,14 +26,15 @@
  */
 package org.rascalmpl.vscode.lsp;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
+import org.rascalmpl.vscode.lsp.extensions.InlayHint;
+import org.rascalmpl.vscode.lsp.extensions.ProvideInlayHintsParams;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.util.locations.LineColumnOffsetMap;
-
 import io.usethesource.vallang.ISourceLocation;
 
 public interface IBaseTextDocumentService extends TextDocumentService {
@@ -43,4 +44,5 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     void registerLanguage(LanguageParameter lang);
     CompletableFuture<Void> executeCommand(String extension, String command);
     LineColumnOffsetMap getColumnMap(ISourceLocation file);
+    CompletableFuture<List<? extends InlayHint>> provideInlayHints(ProvideInlayHintsParams params);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/InlayHint.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/InlayHint.java
@@ -3,7 +3,7 @@ package org.rascalmpl.vscode.lsp.extensions;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 public class InlayHint {
@@ -11,16 +11,21 @@ public class InlayHint {
     private final String label;
 
     @NonNull
-    private final Position position;
+    private final Range range;
 
     @MonotonicNonNull
     private final String category;
 
+    @NonNull
+    private final boolean before;
 
-    public InlayHint(String label, Position position, @Nullable String category) {
+
+
+    public InlayHint(String label, Range range, @Nullable String category, boolean before) {
         this.label = label;
-        this.position = position;
+        this.range = range;
         this.category = category;
+        this.before = before;
     }
 
     public @Nullable String getCategory() {
@@ -30,8 +35,13 @@ public class InlayHint {
     public String getLabel() {
         return label;
     }
-    public Position getPosition() {
-        return position;
+
+    public Range getRange() {
+        return range;
+    }
+
+    public boolean isBefore() {
+        return before;
     }
 
     @Override
@@ -39,15 +49,16 @@ public class InlayHint {
         if (obj instanceof InlayHint) {
             InlayHint other = (InlayHint)obj;
             return other.label.equals(label)
-                && other.position.equals(position)
+                && other.range.equals(range)
                 && Objects.equals(other.category, category)
+                && other.before == before
                 ;
         }
         return false;
     }
     @Override
     public int hashCode() {
-        return Objects.hash(label, position, category);
+        return Objects.hash(label, range, category, before);
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/InlayHint.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/InlayHint.java
@@ -1,0 +1,53 @@
+package org.rascalmpl.vscode.lsp.extensions;
+
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+public class InlayHint {
+    @NonNull
+    private final String label;
+
+    @NonNull
+    private final Position position;
+
+    @MonotonicNonNull
+    private final String category;
+
+
+    public InlayHint(String label, Position position, @Nullable String category) {
+        this.label = label;
+        this.position = position;
+        this.category = category;
+    }
+
+    public @Nullable String getCategory() {
+        return category;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+    public Position getPosition() {
+        return position;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof InlayHint) {
+            InlayHint other = (InlayHint)obj;
+            return other.label.equals(label)
+                && other.position.equals(position)
+                && Objects.equals(other.category, category)
+                ;
+        }
+        return false;
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(label, position, category);
+    }
+
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/InlayHint.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/InlayHint.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2018-2021, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.rascalmpl.vscode.lsp.extensions;
 
 import java.util.Objects;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/ProvideInlayHintsParams.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/ProvideInlayHintsParams.java
@@ -1,0 +1,46 @@
+package org.rascalmpl.vscode.lsp.extensions;
+
+import com.google.common.base.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+public class ProvideInlayHintsParams {
+    @NonNull
+    private TextDocumentIdentifier textDocument;
+
+    @Nullable
+    private Range range;
+
+    public ProvideInlayHintsParams() {}
+
+    public ProvideInlayHintsParams(TextDocumentIdentifier textDocument, @Nullable Range range) {
+        this.textDocument = textDocument;
+        this.range = range;
+    }
+
+    public TextDocumentIdentifier getTextDocument() {
+        return textDocument;
+    }
+
+    public @Nullable Range getRange() {
+        return range;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ProvideInlayHintsParams) {
+            ProvideInlayHintsParams other = (ProvideInlayHintsParams)obj;
+            return Objects.equal(other.textDocument, textDocument) && Objects.equal(other.range, range);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(textDocument, range);
+    }
+
+
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/ProvideInlayHintsParams.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/extensions/ProvideInlayHintsParams.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2018-2021, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.rascalmpl.vscode.lsp.extensions;
 
 import com.google.common.base.Objects;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -42,4 +42,5 @@ public interface ILanguageContributions {
     public CompletableFuture<IConstructor> summarize(ISourceLocation loc, ITree input);
     public CompletableFuture<ISet> lenses(ITree input);
     public CompletableFuture<Void> executeCommand(String command);
+    public CompletableFuture<ISet> inlayHint(ITree input);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -42,5 +42,5 @@ public interface ILanguageContributions {
     public CompletableFuture<IConstructor> summarize(ISourceLocation loc, ITree input);
     public CompletableFuture<ISet> lenses(ITree input);
     public CompletableFuture<Void> executeCommand(String command);
-    public CompletableFuture<ISet> inlayHint(ITree input);
+    public CompletableFuture<IList> inlayHint(ITree input);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -27,6 +27,7 @@
 package org.rascalmpl.vscode.lsp.parametric;
 
 import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.values.parsetrees.ITree;
 
 import io.usethesource.vallang.IConstructor;
@@ -42,5 +43,5 @@ public interface ILanguageContributions {
     public CompletableFuture<IConstructor> summarize(ISourceLocation loc, ITree input);
     public CompletableFuture<ISet> lenses(ITree input);
     public CompletableFuture<Void> executeCommand(String command);
-    public CompletableFuture<IList> inlayHint(ITree input);
+    public CompletableFuture<IList> inlayHint(@Nullable ITree input);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -166,8 +166,8 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<IList> inlayHint(ITree input) {
-        logger.debug("inlayHinter({})", TreeAdapter.getLocation(input));
+    public CompletableFuture<IList> inlayHint(@Nullable ITree input) {
+        logger.debug("inlayHinter({})", input != null ? TreeAdapter.getLocation(input) : null);
         return execFunction("inlayHinter", inlayHinter, VF.list(), input);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -166,9 +166,9 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<ISet> inlayHint(ITree input) {
+    public CompletableFuture<IList> inlayHint(ITree input) {
         logger.debug("inlayHinter({})", TreeAdapter.getLocation(input));
-        return execFunction("inlayHinter", inlayHinter, VF.set(), input);
+        return execFunction("inlayHinter", inlayHinter, VF.list(), input);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -74,6 +74,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private final CompletableFuture<@Nullable IFunction> summarizer;
     private final CompletableFuture<@Nullable IFunction> lenses;
     private final CompletableFuture<@Nullable IFunction> commandExecutor;
+    private final CompletableFuture<@Nullable IFunction> inlayHinter;
 
 
     public InterpretedLanguageContributions(LanguageParameter lang, IBaseTextDocumentService docService, IBaseLanguageClient client, ExecutorService exec) {
@@ -97,6 +98,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
             this.summarizer = contributions.thenApply(s -> getFunctionFor(s, "summarizer"));
             this.lenses = contributions.thenApply(s -> getFunctionFor(s, "lenses"));
             this.commandExecutor = contributions.thenApply(s -> getFunctionFor(s, "executor"));
+            this.inlayHinter = contributions.thenApply(s -> getFunctionFor(s, "inlayHinter"));
         } catch (IOException e1) {
             logger.catching(e1);
             throw new RuntimeException(e1);
@@ -164,6 +166,12 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
+    public CompletableFuture<ISet> inlayHint(ITree input) {
+        logger.debug("inlayHinter({})", TreeAdapter.getLocation(input));
+        return execFunction("inlayHinter", inlayHinter, VF.set(), input);
+    }
+
+    @Override
     public CompletableFuture<Void> executeCommand(String command) {
         logger.debug("executeCommand({})", command);
         return parseCommand(command)
@@ -188,4 +196,5 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
                 return s.call(args);
         }, exec);
     }
+
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
+import javax.swing.Icon;
 import com.google.common.io.CharStreams;
 
 import org.apache.logging.log4j.LogManager;
@@ -106,7 +106,7 @@ import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
 import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
-
+import io.usethesource.vallang.IBool;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISourceLocation;
@@ -288,11 +288,17 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     private InlayHint rowToInlayHint(IValue v) {
-        ITuple t = (ITuple) v;
-        ISourceLocation loc = (ISourceLocation) t.get(0);
-        IString label = (IString) t.get(1);
-        IString kind = (IString) t.get(2);
-        return new InlayHint(label.getValue(), Locations.toPosition(loc, columns), kind.getValue());
+        IConstructor t = (IConstructor) v;
+        ISourceLocation loc = (ISourceLocation) t.get("range");
+        IString label = (IString) t.get("label");
+        IConstructor kind = (IConstructor) t.get("kind");
+        IBool before = (IBool)t.asWithKeywordParameters().getParameter("before");
+
+        String kindName = kind.getName();
+        if (kindName.equals("other")) {
+            kindName = ((IString)kind.get("name")).getValue();
+        }
+        return new InlayHint(label.getValue(), Locations.toRange(loc, columns), kindName, before.getValue());
     }
 
     private CodeLens locCommandTupleToCodeLense(String extension, IValue v) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -33,14 +33,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.swing.Icon;
 import com.google.common.io.CharStreams;
 
 import org.apache.logging.log4j.LogManager;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -296,7 +296,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         if (kindName.equals("other")) {
             kindName = ((IString)kind.get("name")).getValue();
         }
-        return new InlayHint(label.getValue(), Locations.toRange(loc, columns), kindName, before.getValue());
+        return new InlayHint(label.getValue(), Locations.toRange(loc, columns), kindName, before == null ? false : before.getValue());
     }
 
     private CodeLens locCommandTupleToCodeLense(String extension, IValue v) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -87,6 +87,8 @@ import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
+import org.rascalmpl.vscode.lsp.extensions.InlayHint;
+import org.rascalmpl.vscode.lsp.extensions.ProvideInlayHintsParams;
 import org.rascalmpl.vscode.lsp.rascal.RascalLanguageServices.CodeLensSuggestion;
 import org.rascalmpl.vscode.lsp.rascal.model.FileFacts;
 import org.rascalmpl.vscode.lsp.rascal.model.SummaryBridge;
@@ -386,6 +388,13 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public CompletableFuture<Void> executeCommand(String extension, String command) {
         // there is currently no way the Rascal LSP can receive this, but the Rascal DSL LSP does.
         logger.warn("ignoring execute command in Rascal LSP: " + extension + "," + command);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<List<? extends InlayHint>> provideInlayHints(ProvideInlayHintsParams params) {
+        // currently inlay hints not supported by rascal yet
+        logger.warn("ignoring inlay hints for Rascal LSP: {}", params.getTextDocument());
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -28,7 +28,7 @@ package org.rascalmpl.vscode.lsp.util.locations;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-
+import org.apache.lucene.search.TopDocs;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -104,6 +104,10 @@ public class Locations {
 
     public static Position toPosition(int line, int column, LineColumnOffsetMap map, boolean atEnd) {
         return new Position(line, map.translateColumn(line, column, atEnd));
+    }
+
+    public static Position toPosition(ISourceLocation loc, ColumnMaps cm) {
+        return toPosition(loc.getBeginLine() - 1, loc.getBeginColumn(), cm.get(loc), false);
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -28,7 +28,6 @@ package org.rascalmpl.vscode.lsp.util.locations;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import org.apache.lucene.search.TopDocs;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -69,7 +69,7 @@ rel[loc,Command] picoLenses(start[Program] input) = {<input@\loc, renameAtoB(inp
 
 
 list[InlayHint] picoHinter(start[Program] input) {
-    typeLookup = ( "<name>" : "<tp>" | /(Declaration)`<Id name> : <Type tp>` := input);
+    typeLookup = ( "<name>" : "<tp>" | /(IdType)`<Id name> : <Type tp>` := input);
     return [
         hint(name.src, ": <typeLookup["<name>"]>", \type()) | /(Expression)`<Id name>` := input
     ];

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -88,7 +88,7 @@ void main() {
             pathConfig(),
             "Pico",
             "pico",
-            "util::TestIDE",
+            "demo::lang::pico::LanguageServer",
             "picoLanguageContributor"
         )
     );

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -67,9 +67,13 @@ data Command
 
 rel[loc,Command] picoLenses(start[Program] input) = {<input@\loc, renameAtoB(input, title="Rename variables a to b.")>};
 
-list[InlayHint] picoHinter(start[Program] input) = [
-    hint(s.src, " fits any text", parameter()) | /s:(Type)`string` := input
-];
+
+list[InlayHint] picoHinter(start[Program] input) {
+    typeLookup = ( "<name>" : "<tp>" | /(Declaration)`<Id name> : <Type tp>` := input);
+    return [
+        hint(name.src, ": <typeLookup["<name>"]>", \type()) | /(Expression)`<Id name>` := input
+    ];
+}
 
 list[DocumentEdit] getAtoBEdits(start[Program] input)
    = [changed(input@\loc.top, [replace(id@\loc, "b") | /id:(Id) `a` := input])];

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -40,7 +40,8 @@ set[LanguageService] picoLanguageContributor() = {
     outliner(picoOutliner),
     summarizer(picoSummarizer),
     lenses(picoLenses),
-    executor(picoCommands)
+    executor(picoCommands),
+    inlayHinter(picoHinter)
 };
 
 list[DocumentSymbol] picoOutliner(start[Program] input)
@@ -60,10 +61,15 @@ Summary picoSummarizer(loc l, start[Program] input) {
     );
 }
 
+
 data Command
   = renameAtoB(start[Program] program);
 
 rel[loc,Command] picoLenses(start[Program] input) = {<input@\loc, renameAtoB(input, title="Rename variables a to b.")>};
+
+list[InlayHint] picoHinter(start[Program] input) = [
+    hint(s.src, " fits any text", parameter()) | /s:(Type)`string` := input
+];
 
 list[DocumentEdit] getAtoBEdits(start[Program] input)
    = [changed(input@\loc.top, [replace(id@\loc, "b") | /id:(Id) `a` := input])];

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -48,7 +48,7 @@ alias Completer        = list[Completion] (Tree /*input*/, str /*prefix*/, int /
 alias Builder          = list[Message] (list[loc] /*sources*/, PathConfig /*pcfg*/);
 alias LensDetector     = rel[loc src, Command lens] (Tree /*input*/);
 alias CommandExecutor  = void (Command /*command*/);
-alias InlayHinter      = rel[loc src, str label, HintKind kind] (Tree /*input*/);
+alias InlayHinter      = list[InlayHint] (Tree /*input*/);
 
 @synopsis{Each kind of service contibutes the implementation of one (or several) IDE features.}
 data LanguageService
@@ -123,7 +123,15 @@ data Command(str title="")
     = noop()
     ;
 
-data InlayKind
+data InlayHint
+    = hint(
+        loc range, // should point to a cursor position (begin and end column same)
+        str label, // text that should be printed in the ide
+        InlayKind kind,
+        bool before = false // if the hint precedes or follows the text it's hinting
+    );
+
+data InlayKind // this determines style
     = \type()
     | parameter()
     | other(str name)

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -126,7 +126,7 @@ data Command(str title="")
 data InlayHint
     = hint(
         loc range, // should point to a cursor position (begin and end column same)
-        str label, // text that should be printed in the ide
+        str label, // text that should be printed in the ide, spaces in front and back of the text are trimmed and turned into subtle spacing to the content around it.
         InlayKind kind,
         bool before = false // if the hint precedes or follows the text it's hinting
     );

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -48,6 +48,7 @@ alias Completer        = list[Completion] (Tree /*input*/, str /*prefix*/, int /
 alias Builder          = list[Message] (list[loc] /*sources*/, PathConfig /*pcfg*/);
 alias LensDetector     = rel[loc src, Command lens] (Tree /*input*/);
 alias CommandExecutor  = void (Command /*command*/);
+alias InlayHinter      = rel[loc src, str label, HintKind kind] (Tree /*input*/);
 
 @synopsis{Each kind of service contibutes the implementation of one (or several) IDE features.}
 data LanguageService
@@ -57,6 +58,7 @@ data LanguageService
     | completer(Completer completer)
     | builder(Builder builder)
     | lenses(LensDetector detector)
+    | inlayHinter(InlayHinter hinter)
     | executor(CommandExecutor executor)
     ;
 
@@ -119,6 +121,12 @@ data CompletionProposal = sourceProposal(str newText, str proposal=newText);
 
 data Command(str title="")
     = noop()
+    ;
+
+data InlayKind
+    = \type()
+    | parameter()
+    | other(str name)
     ;
 
 @javaClass{org.rascalmpl.vscode.lsp.parametric.RascalInterface}

--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -32,10 +32,11 @@ import * as net from 'net';
 import * as cp from 'child_process';
 import * as os from 'os';
 
-import {LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo, integer } from 'vscode-languageclient/node';
+import {LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo, integer, TextDocumentIdentifier, Range } from 'vscode-languageclient/node';
 import { RascalFileSystemProvider } from './RascalFileSystemProviders';
 import { RascalTerminalLinkProvider } from './RascalTerminalLinkProvider';
 import { getJavaExecutable } from './auto-jvm/JavaLookup';
+import { addHintApi } from './hintExtension';
 
 const deployMode = (process.env.RASCAL_LSP_DEV || "false") !== "true";
 const ALL_LANGUAGES_ID = 'parametric-rascalmpl';
@@ -135,9 +136,11 @@ export function activateRascalLanguageClient(): Promise<LanguageClient> {
     }
 }
 
-export function activateParametricLanguageClient(): Promise<LanguageClient> {
+export async function activateParametricLanguageClient(): Promise<LanguageClient> {
     try {
-        return activateLanguageClient('parametric-rascalmpl', 'org.rascalmpl.vscode.lsp.parametric.ParametricLanguageServer', 'Language Parametric Rascal Language Server', 9999, true);
+        const result = await activateLanguageClient('parametric-rascalmpl', 'org.rascalmpl.vscode.lsp.parametric.ParametricLanguageServer', 'Language Parametric Rascal Language Server', 9999, true);
+        addHintApi(result, rascalExtensionContext!, ALL_LANGUAGES_ID);
+        return result;
     } finally {
         console.log('LSP (Parametric) server started');
     }

--- a/rascal-vscode-extension/src/hintExtension.ts
+++ b/rascal-vscode-extension/src/hintExtension.ts
@@ -71,7 +71,7 @@ export function addHintApi(client: LanguageClient, context: vscode.ExtensionCont
     vscode.window.onDidChangeActiveTextEditor(e => {
         activeEditor = e;
         if (e) {
-            triggerDecorations(e, client);
+            setTimeout(() => triggerDecorations(e, client), 500);
         }
     }, null, context.subscriptions);
 

--- a/rascal-vscode-extension/src/hintExtension.ts
+++ b/rascal-vscode-extension/src/hintExtension.ts
@@ -28,6 +28,17 @@ import * as vscode from 'vscode';
 import { LanguageClient, Range, TextDocumentIdentifier } from 'vscode-languageclient/node';
 
 
+/*
+This module adds inlayHint support to rascal until it is supported in mainline vscode.
+
+The code inspired by:
+    - vscode-extension-samples (the decorator example) (MIT license)
+    - vscode: vscode.proposed.inlayHints.d.ts (MIT license)
+    - vscode: inlayHintsController.ts (MIT license)
+    - rust-analyzer: Apache License
+    - discussion in https://github.com/microsoft/language-server-protocol/issues/956
+    - discussion in https://github.com/microsoft/language-server-protocol/pull/1249
+*/
 
 function buildThemeBlock(kind: string): vscode.ThemableDecorationAttachmentRenderOptions {
     return {
@@ -101,7 +112,6 @@ function triggerDecorations(editor: vscode.TextEditor, client: LanguageClient) {
                             // add non-joiner to prevent ligatures
                             contentText: h.before ? (label + "\u{200c}") : ("\u{200c}" + label),
                             margin: `0px ${marginAfter} 0px ${marginBefore}`
-
                         }
                     }
                 };

--- a/rascal-vscode-extension/src/hintExtension.ts
+++ b/rascal-vscode-extension/src/hintExtension.ts
@@ -91,12 +91,17 @@ function triggerDecorations(editor: vscode.TextEditor, client: LanguageClient) {
         let others: vscode.DecorationOptions[] = [];
         if (hints) {
             hints.forEach(h => {
+                const marginBefore = h.label.startsWith(" ") ? "0.25ex" : "0px";
+                const marginAfter = h.label.endsWith(" ") ? "0.25ex" : "0px";
+                const label = h.label.trim();
                 const decl = <vscode.DecorationOptions> {
                     range: client.protocol2CodeConverter.asRange(h.range),
                     renderOptions: {
                         [h.before ? "before" : "after"]: {
                             // add non-joiner to prevent ligatures
-                            contentText: h.before ? (h.label + "\u{200c}") : ("\u{200c}" + h.label)
+                            contentText: h.before ? (label + "\u{200c}") : ("\u{200c}" + label),
+                            margin: `0px ${marginAfter} 0px ${marginBefore}`
+
                         }
                     }
                 };

--- a/rascal-vscode-extension/src/hintExtension.ts
+++ b/rascal-vscode-extension/src/hintExtension.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2018-2021, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+import * as vscode from 'vscode';
+import { LanguageClient, Range, TextDocumentIdentifier } from 'vscode-languageclient/node';
+
+
+
+function buildThemeBlock(kind: string): vscode.ThemableDecorationAttachmentRenderOptions {
+    return {
+        color: new vscode.ThemeColor(`editorInlayHint.${kind}${kind ==="" ? "f": "F"}oreground`),
+        backgroundColor: new vscode.ThemeColor(`editorInlayHint.${kind}${kind ==="" ? "b": "B"}ackground`),
+        fontStyle: "normal",
+        fontWeight: "normal",
+    };
+
+}
+
+const inlayHintDecoratorStyle = {
+    "type": vscode.window.createTextEditorDecorationType({
+        before: buildThemeBlock("type"),
+        after: buildThemeBlock("type"),
+    }),
+    "parameter": vscode.window.createTextEditorDecorationType({
+        before: buildThemeBlock("parameter"),
+        after: buildThemeBlock("parameter"),
+    }),
+    "other": vscode.window.createTextEditorDecorationType({
+        before: buildThemeBlock(""),
+        after: buildThemeBlock(""),
+    })
+}
+;
+
+export function addHintApi(client: LanguageClient, context: vscode.ExtensionContext, languageId : string) {
+    let activeEditor = vscode.window.activeTextEditor;
+    vscode.window.onDidChangeActiveTextEditor(e => {
+        activeEditor = e;
+        if (e) {
+            triggerDecorations(e, client);
+        }
+    }, null, context.subscriptions);
+
+    function trigger() {
+        if (activeEditor && activeEditor.document.languageId === languageId) {
+            triggerDecorations(activeEditor, client);
+        }
+    }
+
+    let updater = setTimeout(trigger, 500);
+    vscode.workspace.onDidChangeTextDocument(e => {
+        // only trigger if the document is also the current visible one
+        if (activeEditor && e.document === activeEditor.document) {
+            // now we de-jitter it, so that only after 500ms of no changes do we
+            // request for new decorations
+            clearTimeout(updater);
+            updater = setTimeout(trigger, 500);
+        }
+    }, null, context.subscriptions);
+}
+
+function triggerDecorations(editor: vscode.TextEditor, client: LanguageClient) {
+    client.sendRequest<InlayHint[]>("rascal/provideInlayHints", <ProvideInlayHintParameter>{
+        textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
+    }).then(hints => {
+        let params: vscode.DecorationOptions[] = [];
+        let types: vscode.DecorationOptions[] = [];
+        let others: vscode.DecorationOptions[] = [];
+        if (hints) {
+            hints.forEach(h => {
+                const decl = <vscode.DecorationOptions> {
+                    range: client.protocol2CodeConverter.asRange(h.range),
+                    renderOptions: {
+                        [h.before ? "before" : "after"]: {
+                            // add non-joiner to prevent ligatures
+                            contentText: h.before ? (h.label + "\u{200c}") : ("\u{200c}" + h.label)
+                        }
+                    }
+                };
+                switch (h.category) {
+                    case "parameter":
+                        params.push(decl);
+                        break;
+                    case "type":
+                        types.push(decl);
+                        break;
+                    default:
+                        others.push(decl);
+                        break;
+                }
+            });
+        }
+        editor.setDecorations(inlayHintDecoratorStyle.parameter, params);
+        editor.setDecorations(inlayHintDecoratorStyle.type, types);
+        editor.setDecorations(inlayHintDecoratorStyle.other, others);
+    });
+}
+
+
+interface ProvideInlayHintParameter {
+    textDocument: TextDocumentIdentifier;
+    range: Range | undefined;
+}
+
+interface InlayHint {
+    label: string,
+    range: Range,
+    category?: string;
+    before: boolean;
+}


### PR DESCRIPTION
Fixing the static part discussed in #119

Screenshot of the inlay hints added to the pico example: 
![image](https://user-images.githubusercontent.com/179603/146911635-8708963e-01df-422e-a546-a8ba38b29aad.png)
