### PR TITLE
Fix vs code extension tester failing on windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
         env:
           DELAY_FACTOR: '9'
           _JAVA_OPTIONS: '-Xmx2G'
-        run: npx extest setup-and-run out\\test\\vscode-suite\\*.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (mac)"
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
           cache-dependency-path: rascal-vscode-extension/package-lock.json
           registry-url: 'https://registry.npmjs.org'
@@ -100,7 +100,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
           cache-dependency-path: rascal-vscode-extension/package-lock.json
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,13 +55,21 @@ jobs:
           path: ./rascal-vscode-extension/uitests
           key: "vscode-${{matrix.os}}"
 
-      - name: "UI test (windows & mac)"
-        shell: bash
-        if: matrix.os != 'buildjet-4vcpu-ubuntu-2204'
+      - name: "UI test (windows)"
+        if: matrix.os == 'windows-latest'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: ${{ matrix.os == 'windows' && '9' || '8' }}
-          _JAVA_OPTIONS: ${{ matrix.os == 'windows' && '-Xmx2G' || '-Xmx4G' }}
+          DELAY_FACTOR: '9'
+          _JAVA_OPTIONS: '-Xmx2G'
+        run: npx extest setup-and-run out\\test\\vscode-suite\\*.test.js --storage uitests
+
+      - name: "UI test (mac)"
+        shell: bash
+        if: matrix.os == 'macos-latest'
+        working-directory: ./rascal-vscode-extension
+        env:
+          DELAY_FACTOR: '8'
+          _JAVA_OPTIONS: '-Xmx4G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"


### PR DESCRIPTION
This deals with the failure of VS Code extension tester on the windows CI.

It also allows us to finally update to node 18, as extester works on node 18 now.