### PR TITLE
make sure internal warnings end up in the terminal window instead of as a warning pop-up. Fixes #258

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/LSPTerminalREPL.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/LSPTerminalREPL.java
@@ -128,6 +128,10 @@ public class LSPTerminalREPL extends BaseREPL {
                         evaluator.getErrorPrinter().println("Rascal-lsp Version: " + getRascalLspVersion());
                         new StandardTextWriter(true).write(pcfg.asConstructor(), evaluator.getErrorPrinter());
 
+                        if (services instanceof TerminalIDEClient) {
+                            ((TerminalIDEClient) services).registerErrorPrinter(evaluator.getErrorPrinter());
+                        }
+                        
                         for (IValue path : pcfg.getSrcs()) {
                             evaluator.addRascalSearchPath((ISourceLocation) path);
                             reg.watch((ISourceLocation) path, true, d -> sourceLocationChanged(pcfg, d));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
@@ -50,7 +50,6 @@ import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.RegisterDiagnosticsP
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.RegisterLocationsParameters;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.SourceLocationParameter;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.UnRegisterDiagnosticsParameters;
-import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.WarningMessage;
 import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
@@ -73,6 +73,7 @@ public class TerminalIDEClient implements IDEServices {
     private final ITerminalIDEServer server;
     private static final Logger logger = LogManager.getLogger(TerminalIDEClient.class);
     private final ColumnMaps columns = new ColumnMaps(this::getContents);
+    private PrintWriter err;
 
     public TerminalIDEClient(int port) throws IOException {
         @SuppressWarnings("java:S2095") // we don't have to close the socket, we are passing it off to the lsp4j framework
@@ -216,7 +217,18 @@ public class TerminalIDEClient implements IDEServices {
 
     @Override
     public void warning(String message, ISourceLocation src) {
-        server.warning(new WarningMessage(message, src));
+        if (err != null) {
+            // normally we want to see the errors where we triggered them,
+            // i.e. inside the terminal window:
+            err.println(src + ":" + message);
+        }
+        else {
+            // but, this may happen if something is already writing warnings before the interpreter
+            // is fully initialized and connected to an output stream.
+            // to be sure nothing is lost, we use log4j here to store the message in the
+            // right place.
+            logger.warn("{}: {}", src, message);
+        }
     }
 
     @Override
@@ -235,5 +247,9 @@ public class TerminalIDEClient implements IDEServices {
     @Override
     public void unregisterDiagnostics(IList resources) {
         server.unregisterDiagnostics(new UnRegisterDiagnosticsParameters(resources));
+    }
+
+    public void registerErrorPrinter(PrintWriter errorPrinter) {
+        this.err = errorPrinter;
     }
 }


### PR DESCRIPTION
This fixes #258 by posting the warnings on the error stream of the interpreter, rather than as UI pop-up. Due to start-up time it logs to log4j while the error printer is not yet available. Just in case. I don't think there is currently a situation where the `warning` method could be called during startup, but you never know what might change in the future. 