### PR TITLE
Detect and warn about an incorrect project setup

### DIFF
--- a/rascal-vscode-extension/src/Identifiers.ts
+++ b/rascal-vscode-extension/src/Identifiers.ts
@@ -1,0 +1,1 @@
+export const RASCAL_LANGUAGE_ID = "rascalmpl";

--- a/rascal-vscode-extension/src/Identifiers.ts
+++ b/rascal-vscode-extension/src/Identifiers.ts
@@ -1,1 +1,27 @@
+/*
+ * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 export const RASCAL_LANGUAGE_ID = "rascalmpl";

--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -29,6 +29,7 @@ import * as vscode from 'vscode';
 
 import { RascalExtension } from './RascalExtension';
 import { RascalMFValidator } from './ux/RascalMFValidator';
+import { RascalProjectValidator } from './ux/RascalProjectValidator';
 
 const testDeployMode = (process.env['RASCAL_LSP_DEV_DEPLOY'] || "false") === "true";
 const deployMode = (process.env['RASCAL_LSP_DEV'] || "false") !== "true";
@@ -40,6 +41,7 @@ export function activate(context: vscode.ExtensionContext) {
     const extension = new RascalExtension(context, jars, icon, (deployMode || testDeployMode));
     context.subscriptions.push(extension);
     context.subscriptions.push(new RascalMFValidator());
+    context.subscriptions.push(new RascalProjectValidator());
     return extension.externalLanguageRegistry();
 }
 

--- a/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
@@ -31,6 +31,7 @@ import { VSCodeUriResolverServer } from '../fs/VSCodeURIResolver';
 import { activateLanguageClient } from './RascalLSPConnection';
 import { LanguageParameter, ParameterizedLanguageServer } from './ParameterizedLanguageServer';
 import { RascalDebugClient } from '../dap/RascalDebugClient';
+import { RASCAL_LANGUAGE_ID } from '../Identifiers';
 
 
 export class RascalLanguageServer implements vscode.Disposable {
@@ -48,7 +49,7 @@ export class RascalLanguageServer implements vscode.Disposable {
             devPort: 8888,
             isParametricServer: false,
             jarPath: absoluteJarPath,
-            language: "rascalmpl",
+            language: RASCAL_LANGUAGE_ID,
             title: 'Rascal MPL Language Server',
             vfsServer: vfsServer,
             dedicated: false,

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -28,7 +28,7 @@ import * as vscode from 'vscode';
 import {posix} from 'path'; // posix path join is always correct, also on windows
 
 
-const MF_FILE = "RASCAL.MF";
+export const MF_FILE = "RASCAL.MF";
 const MF_DIR = "META-INF";
 
 /**

--- a/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+import * as vscode from 'vscode';
+import {posix} from 'path'; // posix path join is always correct, also on windows
+import { RASCAL_LANGUAGE_ID } from '../Identifiers';
+import { Diagnostic, Position, Range, Uri } from 'vscode';
+import { MF_FILE, buildMFChildPath } from './RascalMFValidator';
+import { DiagnosticSeverity } from 'vscode-languageclient';
+
+const FIRST_WORD = new Range(new Position(0,0), new Position(0,0));
+const EXPLAIN_PROBLEM = "this degraded Rascal's VS Code plugin's capabilities if you want to type-check or execute this module.";
+
+export class RascalProjectValidator implements vscode.Disposable {
+    private readonly toDispose: vscode.Disposable[] = [];
+    private readonly diagnostics: vscode.DiagnosticCollection;
+    private readonly cachedSourcePaths: Map<string, Promise<Uri[]>> = new Map();
+
+    constructor() {
+        this.diagnostics = vscode.languages.createDiagnosticCollection("Rascal Project Diagnostics");
+        this.toDispose.push(this.diagnostics);
+        vscode.workspace.onDidOpenTextDocument(this.validate, this, this.toDispose);
+        vscode.workspace.onDidCloseTextDocument(this.closeFile, this, this.toDispose);
+
+        const watcher = vscode.workspace.createFileSystemWatcher("**/" + MF_FILE, true, false, false);
+        this.toDispose.push(watcher);
+        watcher.onDidChange(e => this.cachedSourcePaths.delete(e.toString()));
+        watcher.onDidDelete(e => this.cachedSourcePaths.delete(e.toString()));
+    }
+
+
+    async validate(e: vscode.TextDocument) {
+        if (e.languageId !== RASCAL_LANGUAGE_ID) {
+            return;
+        }
+        const folder = vscode.workspace.getWorkspaceFolder(e.uri);
+        const messages: Diagnostic[] = [];
+        if (!folder) {
+            messages.push(new Diagnostic(FIRST_WORD, "This Rascal file is not part of a project opened as a workspace folder, " + EXPLAIN_PROBLEM, vscode.DiagnosticSeverity.Warning));
+        }
+        else {
+            await reportMissingFile(buildPOMChildPath(folder.uri), folder, messages);
+
+            const mf = buildMFChildPath(folder.uri);
+            if (!(await reportMissingFile(mf, folder, messages))) {
+                try {
+                    const sources = await this.getSourcePaths(mf);
+                    if (sources.find(s => isChild(s, e.uri)) === undefined) {
+                        messages.push(new Diagnostic(FIRST_WORD, `This file is in the source path of the ${folder.name} project, please review the RASCAL.MF file. Otherwise ${EXPLAIN_PROBLEM}`, DiagnosticSeverity.Warning));
+                    }
+                } catch (ex) {
+                    console.log("Swallowing: ", ex);
+                }
+            }
+
+        }
+        this.diagnostics.set(e.uri, messages);
+    }
+
+    getSourcePaths(mf: vscode.Uri) : Promise<Uri[]> {
+        const key = mf.toString();
+        let result = this.cachedSourcePaths.get(key);
+        if (result !== undefined) {
+            return result;
+        }
+        result = parseSourcePaths(mf);
+        this.cachedSourcePaths.set(key, result);
+        return result;
+    }
+
+    closeFile(e: vscode.TextDocument) {
+        if (e.languageId !== RASCAL_LANGUAGE_ID) {
+            return;
+        }
+        // clear all warnings for close files, to not bother the user more than needed.
+        this.diagnostics.delete(e.uri);
+    }
+
+    dispose() {
+        vscode.Disposable.from(...this.toDispose).dispose();
+    }
+
+
+}
+
+async function fileExists(u : Uri) : Promise<boolean> {
+    try {
+        const stat = await vscode.workspace.fs.stat(u);
+        return (stat.type & vscode.FileType.File) === vscode.FileType.File;
+    }
+    catch (_) {
+        return false;
+    }
+
+}
+
+function buildPOMChildPath(u: Uri): Uri {
+    return Uri.joinPath(u, "pom.xml");
+}
+
+async function reportMissingFile(file: vscode.Uri, project: vscode.WorkspaceFolder, messages: vscode.Diagnostic[]) {
+    if (await fileExists(file)) {
+        return false;
+    }
+    messages.push(new Diagnostic(
+        FIRST_WORD,
+        `${project.name} is missing the ${posix.relative(project.uri.path, file.path)} file, ${EXPLAIN_PROBLEM}`,
+        vscode.DiagnosticSeverity.Warning
+    ));
+    return true;
+}
+
+function isChild(parent: Uri, child: Uri): unknown {
+    const parentPath = parent.path.endsWith('/') ? parent.path : (parent.path + '/');
+    return parent.scheme === child.scheme
+        && parent.authority === child.authority
+        && child.path.startsWith(parentPath);
+}
+
+async function parseSourcePaths(mf: Uri): Promise<vscode.Uri[]> {
+    try {
+        const body = new TextDecoder("UTF8").decode(await vscode.workspace.fs.readFile(mf));
+        const lines = body.split('\n');
+        for (let line of lines) {
+            line = removeComments(line);
+            const [key, value] = line.split(":");
+            if (key && value && key.trim() === "Source") {
+                const parent = mf.with({path : posix.basename(posix.basename(mf.path))});
+                return value.split(',')
+                    .map(s => s.trim())
+                    .map(s => Uri.joinPath(parent, s));
+
+            }
+        }
+        return [];
+    }
+    catch (e) {
+        console.log("Could not parse rascal.mf", e);
+        return [];
+    }
+}
+
+function removeComments(entry: string): string {
+    return entry.replace(/;.*$/, "");
+}
+

