### PR TITLE
Rename refactoring for grammars

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -65,17 +65,17 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.40.7</version>
+      <version>0.40.8</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal-core</artifactId>
-      <version>0.12.4</version>
+      <version>0.12.6-RC1</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>typepal</artifactId>
-      <version>0.14.0</version>
+      <version>0.14.1</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Exception.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Exception.rsc
@@ -34,7 +34,7 @@ import Set;
 alias Capture = tuple[loc def, loc use];
 
 data IllegalRenameReason
-    = invalidName(str name)
+    = invalidName(str name, str identifierDescription)
     | doubleDeclaration(loc old, set[loc] new)
     | captureChange(set[Capture] captures)
     | definitionsOutsideWorkspace(set[loc] defs)
@@ -46,7 +46,7 @@ data RenameException
     | unexpectedFailure(str message)
     ;
 
-str describe(invalidName(name)) = "\'<name>\' is not a valid identifier";
+str describe(invalidName(name, idDescription)) = "\'<name>\' is not a valid <idDescription>";
 str describe(doubleDeclaration(_, _)) = "it causes double declarations";
 str describe(captureChange(_)) = "it changes program semantics";
 str describe(definitionsOutsideWorkspace(_)) = "it renames definitions outside of currently open projects";

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -285,6 +285,8 @@ tuple[Cursor, WorkspaceInfo] rascalGetCursor(WorkspaceInfo ws, Tree cursorT) {
               , <smallestFieldContainingCursor, collectionField()>
                 // Module name declaration, where the cursor location is in the module header
               , <flatMap(rascalLocationOfName(parseModuleWithSpacesCached(cursorLoc.top).top.header), Maybe[loc](loc nameLoc) { return isContainedIn(cursorLoc, nameLoc) ? just(nameLoc) : nothing(); }), moduleName()>
+                // Nonterminal constructor names in exception productions
+              , <findSmallestContaining({l | l <- ws.facts, at := ws.facts[l], at is conditional}, cursorLoc), exceptConstructor()>
             }
     };
 
@@ -327,6 +329,7 @@ tuple[Cursor, WorkspaceInfo] rascalGetCursor(WorkspaceInfo ws, Tree cursorT) {
     }
 
     if (cur.l.scheme == "unknown") throw unsupportedRename("Could not retrieve information for \'<cursorName>\' at <cursorLoc>.");
