### PR TITLE
Refactored utf8 codepoint fix to avoid internal jline classes

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -118,6 +118,11 @@
       <artifactId>org.eclipse.lsp4j.debug</artifactId>
       <version>${lsp4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.13.0</version>
+    </dependency>
   </dependencies>
   <build>
       <resources>


### PR DESCRIPTION
The original fix for the VS Code issues was using internal jline classes and reflection to get to them. I didn't like it, and also wanted to set the input code page (which wasn't possible via jline), so I found that JNA exists, and does exactly what we want: dynamically call into the windows kernel, without any local JNI needed.