### PR TITLE
Ask the user to update the JDK installed by Rascal Extension if new release is out

### DIFF
--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -29,7 +29,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { integer } from 'vscode-languageclient/node';
-import { getJavaExecutable } from './auto-jvm/JavaLookup';
+import { checkForJVMUpdate, getJavaExecutable } from './auto-jvm/JavaLookup';
 import { RascalLanguageServer } from './lsp/RascalLanguageServer';
 import { LanguageParameter, ParameterizedLanguageServer } from './lsp/ParameterizedLanguageServer';
 import { RascalTerminalLinkProvider } from './RascalTerminalLinkProvider';
@@ -50,6 +50,7 @@ export class RascalExtension implements vscode.Disposable {
         this.registerTerminalCommand();
         this.registerMainRun();
         this.registerImportModule();
+        checkForJVMUpdate();
 
         vscode.window.registerTerminalLinkProvider(new RascalTerminalLinkProvider(this.rascal.rascalClient));
     }

--- a/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
+++ b/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
@@ -180,7 +180,7 @@ async function downloadJDK(): Promise<string> {
     }
 
     const result = await downloadJDKWithProgress(choice);
-    vscode.window.showInformationMessage(`Finished downloading ${choice} JDK, rascal will now start`);
+    vscode.window.showInformationMessage(`Finished downloading ${choice} JDK, Rascal will now start`);
     return result;
 }
 

--- a/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
+++ b/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
@@ -32,6 +32,7 @@ import * as dl from './downloaders';
 import {  existsSync, readdirSync } from 'fs';
 import { promisify } from 'util';
 import { readReleaseInfo } from './ReleaseInfo';
+import { readdir, stat } from 'fs/promises';
 
 
 const currentJVMEngineMin = 11;
@@ -203,10 +204,11 @@ async function downloadJDKWithProgress(choice: string) {
 }
 
 export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
