### PR TITLE
Fix 'Start Rascal Terminal and Import this module' command.

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -45,7 +45,7 @@
         "title": "Start Rascal Terminal, Import module and Run main function"
       },
       {
-        "command": "rascalmpl.importMain",
+        "command": "rascalmpl.importModule",
         "title": "Start Rascal Terminal and Import this module"
       }
     ],


### PR DESCRIPTION
This fixes this command in the command palette, matching the command name to the command that is registered from code.