### PR TITLE
Fix unhandled Rascal starting commands

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -38,14 +38,6 @@
       {
         "command": "rascalmpl.createTerminal",
         "title": "Create Rascal Terminal"
-      },
-      {
-        "command": "rascalmpl.runMain",
-        "title": "Start Rascal Terminal, Import module and Run main function"
-      },
-      {
-        "command": "rascalmpl.importMain",
-        "title": "Start Rascal Terminal and Import this module"
       }
     ],
     "languages": [


### PR DESCRIPTION
Removed Code Lens commands from the extension manifest as they are not required and not supposed to be registered here as they are code lens commands and not usual commands.

Fix the issue [#220](https://github.com/usethesource/rascal-language-servers/issues/220)