-    if (existsSync(mainJVMsPath)) {
-        for (const ent of readdirSync(mainJVMsPath, {  }).sort().reverse()) {
+    if (await stat(mainJVMsPath)) {
+        const files = await readdir(mainJVMsPath, {  });
+        for (const ent of files.sort().reverse()) {
             const releaseFilePath = path.join(mainJVMsPath, ent.toString(), "release");
-            const releaseInfo = readReleaseInfo(releaseFilePath);
+            const releaseInfo = await readReleaseInfo(releaseFilePath);
             if(!releaseInfo.implementor){
                 continue;
             }

--- a/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
+++ b/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
@@ -28,11 +28,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import * as cp from 'child_process';
-import { correttoSupported, downloadCorretto, downloadMicrosoftJDK, 
-    downloadTemurin, microsoftSupported, temurinSupported, 
-    identifyLatestTemurinLTSRelease, mapTemuringCorrettoArch, mapTemurinPlatform, 
-    mapCorrettoPlatform, identifyLatestCorrettoRelease, mapMSArchitectures, 
-    mapMSPlatforms, identifyLatestMicrofotJDKRelease } from './downloaders';
+import * as dl from './downloaders';
 import {  existsSync, readdirSync } from 'fs';
 import { promisify } from 'util';
 import { readReleaseInfo } from './ReleaseInfo';
@@ -168,13 +164,13 @@ async function openSettings(): Promise<string> {
 
 async function downloadJDK(): Promise<string> {
     const options = [];
-    if (temurinSupported(currentPreferredJVMEngine)) {
+    if (dl.temurinSupported(currentPreferredJVMEngine)) {
         options.push(temurin);
     }
-    if (microsoftSupported(currentPreferredJVMEngine)) {
+    if (dl.microsoftSupported(currentPreferredJVMEngine)) {
         options.push(msJava);
     }
-    if (correttoSupported(currentPreferredJVMEngine)) {
+    if (dl.correttoSupported(currentPreferredJVMEngine)) {
         options.push(amazon);
     }
     const choice = await vscode.window.showInformationMessage("Select which OpenJDK provider you prefer", {modal:true}, ...options);
@@ -198,9 +194,9 @@ async function downloadJDKWithProgress(choice: string) {
             progress.report({message: message, increment: percIncrement});
         }
         switch (choice) {
-            case temurin: return downloadTemurin(mainJVMPath, currentPreferredJVMEngine, actualProgress);
-            case msJava: return downloadMicrosoftJDK(mainJVMPath, currentPreferredJVMEngine, actualProgress);
-            case amazon: return downloadCorretto(mainJVMPath, currentPreferredJVMEngine, actualProgress);
+            case temurin: return dl.downloadTemurin(mainJVMPath, currentPreferredJVMEngine, actualProgress);
+            case msJava: return dl.downloadMicrosoftJDK(mainJVMPath, currentPreferredJVMEngine, actualProgress);
+            case amazon: return dl.downloadCorretto(mainJVMPath, currentPreferredJVMEngine, actualProgress);
             default:  throw new Error("User setup required");
         }
     });
@@ -219,7 +215,7 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
                     if(!releaseInfo.full_version){
                         break;
                     }
-                    const latest = await identifyLatestTemurinLTSRelease(currentPreferredJVMEngine, mapTemuringCorrettoArch(), mapTemurinPlatform());
+                    const latest = await dl.identifyLatestTemurinLTSRelease(currentPreferredJVMEngine, dl.mapTemuringCorrettoArch(), dl.mapTemurinPlatform());
                     if("jdk-"+releaseInfo.full_version !== latest){
                         askUserForJVMUpdate(temurin);
                     }
@@ -229,7 +225,7 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
                     if(!releaseInfo.java_version){
                         break;
                     }
-                    const latest = await identifyLatestMicrofotJDKRelease(currentPreferredJVMEngine, mapMSArchitectures(), mapMSPlatforms());
+                    const latest = await dl.identifyLatestMicrofotJDKRelease(currentPreferredJVMEngine, dl.mapMSArchitectures(), dl.mapMSPlatforms());
                     if(releaseInfo.java_version !== latest){
                         askUserForJVMUpdate(msJava);
                     }
@@ -239,7 +235,7 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
                     if(!releaseInfo.implementor_version){
                         break;
                     }
-                    const latest = await identifyLatestCorrettoRelease(currentPreferredJVMEngine, mapTemuringCorrettoArch(), mapCorrettoPlatform());
+                    const latest = await dl.identifyLatestCorrettoRelease(currentPreferredJVMEngine, dl.mapTemuringCorrettoArch(), dl.mapCorrettoPlatform());
                     if(releaseInfo.implementor_version.slice(9) !== latest){
                         askUserForJVMUpdate(amazon);
                     }

--- a/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
+++ b/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 /* eslint-disable @typescript-eslint/naming-convention */
 import { existsSync, readFileSync } from "fs";
 

--- a/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
+++ b/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
@@ -58,7 +58,7 @@ export function readReleaseInfo(path:string) : ReleaseInfo {
         lines.forEach(line => {
             const keyValue = line.split("=");
             if(keyValue.length === 2){
-                releaseInfo[keyValue[0].toLowerCase()] = keyValue[1].replaceAll('"', '').replace("\r", "");
+                releaseInfo[keyValue[0].toLowerCase()] = keyValue[1].substring(1, keyValue[1].length-2).trim();
             }
         });
     }

--- a/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
+++ b/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { existsSync, readFileSync } from "fs";
+
+export interface ReleaseInfo {
+    implementor?: string,
+    implementor_version?: string,
+    java_runtime_version?: string,
+    java_version?: string,
+    java_version_date?: string,
+    libc?: string,
+    modules?: string,
+    os_arch?: string,
+    os_name?: string,
+    source?: string,
+    build_source?: string,
+    build_source_repo?: string,
+    source_repo?: string,
+    full_version?: string,
+    semantic_version?: string,
+    build_info?: string,
+    jvm_variant?: string,
+    jvm_version?: string,
+    image_type?: string,
+}
+
+export function readReleaseInfo(path:string) : ReleaseInfo {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const releaseInfo: any = {};
+    if(existsSync(path)){
+        const content = readFileSync(path, {  }).toString();
+        const lines = content.split('\n');
+        lines.forEach(line => {
+            const keyValue = line.split("=");
+            if(keyValue.length === 2){
+                releaseInfo[keyValue[0].toLowerCase()] = keyValue[1].replaceAll('"', '').replace("\r", "");
+            }
+        });
+    }
+    return releaseInfo as ReleaseInfo;
+}

--- a/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
+++ b/rascal-vscode-extension/src/auto-jvm/ReleaseInfo.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { existsSync, readFileSync } from "fs";
+import { readFile, stat } from "fs/promises";
 
 export interface ReleaseInfo {
     implementor?: string,
@@ -49,11 +49,11 @@ export interface ReleaseInfo {
     image_type?: string,
 }
 
-export function readReleaseInfo(path:string) : ReleaseInfo {
+export async function readReleaseInfo(path:string) : Promise<ReleaseInfo> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const releaseInfo: any = {};
-    if(existsSync(path)){
-        const content = readFileSync(path, {  }).toString();
+    if(await stat(path)){
+        const content = await readFile(path, "utf-8");
         const lines = content.split('\n');
         lines.forEach(line => {
             const keyValue = line.split("=");

--- a/rascal-vscode-extension/src/auto-jvm/downloaders.ts
+++ b/rascal-vscode-extension/src/auto-jvm/downloaders.ts
@@ -186,7 +186,7 @@ export async function identifyLatestCorrettoRelease(version: number, arch: Temur
     const url = `https://corretto.aws/downloads/latest/amazon-corretto-${version}-${arch}-${platform}-jdk.${platform === "windows" ? "zip" : "tar.gz"}`;
     const response = await fetch(url, {method: 'HEAD'});
     const fileUrl = response.url;
-    const versionPattern = /resources\/((\d*\.?)+)\//;
+    const versionPattern = /resources\/([0-9.]+)\//;
     const match = fileUrl.match(versionPattern);
     if(!match){
         throw new Error(`unexpected response url ${response}`);
@@ -200,7 +200,7 @@ export async function identifyLatestMicrofotJDKRelease(version: number, arch: MS
     const url = `https://aka.ms/download-jdk/microsoft-jdk-${version}-${platform}-${arch}.${platform === "windows" ? "zip" : "tar.gz"}`;
     const response = await fetch(url, {method: 'HEAD'});
     const fileUrl = response.url;
-    const versionPattern = /jdk-((\d*\.?)+)-/;
+    const versionPattern = /jdk-([0-9.]+)-/;
     const match = fileUrl.match(versionPattern);
     if(!match){
         throw new Error(`unexpected response url ${response}`);

--- a/rascal-vscode-extension/src/auto-jvm/downloaders.ts
+++ b/rascal-vscode-extension/src/auto-jvm/downloaders.ts
@@ -184,7 +184,7 @@ export async function identifyLatestTemurinLTSRelease(version: number, arch: Tem
 
 export async function identifyLatestCorrettoRelease(version: number, arch: TemurinArchitectures, platform: CorrettoPlatforms): Promise<string> {
     const url = `https://corretto.aws/downloads/latest/amazon-corretto-${version}-${arch}-${platform}-jdk.${platform === "windows" ? "zip" : "tar.gz"}`;
-    const response = await fetch(url);
+    const response = await fetch(url, {method: 'HEAD'});
     const fileUrl = response.url;
     const versionPattern = /resources\/((\d*\.?)+)\//;
     const match = fileUrl.match(versionPattern);
@@ -198,7 +198,7 @@ export async function identifyLatestCorrettoRelease(version: number, arch: Temur
 // Does not identify +x versions
 export async function identifyLatestMicrofotJDKRelease(version: number, arch: MSArchitectures, platform: MSPlatforms): Promise<string> {
     const url = `https://aka.ms/download-jdk/microsoft-jdk-${version}-${platform}-${arch}.${platform === "windows" ? "zip" : "tar.gz"}`;
-    const response = await fetch(url);
+    const response = await fetch(url, {method: 'HEAD'});
     const fileUrl = response.url;
     const versionPattern = /jdk-((\d*\.?)+)-/;
     const match = fileUrl.match(versionPattern);

--- a/rascal-vscode-extension/tsconfig.json
+++ b/rascal-vscode-extension/tsconfig.json
@@ -4,8 +4,7 @@
 		"target": "es2020",
 		"outDir": "out",
 		"lib": [
-			"es2020",
-			"ES2021.String"
+			"es2020"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/rascal-vscode-extension/tsconfig.json
+++ b/rascal-vscode-extension/tsconfig.json
@@ -4,7 +4,8 @@
 		"target": "es2020",
 		"outDir": "out",
 		"lib": [
-			"es2020"
+			"es2020",
+			"ES2021.String"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
Automatically checks if the last jdk version is installed, if not, ask the user to update it and then download it.

Fix the [#273](https://github.com/usethesource/rascal-language-servers/issues/273)

![auto-update](https://github.com/usethesource/rascal-language-servers/assets/34212910/afea9a6c-a72c-454c-b507-4cd78110396d)
