### PR TITLE
Switching to  v0.34.0 release of rascal

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -159,7 +159,7 @@
                 <plugin>
                     <groupId>org.rascalmpl</groupId>
                     <artifactId>rascal-maven-plugin</artifactId>
-                    <version>0.22.0-RC1</version>
+                    <version>0.22.0</version>
                     <configuration>
                         <errorsAsWarnings>false</errorsAsWarnings>
                         <bin>${project.build.outputDirectory}</bin>

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.33.7</version>
+      <version>0.34.0-RC2</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>


### PR DESCRIPTION
This is WIP, but after this succeeds, and rascal is released (the current PR depends on a RC version of rascal) this PR will update the dependencies to the lastest rascal release (and the corresponding bumps to other dependencies).