### PR TITLE
Adding support for Rascal Project creation PR-redo

### DIFF
--- a/rascal-vscode-extension/package-lock.json
+++ b/rascal-vscode-extension/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.x",
+        "@types/node": "^16.18.23",
         "@types/node-fetch": "^2.5.12",
         "@types/tar": "^6.1.1",
         "@types/temp": "^0.9.1",
@@ -273,9 +273,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
-      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
+      "version": "16.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -5434,9 +5434,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
-      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
+      "version": "16.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -30,6 +30,7 @@
   ],
   "activationEvents": [
     "onCommand:rascalmpl.createTerminal",
+    "onCommand:rascalmpl.createProject",
     "onLanguage:rascalmpl"
   ],
   "main": "./dist/extension.js",
@@ -46,6 +47,10 @@
       {
         "command": "rascalmpl.importMain",
         "title": "Start Rascal Terminal and Import this module"
+      },
+      {
+        "command": "rascalmpl.createProject",
+        "title": "Create new Rascal project"
       }
     ],
     "languages": [
@@ -112,7 +117,7 @@
   "devDependencies": {
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.x",
+    "@types/node": "^16.18.23",
     "@types/node-fetch": "^2.5.12",
     "@types/tar": "^6.1.1",
     "@types/temp": "^0.9.1",

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -28,12 +28,17 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { writeFileSync } from 'fs';
+
 import { integer } from 'vscode-languageclient/node';
 import { getJavaExecutable } from './auto-jvm/JavaLookup';
 import { RascalLanguageServer } from './lsp/RascalLanguageServer';
 import { LanguageParameter, ParameterizedLanguageServer } from './lsp/ParameterizedLanguageServer';
 import { RascalTerminalLinkProvider } from './RascalTerminalLinkProvider';
 import { VSCodeUriResolverServer } from './fs/VSCodeURIResolver';
+
+const vsfs = vscode.workspace.fs;
+const URI = vscode.Uri;
 
 export class RascalExtension implements vscode.Disposable {
     private readonly vfsServer: VSCodeUriResolverServer;
@@ -50,6 +55,7 @@ export class RascalExtension implements vscode.Disposable {
         this.registerTerminalCommand();
         this.registerMainRun();
         this.registerImportModule();
+        this.createProject();
 
         vscode.window.registerTerminalLinkProvider(new RascalTerminalLinkProvider(this.rascal.rascalClient));
     }
@@ -87,6 +93,34 @@ export class RascalExtension implements vscode.Disposable {
         );
     }
 
+    private createProject() {
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("rascalmpl.createProject", 
+            async () => {
+                try {
+                    const filePath = await vscode.window.showOpenDialog({
+                        canSelectFiles: false,
+                        canSelectFolders: true,
+                        canSelectMany: false,
+                        title: "New Rascal project",
+                    });
+
+                    if (filePath) {
+                        const dest = filePath[0].path;
+                        const destUri = URI.file(dest);
+                        const projectName = dest.split("/").at(-1) as string;
+
+                        newRascalProject(dest, projectName);
+
+                        // Open a workspace window
+                        await vscode.commands.executeCommand("vscode.openFolder", destUri, true);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            })
+        );
+    }
 
     private registerImportModule() {
         this.context.subscriptions.push(
@@ -183,3 +217,105 @@ function calculateRascalREPLMemory() {
     }
     return "-Xmx800M";
 }
+
+async function newRascalProject(dest: string, name: string) {
+        
+    const baseDest = URI.file(dest);
+    vsfs.createDirectory(baseDest);
+
+    const metaPath = URI.joinPath(baseDest, "META-INF");
+    await vsfs.createDirectory(metaPath);
+
+    const srcPath = URI.joinPath(baseDest, "src/main/rascal/");
+    await vsfs.createDirectory(srcPath);
+
+    const rascalMFPath = URI.joinPath(metaPath, "RASCAL.MF");
+    writeFileSync(rascalMFPath.fsPath, rascalMF(name));
+
+    const pomPath = URI.joinPath(baseDest, "pom.xml");
+    writeFileSync(pomPath.fsPath, pomXML(name));
+
+    const mainPath = URI.joinPath(srcPath, "Main.rsc");
+    writeFileSync(mainPath.fsPath, emptyModule);
+
+}
+
+function rascalMF(name: string): string {
+    return "Manifest-Version: 0.0.1\n" +
+            `Project-Name: ${name}\n` +
+            "Source: src/main/rascal\n" +
+            "Require-Libraries: \n"
+            ;
+}
+
+function pomXML(name: string, group="org.rascalmpl", version="0.1.0-SNAPSHOT"): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+      <modelVersion>4.0.0</modelVersion>
+    
+      <groupId>${group}</groupId>
+      <artifactId>${name}</artifactId>
+      <version>${version}</version>
+    
+      <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      </properties>
+    
+      <repositories>
+        <repository>
+            <id>usethesource</id>
+            <url>https://releases.usethesource.io/maven/</url>
+        </repository>
+      </repositories>
+    
+      <pluginRepositories>
+        <pluginRepository>
+           <id>usethesource</id>
+           <url>https://releases.usethesource.io/maven/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    
+      <dependencies>
+        <dependency>
+          <groupId>org.rascalmpl</groupId>
+          <artifactId>rascal</artifactId>
+          <version><getRascalVersion()></version>
+        </dependency>
+      </dependencies>
+    
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+              <compilerArgument>-parameters</compilerArgument> 
+              <release>11</release>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.rascalmpl</groupId>
+            <artifactId>rascal-maven-plugin</artifactId>
+            <version>0.8.2</version>
+            <configuration>
+              <errorsAsWarnings>true</errorsAsWarnings>
+              <bin>\${project.build.outputDirectory}</bin>
+              <srcs>
+                <src>$\{project.basedir}/src/main/rascal</src>
+              </srcs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </project>
+    `;
+}
+
+const emptyModule = "module Main\n" +
+                    "import IO;\n\n"+
+                    "int main(int testArgument=0) {\n" +
+                    `   println("argument: <testArgument>");\n` +
+                    "   return testArgument;\n"+
+                    "}";


### PR DESCRIPTION
Hi @maveme I hope you don't mind we continue the discussion of #246 here.

Let's take some time to discuss the tradeoffs properly.


My concerns:
1. We already have  `util::Reflective::createRascalProject` that also sets up the correct files. I would prefer reusing this, as that way we don't have to have duplicate knowledge (and bugfixes) of how to correctly generate a project. If you need a pointer to how we call rascal from typescript, take a look at how `sendRegisterLanguage` is wired through. I'll be happy to jump on a call and discuss this.
2. I think @jurgenvinju 's point was that it might be too much work to do that, if you don't have the bandwidth for that, it's fine, but then there are some points in the code we should fix (I'll leave some review comments).