### PR TITLE
Generate semantic tokens to indicate absence of highlighting

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -149,10 +149,9 @@ public class SemanticTokenizer implements ISemanticTokens {
             return theList.get(previousIndexOf(field));
         }
 
-        private void growPreviousToken(int newLength) {
+        private void growPreviousToken(int length) {
             int i = previousIndexOf(TokenField.LENGTH);
-            int oldLength = theList.remove(i);
-            theList.add(i, oldLength + newLength);
+            theList.set(i, theList.get(i) + length);
         }
     }
 

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -147,6 +147,9 @@
         "scopes": {
           "ambiguity": [
             "invalid"
+          ],
+          "uncategorized": [
+            "meta.embedded"
           ]
         }
       },
@@ -155,6 +158,9 @@
         "scopes": {
           "ambiguity": [
             "invalid"
+          ],
+          "uncategorized": [
+            "meta.embedded"
           ]
         }
       }
@@ -164,6 +170,10 @@
         "id": "ambiguity",
         "superType": "string",
         "description": "Rascal ambiguous parts of a parse tree"
+      },
+      {
+        "id": "uncategorized",
+        "description": "Absence of highlighting"
       }
     ],
     "configuration": {


### PR DESCRIPTION
This PR extends the semantic highlighter with generation of tokens to explicitly indicate absence of highlighting. To avoid generating an excessive number of such tokens, the tokenizer on-the-fly identifies maximal consecutive regions of "absence of highlighting" (separated by newlines) and generates only a single token per region.