### PR TITLE
Make Interpreter Heap and Stack Size Configurable

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -125,15 +125,15 @@
   "configuration": {
       "title": "Rascal",
       "properties": {
-        "rascal.interpreter.defaultHeapSize": {
+        "rascal.interpreter.maxHeapSize": {
           "type": ["number", "null"],
           "default": null,
-          "description": "Provides the default heap space, in MB, for the Rascal interpreter"
+          "description": "Provides the maximum heap space, in MB, for the Rascal interpreter"
         },
-        "rascal.interpreter.defaultStackSize": {
+        "rascal.interpreter.stackSize": {
           "type": ["number", "null"],
           "default": null,
-          "description": "Provides the default stack size, in MB, for the Rascal interpreter"
+          "description": "Provides the per-thread stack size, in MB, for the Rascal interpreter"
         }
       }
     }

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -121,7 +121,22 @@
         "scopeName": "source.parametric-rascalmpl",
         "path": "./syntaxes/parametric.tmGrammar.json"
       }
-    ]
+    ],
+  "configuration": {
+      "title": "Rascal",
+      "properties": {
+        "rascal.interpreter.defaultHeapSize": {
+          "type": ["number", "null"],
+          "default": null,
+          "description": "Provides the default heap space, in MB, for the Rascal interpreter"
+        },
+        "rascal.interpreter.defaultStackSize": {
+          "type": ["number", "null"],
+          "default": null,
+          "description": "Provides the default stack size, in MB, for the Rascal interpreter"
+        }
+      }
+    }
   },
   "scripts": {
     "lsp4j:package": "cp ../rascal-lsp/target/rascal-lsp*.jar assets/jars/rascal-lsp.jar && cp ../rascal-lsp/target/lib/*.jar assets/jars/",

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -179,10 +179,10 @@ function gb(amount: integer) {
 
 function calculateRascalREPLMemory() {
     const config = vscode.workspace.getConfiguration();
-    if (config.has('rascal.interpreter.defaultHeapSize')) {
-        const defaultHeapSize = config.get('rascal.interpreter.defaultHeapSize');
-        if (defaultHeapSize !== null) {
-            return `-Xmx${defaultHeapSize}M`;
+    if (config.has('rascal.interpreter.maxHeapSize')) {
+        const maxHeapSize = config.get('rascal.interpreter.maxHeapSize');
+        if (maxHeapSize !== null) {
+            return `-Xmx${maxHeapSize}M`;
         }
     }
     
@@ -201,10 +201,10 @@ function calculateRascalREPLMemory() {
 
 function calculateRascalREPLStackSize() {
     const config = vscode.workspace.getConfiguration();
-    if (config.has('rascal.interpreter.defaultStackSize')) {
-        const defaultStackSize = config.get('rascal.interpreter.defaultStackSize');
-        if (defaultStackSize !== null) {
-            return `-Xss${defaultStackSize}M`;
+    if (config.has('rascal.interpreter.stackSize')) {
+        const stackSize = config.get('rascal.interpreter.stackSize');
+        if (stackSize !== null) {
+            return `-Xss${stackSize}M`;
         }
     }
 

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -133,9 +133,15 @@ export class RascalExtension implements vscode.Disposable {
     private buildShellArgs(classPath: string[], ide: IDEServicesConfiguration, ...extraArgs: string[]) {
         const shellArgs = [
                 calculateRascalREPLMemory()
-                , '-cp'
-                , this.buildTerminalJVMPath() + (classPath.length > 0 ? (path.delimiter + classPath.join(path.delimiter)) : ''),
         ];
+        const replStackSize = calculateRascalREPLStackSize();
+        if (replStackSize.length !== 0) {
+            shellArgs.push(replStackSize);
+        }
+        shellArgs.push(
+            '-cp'
+            , this.buildTerminalJVMPath() + (classPath.length > 0 ? (path.delimiter + classPath.join(path.delimiter)) : ''),
+        );
         if (!this.isDeploy) {
             // for development mode we always start the terminal with debuging ready to go
             shellArgs.push(
@@ -172,6 +178,14 @@ function gb(amount: integer) {
 }
 
 function calculateRascalREPLMemory() {
+    const config = vscode.workspace.getConfiguration();
+    if (config.has('rascal.interpreter.defaultHeapSize')) {
+        const defaultHeapSize = config.get('rascal.interpreter.defaultHeapSize');
+        if (defaultHeapSize !== null) {
+            return `-Xmx${defaultHeapSize}M`;
+        }
+    }
+    
     if (os.totalmem() >= gb(32)) {
         return "-Xmx9000M";
     }
@@ -182,5 +196,17 @@ function calculateRascalREPLMemory() {
     if (os.totalmem() >= gb(8)) {
         return "-Xmx2400M";
     }
-    return "-Xmx800M";
+    return "-Xmx800M";    
+}
+
+function calculateRascalREPLStackSize() {
+    const config = vscode.workspace.getConfiguration();
+    if (config.has('rascal.interpreter.defaultStackSize')) {
+        const defaultStackSize = config.get('rascal.interpreter.defaultStackSize');
+        if (defaultStackSize !== null) {
+            return `-Xss${defaultStackSize}M`;
+        }
+    }
+
+    return "";    
 }


### PR DESCRIPTION
This adds the option to set the maximum heap size and the stack size as VSCode settings. The setting can be added as either a User or Workspace setting. The inputs need to be numeric, but there is no checking to ensure they are sensible right now beyond that (someone could, in theory, enter -5 or 8.1).

<img width="554" alt="Screenshot 2023-08-23 at 9 10 55 PM" src="https://github.com/usethesource/rascal-language-servers/assets/805197/2a9b5060-24ba-4808-872f-fb01f7323b19">
