### PR TITLE
Allow creating a rascal terminal without associating it with a project

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/LSPTerminalREPL.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/LSPTerminalREPL.java
@@ -108,14 +108,23 @@ public class LSPTerminalREPL extends BaseREPL {
                     URIResolverRegistry reg = URIResolverRegistry.getInstance();
 
                     ISourceLocation projectDir = ShellEvaluatorFactory.inferProjectRoot(new File(System.getProperty("user.dir")));
-                    String projectName = new RascalManifest().getProjectName(projectDir);
+                    String projectName = "unknown-project";
+                    if (projectDir != null) {
+                        projectName = new RascalManifest().getProjectName(projectDir);
+                    }
 
                     reg.registerLogical(new ProjectURIResolver(services::resolveProjectLocation));
                     reg.registerLogical(new TargetURIResolver(services::resolveProjectLocation));
 
                     try {
-                        PathConfig pcfg = PathConfig.fromSourceProjectRascalManifest(projectDir, RascalConfigMode.INTERPETER);
-
+                        PathConfig pcfg;
+                        if (projectDir != null) {
+                            pcfg = PathConfig.fromSourceProjectRascalManifest(projectDir, RascalConfigMode.INTERPETER);
+                        }
+                        else {
+                            // TODO: see if we need to do something special for RascalConfigMode flag for this default path config
+                            pcfg = new PathConfig();
+                        }
                         evaluator.getErrorPrinter().println("Rascal Version: " + RascalManifest.getRascalVersionNumber());
                         evaluator.getErrorPrinter().println("Rascal-lsp Version: " + getRascalLspVersion());
                         new StandardTextWriter(true).write(pcfg.asConstructor(), evaluator.getErrorPrinter());

--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -188,11 +188,8 @@ export function deactivate() {
 }
 
 function registerTerminalCommand() {
-    const command = vscode.commands.registerTextEditorCommand("rascalmpl.createTerminal", (text, edit) => {
-        if (!text.document.uri) {
-            return;
-        }
-        startTerminal(text.document.uri);
+    const command = vscode.commands.registerCommand("rascalmpl.createTerminal", () => {
+        startTerminal(vscode.window.activeTextEditor?.document.uri);
     });
     rascalExtensionContext!.subscriptions.push(command);
 }
@@ -218,7 +215,7 @@ function registerImportModule() {
     rascalExtensionContext!.subscriptions.push(command);
 }
 
-async function startTerminal(uri: vscode.Uri, ...extraArgs: string[]) {
+async function startTerminal(uri: vscode.Uri | undefined, ...extraArgs: string[]) {
     if (!rascalClient) {
         rascalClient = activateRascalLanguageClient();
     }
@@ -226,10 +223,10 @@ async function startTerminal(uri: vscode.Uri, ...extraArgs: string[]) {
     const rascal = await rascalClient;
     await rascal.onReady();
     const serverConfig = await rascal.sendRequest<IDEServicesConfiguration>("rascal/supplyIDEServicesConfiguration");
-    const compilationPath = await rascal.sendRequest<string[]>("rascal/supplyProjectCompilationClasspath", { uri: uri.toString() });
+    const compilationPath = await rascal.sendRequest<string[]>("rascal/supplyProjectCompilationClasspath", { uri: uri?.toString() });
 
     const terminal = vscode.window.createTerminal({
-        cwd: path.dirname(uri.fsPath),
+        cwd: path.dirname(uri?.fsPath || ""),
         shellPath: await getJavaExecutable(),
         shellArgs: buildShellArgs(compilationPath, serverConfig, ...extraArgs),
         name: 'Rascal Terminal',


### PR DESCRIPTION
This PR adds functionality so that we don't assume a valid project directory for the rascal terminal. Your terminal will work, but won't be linked to any rascal project.

Fixes #121


Scenario's tested:

- creating a terminal without any editors open
- creating a terminal with an editor open (those are still linked to the current active editor)
