### PR TITLE
The terminal that VS Code starts does not setup the correct code point for utf8

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/LSPTerminalREPL.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/LSPTerminalREPL.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
+import org.fusesource.jansi.internal.Kernel32;
 import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.GlobalEnvironment;
@@ -70,6 +70,7 @@ import io.usethesource.vallang.IValueFactory;
 import io.usethesource.vallang.io.StandardTextWriter;
 import jline.Terminal;
 import jline.TerminalFactory;
+import jline.internal.Configuration;
 
 /**
  * This class runs a Rascal terminal REPL that
@@ -98,6 +99,13 @@ public class LSPTerminalREPL extends BaseREPL {
     }
 
     private static ILanguageProtocol makeInterpreter(Terminal terminal, final IDEServices services) throws IOException, URISyntaxException {
+        if (Configuration.isWindows()) {
+            // vs code doesn't properly set the codepage for the terminal
+            // but it requires it to run in utf8, so we have to quickly set the
+            // codepoint ourself, just to make sure we are not getting the default
+            // that the user has (mostly some old codepoint that breaks any unicode character)
+            Kernel32.SetConsoleOutputCP(65001);
+        }
         RascalInterpreterREPL repl =
             new RascalInterpreterREPL(prettyPrompt, allowColors, getHistoryFile()) {
                 private final Set<String> dirtyModules = ConcurrentHashMap.newKeySet();

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -152,7 +152,8 @@ export class RascalExtension implements vscode.Disposable {
         }
         shellArgs.push();
         shellArgs.push(
-            '-Drascal.fallbackResolver=org.rascalmpl.vscode.lsp.uri.FallbackResolver'
+            '-Dfile.encoding=UTF8'
+            , '-Drascal.fallbackResolver=org.rascalmpl.vscode.lsp.uri.FallbackResolver'
             , 'org.rascalmpl.vscode.lsp.terminal.LSPTerminalREPL'
             , '--ideServicesPort'
             , '' + ide.port


### PR DESCRIPTION
To solve that, we've had to use an internal api of jline to set the right windows code point, just before starting jline and friends

this fixes #326 