+    if (cur.kind is exceptConstructor) throw unsupportedRename("Constructors can not be renamed from except productions.");
 
     return <cur, ws>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -402,7 +402,7 @@ private Cursor rascalGetCursor(WorkspaceInfo ws, Tree cursorT) {
                 // Module name declaration, where the cursor location is in the module header
               , <flatMap(rascalLocationOfName(parseModuleWithSpacesCached(cursorLoc.top).top.header), Maybe[loc](loc nameLoc) { return isContainedIn(cursorLoc, nameLoc) ? just(nameLoc) : nothing(); }), moduleName()>
                 // Nonterminal constructor names in exception productions
-              , <findSmallestContaining({l | l <- ws.facts, at := ws.facts[l], at is conditional}, cursorLoc), exceptConstructor()>
+              , <findSmallestContaining({l | l <- ws.facts, at := ws.facts[l], (at is conditional || aprod(prod(_, /conditional(_, _))) := at), /\a-except(cursorName) := at}, cursorLoc), exceptConstructor()>
             }
     };
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -211,6 +211,8 @@ Maybe[loc] rascalLocationOfName(Declaration d) = rascalLocationOfName(d.user.nam
                                                                          || d is \data;
 Maybe[loc] rascalLocationOfName(TypeVar tv) = just(tv.name.src);
 Maybe[loc] rascalLocationOfName(Header h) = rascalLocationOfName(h.name);
+Maybe[loc] rascalLocationOfName(SyntaxDefinition sd) = rascalLocationOfName(sd.defined);
+Maybe[loc] rascalLocationOfName(Sym sym) = just(sym.nonterminal.src);
 default Maybe[loc] rascalLocationOfName(Tree t) = nothing();
 
 private tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits] computeTextEdits(WorkspaceInfo ws, start[Module] m, set[loc] defs, set[loc] uses, str name) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -80,7 +80,7 @@ void throwAnyErrors(program(_, msgs)) {
 }
 
 set[IllegalRenameReason] rascalCheckLegalName(str name, set[IdRole] defRoles) {
-    set[IllegalRenameReason] tryParseAs(type[&T<:Tree] begin, str idDescription) {
+    set[IllegalRenameReason] tryParseAs(type[&T <: Tree] begin, str idDescription) {
         try {
             parse(begin, rascalEscapeName(name));
             return {};

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -213,6 +213,7 @@ Maybe[loc] rascalLocationOfName(TypeVar tv) = just(tv.name.src);
 Maybe[loc] rascalLocationOfName(Header h) = rascalLocationOfName(h.name);
 Maybe[loc] rascalLocationOfName(SyntaxDefinition sd) = rascalLocationOfName(sd.defined);
 Maybe[loc] rascalLocationOfName(Sym sym) = just(sym.nonterminal.src);
+Maybe[loc] rascalLocationOfName(Nonterminal nt) = just(nt.src);
 default Maybe[loc] rascalLocationOfName(Tree t) = nothing();
 
 private tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits] computeTextEdits(WorkspaceInfo ws, start[Module] m, set[loc] defs, set[loc] uses, str name) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -242,7 +242,7 @@ private bool rascalIsFunctionLocal(WorkspaceInfo ws, cursor(use(), cursorLoc, _)
 private bool rascalIsFunctionLocal(WorkspaceInfo _, cursor(typeParam(), _, _)) = true;
 private default bool rascalIsFunctionLocal(_, _) = false;
 
-Maybe[AType] rascalAdtCommonKeywordFieldType(WorkspaceInfo ws, str fieldName, Define _:<_, _, _, dataId(), _, DefInfo defInfo>) {
+Maybe[AType] rascalAdtCommonKeywordFieldType(WorkspaceInfo ws, str fieldName, Define _:<_, _, _, _, _, DefInfo defInfo>) {
     if (defInfo.commonKeywordFields?
       , kwf:(KeywordFormal) `<Type _> <Name kwName> = <Expression _>` <- defInfo.commonKeywordFields
       , "<kwName>" == fieldName) {
@@ -270,7 +270,7 @@ private CursorKind rascalGetDataFieldCursorKind(WorkspaceInfo ws, loc container,
             return dataCommonKeywordField(dt.defined, fieldType);
         }
 
-        for (Define d: <_, _, _, constructorId(), _, defType(acons(adtType, _, _))> <- ws.defines) {
+        for (Define d: <_, _, _, constructorId(), _, defType(acons(adtType, _, _))> <- rascalReachableDefs(ws, {dt.defined})) {
             if (just(fieldType) := rascalConsKeywordFieldType(cursorName, d)) {
                 // Case 3 (or 0): keyword field
                 return dataKeywordField(dt.defined, fieldType);
@@ -278,6 +278,10 @@ private CursorKind rascalGetDataFieldCursorKind(WorkspaceInfo ws, loc container,
                 // Case 2 (or 0): positional field
                 return dataField(dt.defined, fieldType);
             }
+        }
+
+        if (Define d: <_, cursorName, _, fieldId(), _, defType(adtType)> <- rascalReachableDefs(ws, {dt.defined})) {
+            return dataField(dt.defined, d.defInfo.atype);
         }
     }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -480,13 +480,15 @@ private bool rascalContainsName(loc l, str name) {
     *Overloading*
     Considers recognizes overloaded definitions and renames those as well.
 
-    Functions will be considered overloaded when they have the same name, even when the arity or type signature differ.
+    Functions are considered overloaded when they have the same name, even when the arity or type signature differ.
     This means that the following functions defitions will be renamed in unison:
     ```
     list[&T] concat(list[&T] _, list[&T] _) = _;
     set[&T] concat(set[&T] _, set[&T] _) = _;
     set[&T] concat(set[&T] _, set[&T] _, set[&T] _) = _;
     ```
+
+    ADT and grammar definitions are considered overloaded when they have the same name and type, and there is a common use from which they are reachable.
 
     *Validity checking*
     Once all rename candidates have been resolved, validity of the renaming will be checked. A rename is valid iff

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -488,7 +488,27 @@ private bool rascalContainsName(loc l, str name) {
     set[&T] concat(set[&T] _, set[&T] _, set[&T] _) = _;
     ```
 
-    ADT and grammar definitions are considered overloaded when they have the same name and type, and there is a common use from which they are reachable.
+    ADT and grammar definitions are considered overloaded when they have the same name and type, and
+    there is a common use from which they are reachable.
+    As an example, modules `A` and `B` have a definition for ADT `D`:
+    ```
+    module A
+    data D = a();
+    ```
+    ```
+    module B
+    data D = b();
+    ```
+    With no other modules in the workspace, renaming `D` in one of those modules, will not rename `D` in
+    the other module, as they are not considered an overloaded definition. However, if a third module `C`
+    exists, that imports both and uses the definition, the definitions will be considered overloaded, and
+    renaming `D` from either module `A`, `B` or `C` will result in renaming all occurrences.
+    ```
+    module C
+    import A;
+    import B;
+    D f() = a();
+    ```
 
     *Validity checking*
     Once all rename candidates have been resolved, validity of the renaming will be checked. A rename is valid iff

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -214,6 +214,7 @@ Maybe[loc] rascalLocationOfName(Header h) = rascalLocationOfName(h.name);
 Maybe[loc] rascalLocationOfName(SyntaxDefinition sd) = rascalLocationOfName(sd.defined);
 Maybe[loc] rascalLocationOfName(Sym sym) = just(sym.nonterminal.src);
 Maybe[loc] rascalLocationOfName(Nonterminal nt) = just(nt.src);
+Maybe[loc] rascalLocationOfName(NonterminalLabel l) = just(l.src);
 default Maybe[loc] rascalLocationOfName(Tree t) = nothing();
 
 private tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits] computeTextEdits(WorkspaceInfo ws, start[Module] m, set[loc] defs, set[loc] uses, str name) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -169,10 +169,10 @@ rel[loc from, loc to] rascalGetTransitiveReflexiveModulePaths(WorkspaceInfo ws) 
          ;
 }
 
-@memo{maximumSize=1, minutes=5}
+@memo{maximumSize(1), expireAfter(minutes=5)}
 rel[loc from, loc to] rascalGetTransitiveReflexiveScopes(WorkspaceInfo ws) = toRel(ws.scopes)*;
 
-@memo{maximumSize=10, minutes=5}
+@memo{maximumSize(10), expireAfter(minutes=5)}
 set[loc] rascalReachableModules(WorkspaceInfo ws, set[loc] froms) {
     rel[loc from, loc scope] fromScopes = {};
     for (from <- froms) {
@@ -188,7 +188,7 @@ set[loc] rascalReachableModules(WorkspaceInfo ws, set[loc] froms) {
     return {s.top | s <- reachable.modScope};
 }
 
-@memo{maximumSize=1, minutes=5}
+@memo{maximumSize(1), expireAfter(minutes=5)}
 rel[loc, Define] definitionsRel(WorkspaceInfo ws) = toRel(ws.definitions);
 
 set[Define] rascalReachableDefs(WorkspaceInfo ws, set[loc] defs) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -47,8 +47,6 @@ import Map;
 import Set;
 import String;
 
-import IO;
-
 data CursorKind
     = use()
     | def()

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -69,7 +69,7 @@ data Cursor
 alias MayOverloadFun = bool(set[loc] defs, map[loc, Define] defines);
 alias FileRenamesF = rel[loc old, loc new](str newName);
 alias DefsUsesRenames = tuple[set[loc] defs, set[loc] uses, FileRenamesF renames];
-alias ProjectFiles = rel[loc projectFolder, loc file];
+alias ProjectFiles = rel[loc projectFolder, loc file, bool loadModel];
 
 /**
  * This is a subset of the fields from analysis::typepal::TModel, specifically tailored to refactorings.

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -55,6 +55,7 @@ data CursorKind
     | typeParam()
     | collectionField()
     | moduleName()
+    | exceptConstructor()
     ;
 
 data Cursor

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -470,8 +470,8 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(dataField(loc adtLoc,
         initialDefs = getDefs(ws, cursorLoc);
     } else if (cursorLoc in ws.defines<defined>) {
         initialDefs = {cursorLoc};
-    } else if (just(AType adtType) := getFact(ws, cursorLoc)) {
-        set[Define] reachableDefs = rascalReachableDefs(ws, {cursorLoc});
+    } else if (just(AType adtType) := getFact(ws, adtLoc)) {
+        set[Define] reachableDefs = rascalReachableDefs(ws, {adtLoc});
         initialDefs = {
             kwDef.defined
             | Define dataDef: <_, _, _, dataId(), _, defType(adtType)> <- rascalGetADTDefinitions(ws, cursorLoc)

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -168,6 +168,10 @@ test bool dataCommonKeywordFieldReusedName() = testRenameOccurrences({
         ", {})
 });
 
+test bool dataAsFormalField() = testRenameOccurrences({0, 1}, "
+    'int getChild(D d) = d.foo;
+", decls = "data D = x(int foo);");
+
 test bool relField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'f = r.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -76,6 +76,22 @@ decls = "
     'syntax S[&Foo] = s: &Foo foo;
 ", cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
 
+test bool parameterizedProductionFromDef() = expectEq({0, 1}, testRenameOccurrences(""
+, decls = "syntax Foo[&T] = Foo[&T] child &T t;"
+, oldName = "Foo", newName = "Bar"));
+
+test bool parameterizedProductionFromDef() = expectEq({0, 1}, testRenameOccurrences(""
+, decls = "syntax Foo[&T] = Foo[&T] child &T t;"
+, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
+
+test bool startPoductionFromDef() = expectEq({0, 1}, testRenameOccurrences(""
+, decls = "start syntax Foo = start[Foo] child;"
+, oldName = "Foo", newName = "Bar"));
+
+test bool startPoductionFromUse() = expectEq({0, 1}, testRenameOccurrences(""
+, decls = "start syntax Foo = start[Foo] child;"
+, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
+
 test bool constructorFromDef() = expectEq({0, 1}, testRenameOccurrences("
     'S getChild(foo(child)) = child;
 ", decls = "syntax S = foo: S child;"));
@@ -151,6 +167,18 @@ test bool fieldFromUse() = expectEq({0, 1}, testRenameOccurrences("
     'S getChild(S x) = x.foo;
 ", decls = "syntax S = S foo;"
 , cursorAtOldNameOccurrence = 1));
+
+test bool referencedConstructorFromDef() = expectEq({0, 1}, testRenameOccurrences("", decls = "
+    'lexical L = \"l\"+;
+    'syntax S = foo: L l;
+    'syntax T =: foo;
+"));
+
+test bool referencedConstructorFromDef() = expectEq({0, 1}, testRenameOccurrences("", decls = "
+    'lexical L = \"l\"+;
+    'syntax S = foo: L l;
+    'syntax T =: foo;
+", cursorAtOldNameOccurrence = 1));
 
 test bool lexicalFromDef() = expectEq({0, 1}, testRenameOccurrences("
     'if (f := [Foo] \"foo\") g = f;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -126,6 +126,27 @@ test bool referencedConstructor() = testRenameOccurrences({0, 1}, "", decls = "
     'syntax T =: foo;
 ");
 
+@expected{illegalRename}
+test bool nonterminalInvalidName() = testRename("", decls ="
+    'syntax Foo
+    '   = f: \"foo\"
+    '   ;
+", oldName = "Foo", newName = "foo");
+
+@expected{illegalRename}
+test bool constructorInvalidName() = testRename("", decls ="
+    'syntax S
+    '   = foo: \"foo\"
+    '   ;
+", newName = "Foo");
+
+@expected{illegalRename}
+test bool constructorFieldInvalidName() = testRename("", decls ="
+    'syntax S
+    '   = s: S foo
+    '   ;
+", newName = "Foo");
+
 test bool lexicalProduction() = testRenameOccurrences({0, 1}, "
     'if (f := [Foo] \"foo\") g = f;
 ", decls = "lexical Foo = \"foo\"+;"

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -85,6 +85,15 @@ test bool constructorFromUse() = expectEq({0, 1}, testRenameOccurrences("
 ", decls = "syntax S = foo: S child;"
 , cursorAtOldNameOccurrence = 1));
 
+test bool fieldFromDef() = expectEq({0, 1}, testRenameOccurrences("
+    'S getChild(S x) = x.foo;
+", decls = "syntax S = S foo;"));
+
+test bool fieldFromUse() = expectEq({0, 1}, testRenameOccurrences("
+    'S getChild(S x) = x.foo;
+", decls = "syntax S = S foo;"
+, cursorAtOldNameOccurrence = 1));
+
 test bool lexicalFromDef() = expectEq({0, 1}, testRenameOccurrences("
     'if (f := [Foo] \"foo\") g = f;
 ", decls = "lexical Foo = \"foo\"+;"

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -64,6 +64,18 @@ test bool productionFromReifiedType() = expectEq({0, 1, 2}, testRenameOccurrence
     'import ParseTree;
 ", oldName = "Foo", newName = "Bar", cursorAtOldNameOccurrence = 1));
 
+test bool productionParameterFromDef() = expectEq({0, 1}, testRenameOccurrences("",
+decls = "
+    'lexical L = \"l\"+;
+    'syntax S[&Foo] = s: &Foo foo;
+", oldName = "Foo", newName = "Bar"));
+
+test bool productionParameterFromUse() = expectEq({0, 1}, testRenameOccurrences("",
+decls = "
+    'lexical L = \"l\"+;
+    'syntax S[&Foo] = s: &Foo foo;
+", cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
+
 test bool constructorFromDef() = expectEq({0, 1}, testRenameOccurrences("
     'S getChild(foo(child)) = child;
 ", decls = "syntax S = foo: S child;"));
@@ -82,4 +94,12 @@ test bool lexicalFromUse() = expectEq({0, 1}, testRenameOccurrences("
     'if (f := [Foo] \"foo\") g = f;
 ", decls = "lexical Foo = \"foo\"+;"
 , oldName = "Foo", newName = "Bar"
+, cursorAtOldNameOccurrence = 1));
+
+test bool lexicalFromParameter() = expectEq({0, 1}, testRenameOccurrences("
+    'x = [S[Foo]] \"foo\";
+", decls = "
+    'lexical Foo = \"foo\"+;
+    'syntax S[&L] = s: &L l;
+", oldName = "Foo", newName = "Bar"
 , cursorAtOldNameOccurrence = 1));

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -28,80 +28,51 @@ module lang::rascal::tests::rename::Grammars
 
 import lang::rascal::tests::rename::TestUtils;
 
-test bool productionFromDef() = expectEq({0, 1, 2, 3}, testRenameOccurrences("
+test bool productionType() = testRenameOccurrences({0, 1, 2, 3}, "
     'Foo func(Foo f) = f.child;
 ", decls = "syntax Foo = Foo child;"
-, oldName = "Foo", newName = "Bar"));
+, oldName = "Foo", newName = "Bar");
 
-test bool productionFromTypeUse() = expectEq({0, 1, 2, 3}, testRenameOccurrences("
-    'Foo func(Foo f) = f.child;
-", decls = "syntax Foo = Foo child;"
-, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
-
-test bool productionFromConcreteUse() = expectEq({0, 1, 2, 3, 4}, testRenameOccurrences("
+test bool productionConcreteType() = testRenameOccurrences({0, 1, 2, 3, 4}, "
     'Foo func((Foo) `\<Foo child\>`) = child;
 ", decls = "syntax Foo = Foo child;"
-, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
+, oldName = "Foo", newName = "Bar");
 
-test bool productionFromConcreteFieldUse() = expectEq({0, 1, 2, 3, 4}, testRenameOccurrences("
-    'Foo func((Foo) `\<Foo child\>`) = child;
-", decls = "syntax Foo = Foo child;"
-, cursorAtOldNameOccurrence = 2, oldName = "Foo", newName = "Bar"));
-
-test bool productionFromPatternUse() = expectEq({0, 1, 2}, testRenameOccurrences("
-    'value t = \"tree\";
+test bool productionPattern() = testRenameOccurrences({0, 1, 2}, "
+    'Tree t;
     'if (/Foo f := t) x = f;
 ", decls = "syntax Foo = Foo child;"
-, cursorAtOldNameOccurrence = 2, oldName = "Foo", newName = "Bar"));
+, imports = "import ParseTree;"
+, oldName = "Foo", newName = "Bar");
 
-test bool productionFromReifiedType() = expectEq({0, 1, 2}, testRenameOccurrences("
+test bool productionReifiedType() = testRenameOccurrences({0, 1, 2}, "
     't = parse(#Foo, \"foo(aaa)\");
     't = implode(#Foo, t);
 ", decls = "
     'lexical A = \"a\"+;
     'syntax Foo = s: \"foo\" \"(\" A a \")\";
-    '
-    'import ParseTree;
-", oldName = "Foo", newName = "Bar", cursorAtOldNameOccurrence = 1));
+", imports = "import ParseTree;
+", oldName = "Foo", newName = "Bar");
 
-test bool productionParameterFromDef() = expectEq({0, 1}, testRenameOccurrences("",
+test bool productionParameter() = testRenameOccurrences({0, 1}, "",
 decls = "
     'lexical L = \"l\"+;
     'syntax S[&Foo] = s: &Foo foo;
-", oldName = "Foo", newName = "Bar"));
+", oldName = "Foo", newName = "Bar");
 
-test bool productionParameterFromUse() = expectEq({0, 1}, testRenameOccurrences("",
-decls = "
-    'lexical L = \"l\"+;
-    'syntax S[&Foo] = s: &Foo foo;
-", cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
-
-test bool parameterizedProductionFromDef() = expectEq({0, 1}, testRenameOccurrences(""
+test bool parameterizedProduction() = testRenameOccurrences({0, 1}, ""
 , decls = "syntax Foo[&T] = Foo[&T] child &T t;"
-, oldName = "Foo", newName = "Bar"));
+, oldName = "Foo", newName = "Bar");
 
-test bool parameterizedProductionFromDef() = expectEq({0, 1}, testRenameOccurrences(""
-, decls = "syntax Foo[&T] = Foo[&T] child &T t;"
-, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
-
-test bool startPoductionFromDef() = expectEq({0, 1}, testRenameOccurrences(""
+test bool startPoduction() = testRenameOccurrences({0, 1}, ""
 , decls = "start syntax Foo = start[Foo] child;"
-, oldName = "Foo", newName = "Bar"));
+, oldName = "Foo", newName = "Bar");
 
-test bool startPoductionFromUse() = expectEq({0, 1}, testRenameOccurrences(""
-, decls = "start syntax Foo = start[Foo] child;"
-, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
-
-test bool constructorFromDef() = expectEq({0, 1}, testRenameOccurrences("
+test bool constructor() = testRenameOccurrences({0, 1}, "
     'S getChild(foo(child)) = child;
-", decls = "syntax S = foo: S child;"));
+", decls = "syntax S = foo: S child;");
 
-test bool constructorFromUse() = expectEq({0, 1}, testRenameOccurrences("
-    'S getChild(foo(child)) = child;
-", decls = "syntax S = foo: S child;"
-, cursorAtOldNameOccurrence = 1));
-
-test bool exceptedConstructorFromDef() = expectEq({0, 1, 2}, testRenameOccurrences("
+test bool exceptedConstructor() = testRenameOccurrences({0, 1, 2}, "
     'S getChild(foo(child)) = child;
 ", decls = "
     'syntax S
@@ -109,92 +80,53 @@ test bool exceptedConstructorFromDef() = expectEq({0, 1, 2}, testRenameOccurrenc
     '  | baz: \"baz\"
     '  | notFoo: S s!foo!notFoo
     '  ;
-"));
+", skipCursors = {1});
 
-test bool exceptedConstructorFromUse() = expectEq({0, 1, 2}, testRenameOccurrences("
-    'S getChild(foo(child)) = child;
-", decls = "
-    'syntax S
-    '  = foo: \"foo\" S s
-    '  | baz: \"baz\"
-    '  | notFoo: S s!foo!notFoo
-    '  ;
-", cursorAtOldNameOccurrence = -1));
-
-@expected{unsupportedRename}
-test bool exceptedConstructorFromExcept() = expectEq({0, 1, 2}, testRenameOccurrences("
-    'S getChild(foo(child)) = child;
-", decls = "
-    'syntax S
-    '  = foo: \"foo\" S s
-    '  | baz: \"baz\"
-    '  | notFoo: S s!foo!notFoo
-    '  ;
-", cursorAtOldNameOccurrence = 1));
-
-test bool exceptedConstructorMultiple() = expectEq({0, 1, 2}, testRenameOccurrences("", decls = "
+test bool exceptedConstructorMultiple() = testRenameOccurrences({0, 1, 2}, "", decls = "
     'syntax S
     '  = foo: \"foo\" S s
     '  | baz: \"baz\"
     '  | notFoo: S s!foo!notFoo
     '  | probablyBaz: S s!foo!notFoo!probablyBaz
     '  ;
-"));
+", skipCursors = {1, 2});
 
-test bool exceptedDuplicateConstructor1() = expectEq({0, 1, 2}, testRenameOccurrences("", decls = "
+test bool exceptedDuplicateConstructorAtStart() = testRenameOccurrences({0, 1, 2}, "", decls = "
     'syntax S
     '  = foo: \"foo\" S s
     '  | baz: \"baz\"
     '  | notFoo: S s!notFoo!foo
     '  ;
     'syntax T = foo: \"Tfoo\";
-"));
+", skipCursors = {1});
 
-test bool exceptedDuplicateConstructor2() = expectEq({0, 1, 2}, testRenameOccurrences("", decls = "
+test bool exceptedDuplicateConstructorAtEnd() = testRenameOccurrences({0, 1, 2}, "", decls = "
     'syntax S
     '  = foo: \"foo\" S s
     '  | baz: \"baz\"
     '  | notFoo: S s!foo!notFoo
     '  ;
     'syntax S = foo: \"Tfoo\";
-"));
+", skipCursors = {1});
 
-test bool fieldFromDef() = expectEq({0, 1}, testRenameOccurrences("
+test bool syntaxConstructorField() = testRenameOccurrences({0, 1}, "
     'S getChild(S x) = x.foo;
-", decls = "syntax S = S foo;"));
+", decls = "syntax S = S foo;");
 
-test bool fieldFromUse() = expectEq({0, 1}, testRenameOccurrences("
-    'S getChild(S x) = x.foo;
-", decls = "syntax S = S foo;"
-, cursorAtOldNameOccurrence = 1));
-
-test bool referencedConstructorFromDef() = expectEq({0, 1}, testRenameOccurrences("", decls = "
+test bool referencedConstructor() = testRenameOccurrences({0, 1}, "", decls = "
     'lexical L = \"l\"+;
     'syntax S = foo: L l;
     'syntax T =: foo;
-"));
+");
 
-test bool referencedConstructorFromDef() = expectEq({0, 1}, testRenameOccurrences("", decls = "
-    'lexical L = \"l\"+;
-    'syntax S = foo: L l;
-    'syntax T =: foo;
-", cursorAtOldNameOccurrence = 1));
-
-test bool lexicalFromDef() = expectEq({0, 1}, testRenameOccurrences("
+test bool lexicalProduction() = testRenameOccurrences({0, 1}, "
     'if (f := [Foo] \"foo\") g = f;
 ", decls = "lexical Foo = \"foo\"+;"
-, oldName = "Foo", newName = "Bar"));
+, oldName = "Foo", newName = "Bar");
 
-test bool lexicalFromUse() = expectEq({0, 1}, testRenameOccurrences("
-    'if (f := [Foo] \"foo\") g = f;
-", decls = "lexical Foo = \"foo\"+;"
-, oldName = "Foo", newName = "Bar"
-, cursorAtOldNameOccurrence = 1));
-
-test bool lexicalFromParameter() = expectEq({0, 1}, testRenameOccurrences("
+test bool lexicalAsParameter() = testRenameOccurrences({0, 1}, "
     'x = [S[Foo]] \"foo\";
 ", decls = "
     'lexical Foo = \"foo\"+;
     'syntax S[&L] = s: &L l;
-", oldName = "Foo", newName = "Bar"
-, cursorAtOldNameOccurrence = 1));
+", oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -73,42 +73,48 @@ test bool constructor() = testRenameOccurrences({0, 1}, "
     'S getChild(foo(child)) = child;
 ", decls = "syntax S = foo: S child;");
 
-test bool exceptedConstructor() = testRenameOccurrences({0, 1, 2}, "
-    'S getChild(foo(child)) = child;
-", decls = "
+test bool exceptedConstructor() = testRenameOccurrences({0, 1, 2, 3, 4}, "",
+decls = "
     'syntax S
     '  = foo: \"foo\" S s
     '  | baz: \"baz\"
-    '  | notFoo: S s!foo!notFoo
+    '  | atStart: S s!foo!baz
+    '  | atEnd: S s!baz!foo
+    '  | sandwiched: S s!baz!foo!atEnd
+    '  | single: S s!foo
     '  ;
-", skipCursors = {1});
+");
 
-test bool exceptedConstructorMultiple() = testRenameOccurrences({0, 1, 2}, "", decls = "
+test bool exceptConstructorDifferentNonterminal() = testRenameOccurrences({0, 2}, "",
+decls = "
     'syntax S
-    '  = foo: \"foo\" S s
-    '  | baz: \"baz\"
-    '  | notFoo: S s!foo!notFoo
-    '  | probablyBaz: S s!foo!notFoo!probablyBaz
-    '  ;
-", skipCursors = {1, 2});
+    '   = anotherBut: T t!foo
+    '   | foo: \"do not rename me!\"
+    '   ;
 
-test bool exceptedDuplicateConstructorAtStart() = testRenameOccurrences({0, 1, 2}, "", decls = "
+    'syntax T
+    '   = foo: \"foo\"
+    '   | bar: \"bar\"
+    '   ;
+");
+
+test bool exceptedDuplicateConstructorAtEnd() = testRenameOccurrences({0, 1}, "", decls = "
     'syntax S
     '  = foo: \"foo\" S s
     '  | baz: \"baz\"
     '  | notFoo: S s!notFoo!foo
     '  ;
     'syntax T = foo: \"Tfoo\";
-", skipCursors = {1});
+");
 
-test bool exceptedDuplicateConstructorAtEnd() = testRenameOccurrences({0, 1, 2}, "", decls = "
+test bool exceptedDuplicateConstructorAtStart() = testRenameOccurrences({0, 1}, "", decls = "
     'syntax S
     '  = foo: \"foo\" S s
     '  | baz: \"baz\"
     '  | notFoo: S s!foo!notFoo
     '  ;
-    'syntax S = foo: \"Tfoo\";
-", skipCursors = {1});
+    'syntax T = foo: \"Tfoo\";
+");
 
 test bool syntaxConstructorField() = testRenameOccurrences({0, 1}, "
     'S getChild(S x) = x.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -1,0 +1,85 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::rename::Grammars
+
+import lang::rascal::tests::rename::TestUtils;
+
+test bool productionFromDef() = expectEq({0, 1, 2, 3}, testRenameOccurrences("
+    'Foo func(Foo f) = f.child;
+", decls = "syntax Foo = c: Foo child;"
+, oldName = "Foo", newName = "Bar"));
+
+test bool productionFromTypeUse() = expectEq({0, 1, 2, 3}, testRenameOccurrences("
+    'Foo func(Foo f) = f.child;
+", decls = "syntax Foo = c: Foo child;"
+, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
+
+test bool productionFromConcreteUse() = expectEq({0, 1, 2, 3, 4}, testRenameOccurrences("
+    'Foo func((Foo) `\<Foo child\>`) = child;
+", decls = "syntax Foo = c: Foo child;"
+, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
+
+test bool productionFromConcreteFieldUse() = expectEq({0, 1, 2, 3, 4}, testRenameOccurrences("
+    'Foo func((Foo) `\<Foo child\>`) = child;
+", decls = "syntax Foo = c: Foo child;"
+, cursorAtOldNameOccurrence = 2, oldName = "Foo", newName = "Bar"));
+
+test bool productionFromPatternUse() = expectEq({0, 1, 2}, testRenameOccurrences("
+    'value t = \"tree\";
+    'if (/Foo f := t) x = f;
+", decls = "syntax Foo = c: Foo child;"
+, cursorAtOldNameOccurrence = 2, oldName = "Foo", newName = "Bar"));
+
+test bool productionFromReifiedType() = expectEq({0, 1, 2}, testRenameOccurrences("
+    't = parse(#Foo, \"foo(aaa)\");
+    't = implode(#Foo, t);
+", decls = "
+    'lexical A = \"a\"+;
+    'syntax Foo = s: \"foo\" \"(\" A a \")\";
+    '
+    'import ParseTree;
+", oldName = "Foo", newName = "Bar", cursorAtOldNameOccurrence = 1));
+
+test bool constructorFromDef() = expectEq({0, 1}, testRenameOccurrences("
+    'S getChild(foo(child)) = child;
+", decls = "syntax S = foo: S child;"));
+
+test bool constructorFromUse() = expectEq({0, 1}, testRenameOccurrences("
+    'S getChild(foo(child)) = child;
+", decls = "syntax S = foo: S child;"
+, cursorAtOldNameOccurrence = 1));
+
+test bool lexicalFromDef() = expectEq({0, 1}, testRenameOccurrences("
+    'if (f := [Foo] \"foo\") g = f;
+", decls = "lexical Foo = \"foo\"+;"
+, oldName = "Foo", newName = "Bar"));
+
+test bool lexicalFromUse() = expectEq({0, 1}, testRenameOccurrences("
+    'if (f := [Foo] \"foo\") g = f;
+", decls = "lexical Foo = \"foo\"+;"
+, oldName = "Foo", newName = "Bar"
+, cursorAtOldNameOccurrence = 1));

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -85,6 +85,64 @@ test bool constructorFromUse() = expectEq({0, 1}, testRenameOccurrences("
 ", decls = "syntax S = foo: S child;"
 , cursorAtOldNameOccurrence = 1));
 
+test bool exceptedConstructorFromDef() = expectEq({0, 1, 2}, testRenameOccurrences("
+    'S getChild(foo(child)) = child;
+", decls = "
+    'syntax S
+    '  = foo: \"foo\" S s
+    '  | baz: \"baz\"
+    '  | notFoo: S s!foo!notFoo
+    '  ;
+"));
+
+test bool exceptedConstructorFromUse() = expectEq({0, 1, 2}, testRenameOccurrences("
+    'S getChild(foo(child)) = child;
+", decls = "
+    'syntax S
+    '  = foo: \"foo\" S s
+    '  | baz: \"baz\"
+    '  | notFoo: S s!foo!notFoo
+    '  ;
+", cursorAtOldNameOccurrence = -1));
+
+@expected{unsupportedRename}
+test bool exceptedConstructorFromExcept() = expectEq({0, 1, 2}, testRenameOccurrences("
+    'S getChild(foo(child)) = child;
+", decls = "
+    'syntax S
+    '  = foo: \"foo\" S s
+    '  | baz: \"baz\"
+    '  | notFoo: S s!foo!notFoo
+    '  ;
+", cursorAtOldNameOccurrence = 1));
+
+test bool exceptedConstructorMultiple() = expectEq({0, 1, 2}, testRenameOccurrences("", decls = "
+    'syntax S
+    '  = foo: \"foo\" S s
+    '  | baz: \"baz\"
+    '  | notFoo: S s!foo!notFoo
+    '  | probablyBaz: S s!foo!notFoo!probablyBaz
+    '  ;
+"));
+
+test bool exceptedDuplicateConstructor1() = expectEq({0, 1, 2}, testRenameOccurrences("", decls = "
+    'syntax S
+    '  = foo: \"foo\" S s
+    '  | baz: \"baz\"
+    '  | notFoo: S s!notFoo!foo
+    '  ;
+    'syntax T = foo: \"Tfoo\";
+"));
+
+test bool exceptedDuplicateConstructor2() = expectEq({0, 1, 2}, testRenameOccurrences("", decls = "
+    'syntax S
+    '  = foo: \"foo\" S s
+    '  | baz: \"baz\"
+    '  | notFoo: S s!foo!notFoo
+    '  ;
+    'syntax S = foo: \"Tfoo\";
+"));
+
 test bool fieldFromDef() = expectEq({0, 1}, testRenameOccurrences("
     'S getChild(S x) = x.foo;
 ", decls = "syntax S = S foo;"));

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -65,7 +65,7 @@ test bool parameterizedProduction() = testRenameOccurrences({0, 1}, ""
 , decls = "syntax Foo[&T] = Foo[&T] child &T t;"
 , oldName = "Foo", newName = "Bar");
 
-test bool startPoduction() = testRenameOccurrences({0, 1}, ""
+test bool startProduction() = testRenameOccurrences({0, 1}, ""
 , decls = "start syntax Foo = start[Foo] child;"
 , oldName = "Foo", newName = "Bar");
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -41,8 +41,9 @@ test bool productionConcreteType() = testRenameOccurrences({0, 1, 2, 3, 4}, "
 test bool productionPattern() = testRenameOccurrences({0, 1, 2}, "
     'Tree t;
     'if (/Foo f := t) x = f;
-", decls = "syntax Foo = Foo child;"
-, imports = "import ParseTree;"
+", decls =
+    "syntax Foo = Foo child;
+    'data Tree;"
 , oldName = "Foo", newName = "Bar");
 
 test bool productionReifiedType() = testRenameOccurrences({0, 1, 2}, "

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -166,6 +166,15 @@ test bool metaVariable() = testRenameOccurrences({0, 1},
     'data Tree;"
 );
 
+@synopsis{
+      (defs)
+       / \
+    Left  Right
+       \ /
+      Merger
+        |
+      (uses)
+}
 test bool nonterminalsInVModuleStructure() = testRenameOccurrences({
     byText("Left", "syntax Foo = f: \"f\";", {0}), byText("Right", "syntax Foo = g: \"g\";", {0})
                     , byText("Merger",
@@ -199,11 +208,9 @@ test bool nonterminalsInWModuleStructureWithoutMerge() = testRenameOccurrences({
 @synopsis{
     (defs)
     /  | \
-    v  v  v
     A  B  C
      \/ \/
       D E
-      ^ ^
      /   \
      (uses)
 }
@@ -219,6 +226,17 @@ test bool nonterminalsInWModuleStructureWithMerge() = testRenameOccurrences({
                                         'bool func(Foo foo) = foo == h();", {0})
 }, oldName = "Foo", newName = "Bar");
 
+@synopsis{
+      (defs)
+       / \
+    Left  Right
+       \ /
+      Merger
+        |
+       User
+        |
+      (uses)
+}
 test bool nonterminalsInYModuleStructure() = testRenameOccurrences({
     byText("Left", "syntax Foo = f: \"f\";", {0}), byText("Right", "syntax Foo = g: \"g\";", {0})
                     , byText("Merger",
@@ -231,6 +249,15 @@ test bool nonterminalsInYModuleStructure() = testRenameOccurrences({
                         ", {0})
 }, oldName = "Foo", newName = "Bar");
 
+@synopsis{
+      (defs)
+        |
+     Definer
+       / \
+    Left  Right
+       \ /
+      (uses)
+}
 test bool nonterminalsInInvertedVModuleStructure() = testRenameOccurrences({
             byText("Definer", "syntax Foo = f: \"f\" | g: \"g\";", {0}),
     byText("Left", "import Definer;
@@ -238,6 +265,17 @@ test bool nonterminalsInInvertedVModuleStructure() = testRenameOccurrences({
                                                                             'bool isG(Foo foo) = foo == g();", {0})
 }, oldName = "Foo", newName = "Bar");
 
+@synopsis{
+      (defs)
+        |
+     Definer
+       / \
+    Left  Right
+       \ /
+      User
+        |
+      (uses)
+}
 test bool nonterminalsInDiamondModuleStructure() = testRenameOccurrences({
             byText("Definer", "syntax Foo = f: \"f\" | g: \"g\";", {0}),
     byText("Left", "extend Definer;", {}), byText("Right", "extend Definer;", {}),
@@ -250,6 +288,16 @@ test bool nonterminalsInDiamondModuleStructure() = testRenameOccurrences({
 @synopsis{
     Two disjunct module trees. Both trees define `syntax Foo`. Since the trees are disjunct,
     we expect a renaming triggered from the left side leaves the right side untouched.
+
+          (defs)
+          /   \
+LeftDefiner   RightDefiner
+     |             |
+LeftExtender  RightExtender
+     |             |
+  LeftUser    RightUser
+         \    /
+         (uses)
 }
 test bool nonterminalsInIIModuleStructure() = testRenameOccurrences({
     byText("LeftDefiner", "syntax Foo = f: \"f\";", {0}),              byText("RightDefiner", "syntax Foo = g: \"g\";", {}),

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -130,3 +130,10 @@ test bool lexicalAsParameter() = testRenameOccurrences({0, 1}, "
     'lexical Foo = \"foo\"+;
     'syntax S[&L] = s: &L l;
 ", oldName = "Foo", newName = "Bar");
+
+test bool metaVariable() = testRenameOccurrences({0, 1},
+    "void f (Tree pt) { if ((S)`\<S foo\>` := pt) x = foo; }"
+, decls =
+    "syntax S = s: S child;
+    'data Tree;"
+);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -30,28 +30,28 @@ import lang::rascal::tests::rename::TestUtils;
 
 test bool productionFromDef() = expectEq({0, 1, 2, 3}, testRenameOccurrences("
     'Foo func(Foo f) = f.child;
-", decls = "syntax Foo = c: Foo child;"
+", decls = "syntax Foo = Foo child;"
 , oldName = "Foo", newName = "Bar"));
 
 test bool productionFromTypeUse() = expectEq({0, 1, 2, 3}, testRenameOccurrences("
     'Foo func(Foo f) = f.child;
-", decls = "syntax Foo = c: Foo child;"
+", decls = "syntax Foo = Foo child;"
 , cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
 
 test bool productionFromConcreteUse() = expectEq({0, 1, 2, 3, 4}, testRenameOccurrences("
     'Foo func((Foo) `\<Foo child\>`) = child;
-", decls = "syntax Foo = c: Foo child;"
+", decls = "syntax Foo = Foo child;"
 , cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));
 
 test bool productionFromConcreteFieldUse() = expectEq({0, 1, 2, 3, 4}, testRenameOccurrences("
     'Foo func((Foo) `\<Foo child\>`) = child;
-", decls = "syntax Foo = c: Foo child;"
+", decls = "syntax Foo = Foo child;"
 , cursorAtOldNameOccurrence = 2, oldName = "Foo", newName = "Bar"));
 
 test bool productionFromPatternUse() = expectEq({0, 1, 2}, testRenameOccurrences("
     'value t = \"tree\";
     'if (/Foo f := t) x = f;
-", decls = "syntax Foo = c: Foo child;"
+", decls = "syntax Foo = Foo child;"
 , cursorAtOldNameOccurrence = 2, oldName = "Foo", newName = "Bar"));
 
 test bool productionFromReifiedType() = expectEq({0, 1, 2}, testRenameOccurrences("

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -228,8 +228,7 @@ list[DocumentEdit] testRascalCore(loc rascalCoreDir, loc typepalDir) {
 
 list[DocumentEdit] getEdits(loc singleModule, set[loc] projectDirs, int cursorAtOldNameOccurrence, str oldName, str newName, PathConfig(loc) getPathConfig) {
     loc f = resolveLocation(singleModule);
-    m = parseModuleWithSpaces(f);
-    Tree cursor = collectNameTrees(m, oldName)[cursorAtOldNameOccurrence];
+    Tree cursor = findCursor(singleModule, oldName, cursorAtOldNameOccurrence);
     return rascalRenameSymbol(cursor, projectDirs, newName, getPathConfig);
 }
 
@@ -315,7 +314,9 @@ private str modulePathToName(str path) = replaceAll(path, "/", "::");
 
 private Tree findCursor(loc f, str id, int occ) {
     m = parseModuleWithSpaces(f);
-    return collectNameTrees(m, id)[occ];
+    names = collectNameTrees(m, id);
+    if (occ >= size(names) || occ < 0) throw "Found <size(names)> occurrences of \'<id>\'; cannot use occurrence at position <occ> as cursor";
+    return names[occ];
 }
 
 private loc storeTestModule(loc dir, str name, str body) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -249,8 +249,8 @@ private list[Tree] collectNameTrees(start[Module] m, str name) {
         // 'Normal' names
         case Name n:
             if ("<n>" == name) names += n;
-        // Symbols as used in grammars
-        case Sym s:
+        // Nonterminals (grammars)
+        case Nonterminal s:
             if ("<s>" == name) names += s;
     }
     return names;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -252,6 +252,9 @@ private list[Tree] collectNameTrees(start[Module] m, str name) {
         // Nonterminals (grammars)
         case Nonterminal s:
             if ("<s>" == name) names += s;
+        // Labels for nonterminals (grammars)
+        case NonterminalLabel label:
+            if ("<label>" == name) names += label;
     }
     return names;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -259,6 +259,7 @@ private tuple[list[DocumentEdit], set[int]] getEditsAndModule(str stmtsStr, int 
 
     // Write the file to disk (and clean up later) to easily emulate typical editor behaviour
     loc testDir = |memory://tests/rename/<moduleName>|;
+    remove(testDir);
     loc moduleFileName = testDir + "rascal" + "<moduleName>.rsc";
     writeFile(moduleFileName, moduleStr);
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -89,7 +89,7 @@ bool expectEq(&T expected, &T actual, str epilogue = "") {
 bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str newName = "bar") {
     bool success = true;
     for (mm <- modules, cursorOcc <- (mm.nameOccs - mm.skipCursors)) {
-        str testName = "Test<abs(arbInt())>";
+        str testName = "Test<abs(arbInt(10))>";
         loc testDir = |memory://tests/rename/<testName>|;
 
         if(any(m <- modules, m is byLoc)) {
@@ -248,7 +248,7 @@ list[DocumentEdit] getEdits(str stmtsStr, int cursorAtOldNameOccurrence, str old
     return edits;
 }
 
-private tuple[list[DocumentEdit], set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports, str moduleName = "TestModule<abs(arbInt())>") {
+private tuple[list[DocumentEdit], set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports, str moduleName = "TestModule<abs(arbInt(10))>") {
     str moduleStr =
     "module <moduleName>
     '<trim(imports)>

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
@@ -180,3 +180,11 @@ test bool dataTypesInIIModuleStructure() = testRenameOccurrences({
                        'bool func(Foo foo) = foo == f();", {0}),       byText("RightUser", "import RightExtender;
                                                                         'bool func(Foo foo) = foo == g();", {})
 }, <"LeftDefiner", "Foo", 0>, newName = "Bar");
+
+test bool asType() = expectEq({0, 1}, testRenameOccurrences("
+    'str s = \"text\";
+    'if (t := [Foo] s) {
+    '   str u = t;
+    '}
+", decls = "alias Foo = str;"
+, cursorAtOldNameOccurrence = 1, oldName = "Foo", newName = "Bar"));


### PR DESCRIPTION
Implements grammar support for the rename refactoring. 

Complementary to #397. Allows renaming of productions, constructors, fields/labels in grammars.