### PR TITLE
Report errors to the user

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -189,7 +189,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
             var contributions = EvaluatorUtil.runEvaluator(name + ": loading contributions", eval,
                 e -> loadContributions(e, lang),
                 ValueFactoryFactory.getValueFactory().set(),
-                exec, true).get();
+                exec).get();
             this.store = eval.thenApply(e -> ((ModuleEnvironment)e.getModule(mainModule)).getStore());
             this.parser = getFunctionFor(contributions, LanguageContributions.PARSER);
             this.outliner = getFunctionFor(contributions, LanguageContributions.OUTLINER);
@@ -443,7 +443,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
         logger.debug("executeCommand({}...) (full command value in TRACE level)", () -> command.substring(0, Math.min(10, command.length())));
         logger.trace("Full command: {}", command);
         return InterruptibleFuture.flatten(parseCommand(command).thenCombine(commandExecutor,
-            (cons, func) -> EvaluatorUtil.<@Nullable IValue>runEvaluator("executeCommand", eval, ev -> func.call(cons), null, exec, false)
+            (cons, func) -> EvaluatorUtil.<@Nullable IValue>runEvaluator("executeCommand", eval, ev -> func.call(cons), null, exec)
         ), exec);
     }
 
@@ -454,7 +454,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
                     return InterruptibleFuture.completedFuture(defaultResult);
                 }
 
-                return EvaluatorUtil.runEvaluator(name, eval, e -> s.call(args), defaultResult, exec, false);
+                return EvaluatorUtil.runEvaluator(name, eval, e -> s.call(args), defaultResult, exec);
             }),
             exec);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -86,7 +86,7 @@ public class RascalLanguageServices {
             return runEvaluator("Rascal makeSummary", summaryEvaluator, eval -> {
                 IConstructor result = (IConstructor) eval.call("makeSummary", moduleName, pcfg.asConstructor());
                 return result != null && result.asWithKeywordParameters().hasParameters() ? result : null;
-            }, null, exec, false);
+            }, null, exec);
         } catch (IOException e) {
             logger.error("Error looking up module name from source location {}", occ, e);
             return new InterruptibleFuture<>(CompletableFuture.completedFuture(null), () -> {
@@ -98,7 +98,7 @@ public class RascalLanguageServices {
         Executor exec) {
         return runEvaluator("Rascal checkAll", compilerEvaluator,
             e -> translateCheckResults((IList) e.call("checkAll", folder, pcfg.asConstructor())),
-            Collections.emptyMap(), exec, false);
+            Collections.emptyMap(), exec);
     }
 
     private static Map<ISourceLocation, ISet> translateCheckResults(IList messages) {
@@ -126,7 +126,7 @@ public class RascalLanguageServices {
         logger.debug("Running rascal check for: {} with: {}", files, pcfg);
         return runEvaluator("Rascal check", compilerEvaluator,
             e -> translateCheckResults((IList) e.call("check", files, pcfg.asConstructor())),
-            buildEmptyResult(files), exec, false);
+            buildEmptyResult(files), exec);
     }
 
 
@@ -155,7 +155,7 @@ public class RascalLanguageServices {
         }
 
         return runEvaluator("Rascal outline", outlineEvaluator, eval -> (IList) eval.call("outlineRascalModule", module),
-            VF.list(), exec, false);
+            VF.list(), exec);
     }
 
 


### PR DESCRIPTION
Initially we crashed frequently and we wanted to hide this from the user. But now we are much more stable, so we can show all errors to the user. Note that VS Code and the language client implementation report errors differently for some calls

Fixes #384