--- a/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
@@ -171,6 +171,7 @@ function isChild(parent: Uri, child: Uri): unknown {
         && child.path.startsWith(parent.path.endsWith('/') ? parent.path : (parent.path + '/'));
 }
 
+// TODO: at a later point, merge this with code in the RascalMF validator
 async function parseSourcePaths(mf: Uri): Promise<vscode.Uri[]> {
     try {
         const body = new TextDecoder("UTF8").decode(await vscode.workspace.fs.readFile(mf));


### PR DESCRIPTION
This module now checks for some common errors:

- rascal file opened that is not part of any of the projects active in the workspace
- rascal file without a pom.xml in the right position
- rascal file without a rascal.mf in the right place
- rascal file in a path not defined in the rascal.mf sources key.

Some screenshots:

![image](https://github.com/user-attachments/assets/6cf56687-92bc-4e23-a822-df26ba419d8f)
![image](https://github.com/user-attachments/assets/fd920d18-39b6-4982-a28e-7f1fd68ccfeb)

Btw, yes, we could do this in rascal with some validation, but that would involve another extension on the LSP protocol. Until we've grown the checker to deal with this properly, we can help the user make less mistakes.

Ideally we would also add some quick fixes, but that's not always so simple to figure out.

This prevents cases like #410 and #341, or at least leaves the user less confused.
