### PR TITLE
Also publish to open vsx

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
         with:
           packagePath: ./rascal-vscode-extension
           pat: ${{ secrets.OPEN_VSX_ACCESS }}
+          registryUrl: https://open-vsx.org 
 
       - name: Publish release to Visual Studio Marketplace
         if: startsWith(github.ref, 'refs/tags/v')
@@ -75,7 +76,7 @@ jobs:
           packagePath: ./rascal-vscode-extension
           pat: ${{ secrets.AZURE_USETHESOURCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }} # copy exact same vsix from the previous step
 
       - name: rewrite package.json & readme for NPM package
         working-directory: rascal-vscode-extension

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,14 @@ jobs:
           path: rascal-vscode-extension/*.vsix
           retention-days: 20
 
+      - name: Publish release to Open VSX Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
+        with:
+          packagePath: ./rascal-vscode-extension
+          pat: ${{ secrets.OPEN_VSX_ACCESS }}
+
       - name: Publish release to Visual Studio Marketplace
         if: startsWith(github.ref, 'refs/tags/v')
         uses: HaaLeo/publish-vscode-extension@v1
@@ -67,6 +75,7 @@ jobs:
           packagePath: ./rascal-vscode-extension
           pat: ${{ secrets.AZURE_USETHESOURCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
 
       - name: rewrite package.json & readme for NPM package
         working-directory: rascal-vscode-extension


### PR DESCRIPTION
This fixed #233

Since the github action we used already supported this, and the manual explained how to set it up so that it uses the same exact vsix, I feel comfertable that this would work for the next release.