### PR TITLE
Dynamically add/update categories to productions of Rascal literals

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -113,7 +113,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     private final ExecutorService ownExecuter;
     private @MonotonicNonNull RascalLanguageServices rascalServices;
 
-    private final SemanticTokenizer tokenizer = new SemanticTokenizer();
+    private final SemanticTokenizer tokenizer = new SemanticTokenizer(true);
     private @MonotonicNonNull LanguageClient client;
 
     private final Map<ISourceLocation, TextDocumentState> documents;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -539,16 +539,18 @@ public class SemanticTokenizer implements ISemanticTokens {
         }
     }
 
+    // The idea behind the patch is to dynamically map productions in Rascal's
+    // own grammar with no category, or with a legacy category (e.g., string
+    // literals), to current categories (i.e., semantic token types).
     private static class RascalPatch {
 
-        // The idea behind the patch is to dynamically map category-less
-        // productions to categories. As an optimization, productions that have
-        // been mapped before are cached in an identity map/set for fast
-        // lookups.
+        // As an optimization, productions that have already been mapped in the
+        // past, are cached in an identity map/set for fast lookups in the
+        // future.
         Map<IConstructor, String> positiveCache = new IdentityHashMap<>();
         Set<IConstructor> negativeCache = Collections.newSetFromMap(new IdentityHashMap<>());
 
-        @SuppressWarnings("java:S131") // Switches without defaults are intended here
+        @SuppressWarnings("java:S131") // Switches without defaults are intended in this method
         public String apply(IConstructor prod, String defaultCategory) {
 
             // Check the caches
@@ -561,6 +563,7 @@ public class SemanticTokenizer implements ISemanticTokens {
 
             // Apply the patch (positively)
             var def = ProductionAdapter.getDefined(prod);
+
             if (isLabeledLiteral(def)) {
                 switch (SymbolAdapter.getLabel(def)) {
                 case "integer":
@@ -573,6 +576,7 @@ public class SemanticTokenizer implements ISemanticTokens {
                     return putIntoPositiveCache(prod, SemanticTokenTypes.Regexp);
                 }
             }
+
             if (SymbolAdapter.isLex(def)) {
                 switch (SymbolAdapter.getName(def)) {
                 case "StringConstant":

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -585,6 +585,7 @@ public class SemanticTokenizer implements ISemanticTokens {
                 case "PreStringChars":
                 case "MidStringChars":
                 case "PostStringChars":
+                case "Char":
                     return putIntoPositiveCache(prod, SemanticTokenTypes.String);
                 }
             }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -596,7 +596,7 @@ public class SemanticTokenizer implements ISemanticTokens {
 
         private boolean isLabeledLiteral(IConstructor def) {
             return SymbolAdapter.isLabel(def) &&
-                SymbolAdapter.getLabeledSymbol(def).getName().equals("Literal");
+                SymbolAdapter.getName(SymbolAdapter.getLabeledSymbol(def)).equals("Literal");
         }
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -570,7 +570,7 @@ public class SemanticTokenizer implements ISemanticTokens {
             if (category != null) {
                 return category;
             }
-            if (doNotPatch.getIfPresent(prod)) {
+            if (doNotPatch.getIfPresent(prod) != null) {
                 return defaultCategory; // Possibly different each time this cache is hit
             }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -540,8 +540,9 @@ public class SemanticTokenizer implements ISemanticTokens {
     }
 
     // The idea behind the patch is to dynamically map productions in Rascal's
-    // own grammar with no category, or with a legacy category (e.g., string
-    // literals), to current categories (i.e., semantic token types).
+    // own grammar with no category (e.g, number literals), or with a legacy
+    // category (e.g., string literals), to current categories (i.e., semantic
+    // token types).
     private static class RascalPatch {
 
         // As an optimization, productions that have already been mapped in the


### PR DESCRIPTION
This PR adds a semantic tokenizer feature (intended to be temporary) to dynamically add/update categories to productions in Rascal's own grammar with no category (e.g., number literals) or with a legacy category (e.g., string literals).