### PR TITLE
Rename refactoring: test all possible occurrences

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -305,7 +305,12 @@ tuple[Cursor, WorkspaceInfo] rascalGetCursor(WorkspaceInfo ws, Tree cursorT) {
             if (d <- defs, just(amodule(_)) := getFact(ws, d)) {
                 // Cursor is at an import
                 cur = cursor(moduleName(), c, cursorName);
-            } else if (u <- ws.useDef<0>, u.begin <= cursorLoc.begin && u.end > cursorLoc.end) {
+            } else if (u <- ws.useDef<0>
+                     , isContainedIn(cursorLoc, u)
+                     , u.end > cursorLoc.end
+                     // If the cursor is on a variable, we expect a module variable (`moduleVariable()`); not a local (`variableId()`)
+                     , {variableId()} !:= (ws.defines<defined, idRole>)[getDefs(ws, u)]
+                ) {
                 // Cursor is at a qualified name
                 cur = cursor(moduleName(), c, cursorName);
             } else if (defines != {}) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Annotations.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Annotations.rsc
@@ -29,32 +29,17 @@ module lang::rascal::tests::rename::Annotations
 import lang::rascal::tests::rename::TestUtils;
 import lang::rascal::lsp::refactor::Exception;
 
-test bool annoAtDecl() = {0, 1} == testRenameOccurrences("
+test bool userDefinedAnno() = testRenameOccurrences({0, 1, 2}, "
     'x = d();
     'x@foo = 8;
+    'int i = x@foo;
     ", decls = "
     'data D = d();
     'anno int D@foo;
 ");
 
-test bool annoAtUse() = {0, 1} == testRenameOccurrences("
-    'x = d();
-    'int i = x@foo;
-    ", decls = "
-    'data D = d();
-    'anno int D@foo;
-", cursorAtOldNameOccurrence = 1);
-
-test bool annoAtAssign() = {0, 1} == testRenameOccurrences("
-    'x = d();
-    'x@foo = 8;
-    ", decls = "
-    'data D = d();
-    'anno int D@foo;
-", cursorAtOldNameOccurrence = 1);
-
 @expected{illegalRename}
-test bool builtinAnno() = {0, 1} == testRenameOccurrences("
+test bool builtinAnno() = testRename("
     'Tree t = char(8);
     'x = t@\\loc;
 ", oldName = "\\loc", imports = "import ParseTree;");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -29,20 +29,14 @@ module lang::rascal::tests::rename::Fields
 import lang::rascal::tests::rename::TestUtils;
 import lang::rascal::lsp::refactor::Exception;
 
-test bool dataFieldAtDef() = {0, 1} == testRenameOccurrences("
+test bool dataField() = testRenameOccurrences({0, 1}, "
     'D oneTwo = d(1, 2);
     'x = d.foo;
     ", decls = "data D = d(int foo, int baz);"
 );
 
-test bool dataFieldAtUse() = {0, 1} == testRenameOccurrences("
-    'D oneTwo = d(1, 2);
-    'x = d.foo;
-    ", decls = "data D = d(int foo, int baz);"
-, cursorAtOldNameOccurrence = 1);
-
 // TODO Implement data types properly
-// test bool multipleConstructorDataField() = {0, 1, 2} == testRenameOccurrences("
+// test bool multipleConstructorDataField() = testRenameOccurrences({0, 1, 2}, "
 //     'x = d(1, 2);
 //     'y = x.foo;
 //     ", decls = "data D = d(int foo) | d(int foo, int baz);"
@@ -86,49 +80,39 @@ test bool crossModuleDataFieldAtUse() = testRenameOccurrences({
 //         ", {0})
 // }, <"Scratch2", "foo", 0>);
 
-test bool relFieldAtDef() = {0, 1} == testRenameOccurrences("
+test bool relField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'f = r.foo;
 ");
 
-test bool relFieldAtUse() = {0, 1} == testRenameOccurrences("
-    'rel[str foo, str baz] r = {};
-    'f = r.foo;
-", cursorAtOldNameOccurrence = 1);
-
-test bool lrelFieldAtDef() = {0, 1} == testRenameOccurrences("
+test bool lrelField() = testRenameOccurrences({0, 1}, "
     'lrel[str foo, str baz] r = [];
     'f = r.foo;
 ");
 
-test bool lrelFieldAtUse() = {0, 1} == testRenameOccurrences("
-    'lrel[str foo, str baz] r = [];
-    'foos = r.foo;
-", cursorAtOldNameOccurrence = 1);
-
-test bool relSubscript() = {0, 1} == testRenameOccurrences("
+test bool relSubscript() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'x = r\<foo\>;
-");
+", skipCursors = {1});
 
-test bool relSubscriptWithVar() = {0, 2} == testRenameOccurrences("
+test bool relSubscriptWithVar() = testRenameOccurrences({0, 2}, "
     'rel[str foo, str baz] r = {};
     'str foo = \"foo\";
     'x = r\<foo\>;
-");
+", skipCursors = {2});
 
-test bool tupleFieldSubscriptUpdate() = {0, 1, 2} == testRenameOccurrences("
+test bool tupleFieldSubscriptUpdate() = testRenameOccurrences({0, 1, 2}, "
     'tuple[str foo, int baz] t = \<\"one\", 1\>;
     'u = t[foo = \"two\"];
     'v = u.foo;
 ");
 
-test bool tupleFieldAccessUpdate() = {0, 1} == testRenameOccurrences("
+test bool tupleFieldAccessUpdate() = testRenameOccurrences({0, 1}, "
     'tuple[str foo, int baz] t = \<\"one\", 1\>;
     't.foo = \"two\";
 ");
 
-test bool similarCollectionTypes() = {0, 1, 2, 3, 4} == testRenameOccurrences("
+test bool similarCollectionTypes() = testRenameOccurrences({0, 1, 2, 3, 4}, "
     'rel[str foo, int baz] r = {};
     'lrel[str foo, int baz] lr = [];
     'set[tuple[str foo, int baz]] st = {};
@@ -136,29 +120,17 @@ test bool similarCollectionTypes() = {0, 1, 2, 3, 4} == testRenameOccurrences("
     'tuple[str foo, int baz] t = \<\"\", 0\>;
 ");
 
-test bool differentRelWithSameFieldAtDef() = {0, 1} == testRenameOccurrences("
+test bool differentRelWithSameField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, int baz] r1 = {};
     'foos1 = r1.foo;
     'rel[int n, str foo] r2 = {};
     'foos2 = r2.foo;
 ");
 
-test bool differentRelWithSameFieldAtUse() = {0, 1} == testRenameOccurrences("
-    'rel[str foo, int baz] r1 = {};
-    'foos1 = r1.foo;
-    'rel[int n, str foo] r2 = {};
-    'foos2 = r2.foo;
-", cursorAtOldNameOccurrence = 1);
-
-test bool tupleFieldAtDef() = {0, 1} == testRenameOccurrences("
+test bool tupleField() = testRenameOccurrences({0, 1}, "
     'tuple[int foo] t = \<8\>;
     'y = t.foo;
 ");
-
-test bool tupleFieldAtUse() = {0, 1} == testRenameOccurrences("
-    'tuple[int foo] t = \<8\>;
-    'y = t.foo;
-", cursorAtOldNameOccurrence = 1);
 
 // We would prefer an illegalRename exception here
 @expected{unsupportedRename}

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -47,7 +47,7 @@ test bool duplicateDataField() = testRename("", decls =
     "data D = d(int foo, int bar);"
 );
 
-test bool crossModuleDataFieldAtDef() = testRenameOccurrences({
+test bool crossModuleDataField() = testRenameOccurrences({
     byText("Foo", "data D = a(int foo) | b(int bar);", {0}),
     byText("Main", "
     'import Foo;
@@ -56,18 +56,7 @@ test bool crossModuleDataFieldAtDef() = testRenameOccurrences({
     '   g = a.foo;
     '}
     ", {0})
-}, <"Foo", "foo", 0>);
-
-test bool crossModuleDataFieldAtUse() = testRenameOccurrences({
-    byText("Foo", "data D = a(int foo) | b(int bar);", {0}),
-    byText("Main", "
-    'import Foo;
-    'void main() {
-    '   f = a(8);
-    '   g = a.foo;
-    '}
-    ", {0})
-}, <"Main", "foo", 0>);
+});
 
 // TODO Implement data types properly
 // test bool extendedDataField() = testRenameOccurrences({
@@ -78,7 +67,7 @@ test bool crossModuleDataFieldAtUse() = testRenameOccurrences({
 //         'extend Scratch1;
 //         'data Foo = g(int foo);
 //         ", {0})
-// }, <"Scratch2", "foo", 0>);
+// });
 
 test bool relField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -29,7 +29,7 @@ module lang::rascal::tests::rename::FormalParameters
 import lang::rascal::tests::rename::TestUtils;
 import lang::rascal::lsp::refactor::Exception;
 
-test bool outerNestedFunctionParameter() = {0, 3} == testRenameOccurrences("
+test bool outerNestedFunctionParameter() = testRenameOccurrences({0, 3}, "
     'int f(int foo) {
     '   int g(int foo) {
     '       return foo;
@@ -38,48 +38,43 @@ test bool outerNestedFunctionParameter() = {0, 3} == testRenameOccurrences("
     '}
 ");
 
-test bool innerNestedFunctionParameter() = {1, 2} == testRenameOccurrences("
+test bool innerNestedFunctionParameter() = testRenameOccurrences({1, 2}, "
     'int f(int foo) {
     '   int g(int foo) {
     '       return foo;
     '   }
     '   return f(foo);
     '}
-", cursorAtOldNameOccurrence = 1);
+");
 
-test bool publicFunctionParameter() = {0, 1} == testRenameOccurrences("", decls = "
+test bool publicFunctionParameter() = testRenameOccurrences({0, 1}, "", decls = "
     'public int f(int foo) {
     '   return foo;
     '}
 ");
 
-test bool defaultFunctionParameter() = {0, 1} == testRenameOccurrences("", decls = "
+test bool defaultFunctionParameter() = testRenameOccurrences({0, 1}, "", decls = "
     'int f(int foo) {
     '   return foo;
     '}
 ");
 
-test bool privateFunctionParameter() = {0, 1} == testRenameOccurrences("", decls = "
+test bool privateFunctionParameter() = testRenameOccurrences({0, 1}, "", decls = "
     'private int f(int foo) {
     '   return foo;
     '}
 ");
 
-test bool nestedKeywordParameter() = {0, 1, 2} == testRenameOccurrences("
+test bool nestedKeywordParameter() = testRenameOccurrences({0, 1, 2}, "
     'int f(int foo = 8) = foo;
     'int x = f(foo = 10);
-");
+", skipCursors = {2});
 
-test bool keywordParameterFromDef() = expectEq({0, 1, 2}, testRenameOccurrences(
+test bool keywordParameter() = testRenameOccurrences({0, 1, 2},
     "int x = f(foo = 10);"
     , decls="int f(int foo = 8) = foo;"
-));
-
-test bool keywordParameterFromUse() = expectEq({0, 1, 2}, testRenameOccurrences(
-    "int x = f(foo = 10);"
-    , decls="int f(int foo = 8) = foo;"
-    , cursorAtOldNameOccurrence = 1
-));
+    , skipCursors = {2}
+);
 
 @expected{illegalRename} test bool doubleParameterDeclaration1() = testRename("int f(int foo, int bar) = 1;");
 @expected{illegalRename} test bool doubleParameterDeclaration2() = testRename("int f(int bar, int foo) = 1;");
@@ -90,7 +85,7 @@ test bool keywordParameterFromUse() = expectEq({0, 1, 2}, testRenameOccurrences(
 @expected{illegalRename} test bool doubleKeywordParameterDeclaration1() = testRename("int f(int foo = 8, int bar = 9) = 1;");
 @expected{illegalRename} test bool doubleKeywordParameterDeclaration2() = testRename("int f(int bar = 9, int foo = 8) = 1;");
 
-test bool renameParamToConstructorName() = {0, 1} == testRenameOccurrences(
+test bool renameParamToConstructorName() = testRenameOccurrences({0, 1},
     "int f(int foo) = foo;",
     decls = "data Bar = bar();"
 );
@@ -101,7 +96,7 @@ test bool renameParamToUsedConstructorName() = testRename(
     decls = "data Bar = bar(int x);"
 );
 
-test bool paremeterShadowsParameter1() = {0, 3} == testRenameOccurrences("
+test bool paremeterShadowsParameter1() = testRenameOccurrences({0, 3}, "
     'int f1(int foo) {
     '   int f2(int foo) {
     '       int baz = 9;
@@ -111,7 +106,7 @@ test bool paremeterShadowsParameter1() = {0, 3} == testRenameOccurrences("
     '}
 ");
 
-test bool paremeterShadowsParameter2() = {1, 2} == testRenameOccurrences("
+test bool paremeterShadowsParameter2() = testRenameOccurrences({1, 2}, "
     'int f1(int foo) {
     '   int f2(int foo) {
     '       int baz = 9;
@@ -119,7 +114,7 @@ test bool paremeterShadowsParameter2() = {1, 2} == testRenameOccurrences("
     '   }
     '   return f2(foo);
     '}
-", cursorAtOldNameOccurrence = 1);
+");
 
 @expected{illegalRename}
 test bool paremeterShadowsParameter3() = testRename("

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -28,13 +28,13 @@ module lang::rascal::tests::rename::Functions
 
 import lang::rascal::tests::rename::TestUtils;
 
-test bool nestedFunctionParameter() = {0, 1} == testRenameOccurrences("
+test bool nestedFunctionParameter() = testRenameOccurrences({0, 1}, "
     'int f(int foo, int baz) {
     '   return foo;
     '}
 ");
 
-test bool nestedRecursiveFunctionName() = {0, 1, 2, 3} == testRenameOccurrences("
+test bool nestedRecursiveFunctionName() = testRenameOccurrences({0, 1, 2, 3}, "
     'int fib(int n) {
     '   switch (n) {
     '       case 0: {
@@ -50,9 +50,9 @@ test bool nestedRecursiveFunctionName() = {0, 1, 2, 3} == testRenameOccurrences(
     '}
     '
     'fib(7);
-", oldName = "fib", newName = "fibonacci", cursorAtOldNameOccurrence = -1);
+", oldName = "fib", newName = "fibonacci");
 
-test bool recursiveFunctionName() = {0, 1, 2, 3} == testRenameOccurrences("fib(7);", decls = "
+test bool recursiveFunctionName() = testRenameOccurrences({0, 1, 2, 3}, "fib(7);", decls = "
     'int fib(int n) {
     '   switch (n) {
     '       case 0: {
@@ -66,76 +66,58 @@ test bool recursiveFunctionName() = {0, 1, 2, 3} == testRenameOccurrences("fib(7
     '       }
     '   }
     '}
-", oldName = "fib", newName = "fibonacci", cursorAtOldNameOccurrence = -1);
+", oldName = "fib", newName = "fibonacci");
 
-test bool nestedPublicFunction() = {0, 1} == testRenameOccurrences("
+test bool nestedPublicFunction() = testRenameOccurrences({0, 1}, "
     'public int foo(int f) {
     '   return f;
     '}
     'foo(1);
 ");
 
-test bool nestedDefaultFunction() = {0, 1} == testRenameOccurrences("
+test bool nestedDefaultFunction() = testRenameOccurrences({0, 1}, "
     'int foo(int f) {
     '   return f;
     '}
     'foo(1);
 ");
 
-test bool nestedPrivateFunction() = {0, 1} == testRenameOccurrences("
+test bool nestedPrivateFunction() = testRenameOccurrences({0, 1}, "
     'private int foo(int f) {
     '   return f;
     '}
     'foo(1);
 ");
 
-test bool publicFunction() = {0, 1} == testRenameOccurrences("foo(1);", decls = "
+test bool publicFunction() = testRenameOccurrences({0, 1}, "foo(1);", decls = "
     'public int foo(int f) {
     '   return f;
     '}
 ");
 
-test bool defaultFunction() = {0, 1} == testRenameOccurrences("foo(1);", decls = "
+test bool defaultFunction() = testRenameOccurrences({0, 1}, "foo(1);", decls = "
     'int foo(int f) {
     '   return f;
     '}
 ");
 
-test bool privateFunction() = {0, 1} == testRenameOccurrences("foo(1);", decls = "
+test bool privateFunction() = testRenameOccurrences({0, 1}, "foo(1);", decls = "
     'private int foo(int f) {
     '   return f;
     '}
 ");
 
-test bool backtrackOverloadFromUse() = {0, 1, 2} == testRenameOccurrences("x = foo(3);", decls = "
-    'int foo(int x) = x when x \< 2;
-    'default int foo(int x) = x;
-", cursorAtOldNameOccurrence = -1);
-
-test bool backtrackOverloadFromDef() = {0, 1, 2} == testRenameOccurrences("x = foo(3);", decls = "
+test bool backtrackOverload() = testRenameOccurrences({0, 1, 2}, "x = foo(3);", decls = "
     'int foo(int x) = x when x \< 2;
     'default int foo(int x) = x;
 ");
 
-test bool patternOverloadFromUse() = {0, 1, 2, 3} == testRenameOccurrences("x = size([1, 2]);", decls = "
-    'int size(list[&T] _: []) = 0;
-    'int size(list[&T] _: [_, *l]) = 1 + size(l);
-", cursorAtOldNameOccurrence = -1, oldName = "size", newName = "sizeof");
-
-test bool patternOverloadFromDef() = {0, 1, 2, 3} == testRenameOccurrences("x = size([1, 2]);", decls = "
+test bool patternOverload() = testRenameOccurrences({0, 1, 2, 3}, "x = size([1, 2]);", decls = "
     'int size(list[&T] _: []) = 0;
     'int size(list[&T] _: [_, *l]) = 1 + size(l);
 ", oldName = "size", newName = "sizeof");
 
-test bool typeOverloadFromUse() = {0, 1, 2, 3, 4, 5, 6} == testRenameOccurrences("x = size([1, 2]);", decls = "
-    'int size(list[&T] _: []) = 0;
-    'int size(list[&T] _: [_, *l]) = 1 + size(l);
-    '
-    'int size(set[&T] _: {}) = 0;
-    'int size(set[&T] _: {_, *s}) = 1 + size(s);
-", cursorAtOldNameOccurrence = -1, oldName = "size", newName = "sizeof");
-
-test bool typeOverloadFromDef() = {0, 1, 2, 3, 4, 5, 6} == testRenameOccurrences("x = size([1, 2]);", decls = "
+test bool typeOverload() = testRenameOccurrences({0, 1, 2, 3, 4, 5, 6}, "x = size([1, 2]);", decls = "
     'int size(list[&T] _: []) = 0;
     'int size(list[&T] _: [_, *l]) = 1 + size(l);
     '
@@ -143,19 +125,13 @@ test bool typeOverloadFromDef() = {0, 1, 2, 3, 4, 5, 6} == testRenameOccurrences
     'int size(set[&T] _: {_, *s}) = 1 + size(s);
 ", oldName = "size", newName = "sizeof");
 
-test bool arityOverloadFromUse() = {0, 1, 2, 3, 4, 5} == testRenameOccurrences("x = concat(\"foo\", \"bar\");", decls = "
-    'str concat(str s) = s;
-    'str concat(str s1, str s2) = s1 + concat(s2);
-    'str concat(str s1, str s2, str s3) = s1 + concat(s2, s3);
-", cursorAtOldNameOccurrence = -1, oldName = "concat", newName = "foo");
-
-test bool arityOverloadFromDef() = {0, 1, 2, 3, 4, 5} == testRenameOccurrences("x = concat(\"foo\", \"bar\");", decls = "
+test bool arityOverload() = testRenameOccurrences({0, 1, 2, 3, 4, 5}, "x = concat(\"foo\", \"bar\");", decls = "
     'str concat(str s) = s;
     'str concat(str s1, str s2) = s1 + concat(s2);
     'str concat(str s1, str s2, str s3) = s1 + concat(s2, s3);
 ", oldName = "concat", newName = "foo");
 
-test bool overloadClash() = {0} == testRenameOccurrences("", decls = "
+test bool overloadClash() = testRenameOccurrences({0}, "", decls = "
     'int foo = 0;
     'int foo(int x) = x when x \< 2;
 ");
@@ -171,34 +147,28 @@ test bool crossModuleOverload() = testRenameOccurrences({
     ", {0, 1})
 }, <"Main", "concat", 0>, newName = "conc");
 
-test bool simpleTypeParams() = {0, 1} == testRenameOccurrences("
+test bool simpleTypeParams() = testRenameOccurrences({0, 1}, "
     '&T foo(&T l) = l;
+    '&T bar(&T x, int y) = x;
 ", oldName = "T", newName = "U");
 
-test bool typeParamsFromReturn() = {0, 1, 2} == testRenameOccurrences("
+test bool typeParams() = testRenameOccurrences({0, 1, 2}, "
     '&T foo(&T l) {
     '   &T m = l;
     '   return m;
     '}
 ", oldName = "T", newName = "U");
 
-test bool keywordTypeParamFromReturn() = {0, 1, 2} == testRenameOccurrences("
+test bool keywordTypeParamFromReturn() = testRenameOccurrences({0, 1, 2}, "
     '&T foo(&T \<: int l, &T \<: int kw = 1) = l + kw;
 ", oldName = "T", newName = "U");
-
-test bool typeParamsFromFormal() = {0, 1, 2} == testRenameOccurrences("
-    '&T foo(&T l) {
-    '   &T m = l;
-    '   return m;
-    '}
-", oldName = "T", newName = "U", cursorAtOldNameOccurrence = 1);
 
 @expected{illegalRename}
 test bool typeParamsClash() = testRename("
     '&T foo(&T l, &U m) = l;
 ", oldName = "T", newName = "U", cursorAtOldNameOccurrence = 1);
 
-test bool nestedTypeParams() = {0, 1, 2, 3} == testRenameOccurrences("
+test bool nestedTypeParams() = testRenameOccurrences({0, 1, 2, 3}, "
     '&T f(&T t) {
     '   &T g(&T t) = t;
     '   return g(t);
@@ -213,19 +183,19 @@ test bool nestedTypeParamClash() = testRename("
     }
 ", oldName = "S", newName = "T", cursorAtOldNameOccurrence = 1);
 
-test bool adjacentTypeParams() = {0, 1} == testRenameOccurrences("
+test bool adjacentTypeParams() = testRenameOccurrences({0, 1}, "
     '&S f(&S s) = s;
     '&T f(&T t) = t;
 ", oldName = "S", newName = "T");
 
-test bool typeParamsListReturn() = {0, 1, 2} == testRenameOccurrences("
+test bool typeParamsListReturn() = testRenameOccurrences({0, 1, 2}, "
     'list[&T] foo(&T l) {
     '   list[&T] m = [l, l];
     '   return m;
     '}
-", oldName = "T", newName = "U", cursorAtOldNameOccurrence = 1);
+", oldName = "T", newName = "U");
 
-test bool localOverloadedFunction() = {0, 1, 2, 3} == testRenameOccurrences("
+test bool localOverloadedFunction() = testRenameOccurrences({0, 1, 2, 3}, "
     'bool foo(g()) = true;
     'bool foo(h()) = foo(g());
     '

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -145,7 +145,7 @@ test bool crossModuleOverload() = testRenameOccurrences({
         'extend Str;
         'str concat(str s1, str s2, str s3) = s1 + concat(s2, s3);
     ", {0, 1})
-}, <"Main", "concat", 0>, newName = "conc");
+}, oldName = "concat", newName = "conc");
 
 test bool simpleTypeParams() = testRenameOccurrences({0, 1}, "
     '&T foo(&T l) = l;
@@ -202,23 +202,14 @@ test bool localOverloadedFunction() = testRenameOccurrences({0, 1, 2, 3}, "
     'foo(h());
 ", decls = "data D = g() | h();");
 
-test bool functionsInVModuleStructureFromLeft() = testRenameOccurrences({
+test bool functionsInVModuleStructure() = testRenameOccurrences({
     byText("Left", "str foo(str s) = s when s == \"x\";", {0}), byText("Right", "str foo(str s) = s when s == \"y\";", {0})
                     , byText("Merger",
                         "import Left;
                         'import Right;
                         'void main() { x = foo(\"foo\"); }
                         ", {0})
-}, <"Left", "foo", 0>);
-
-test bool functionsInVModuleStructureFromMerger() = testRenameOccurrences({
-    byText("Left", "str foo(str s) = s when s == \"x\";", {0}), byText("Right", "str foo(str s) = s when s == \"y\";", {0})
-                    , byText("Merger",
-                        "import Left;
-                        'import Right;
-                        'void main() { foo(\"foo\"); }
-                        ", {0})
-}, <"Merger", "foo", 0>);
+});
 
 test bool functionsInYModuleStructure() = testRenameOccurrences({
     byText("Left", "str foo(str s) = s when s == \"x\";", {0}), byText("Right", "str foo(str s) = s when s == \"x\";", {0})
@@ -230,7 +221,7 @@ test bool functionsInYModuleStructure() = testRenameOccurrences({
                         "import Merger;
                         'void main() { foo(\"foo\"); }
                         ", {0})
-}, <"Left", "foo", 0>);
+});
 
 test bool functionsInInvertedVModuleStructure() = testRenameOccurrences({
             byText("Definer", "str foo(str s) = s when s == \"x\";
@@ -238,7 +229,7 @@ test bool functionsInInvertedVModuleStructure() = testRenameOccurrences({
     byText("Left", "import Definer;
                    'void main() { foo(\"foo\"); }", {0}), byText("Right", "import Definer;
                                                                           'void main() { foo(\"fu\"); }", {0})
-}, <"Left", "foo", 0>);
+});
 
 test bool functionsInDiamondModuleStructure() = testRenameOccurrences({
             byText("Definer", "str foo(str s) = s when s == \"x\";
@@ -247,7 +238,7 @@ test bool functionsInDiamondModuleStructure() = testRenameOccurrences({
             byText("User", "import Left;
                            'import Right;
                            'void main() { foo(\"foo\"); }", {0})
-}, <"Definer", "foo", 0>);
+});
 
 test bool functionsInIIModuleStructure() = testRenameOccurrences({
     byText("LeftDefiner",  "str foo(str s) = s when s == \"x\";", {0}), byText("RightDefiner",  "str foo(str s) = s when s == \"y\";", {}),
@@ -255,4 +246,4 @@ test bool functionsInIIModuleStructure() = testRenameOccurrences({
     byText("LeftUser",     "import LeftExtender;
                            'void main() { foo(\"foo\"); }", {0}),       byText("RightUser",     "import RightExtender;
                                                                                                 'void main() { foo(\"fu\"); }", {})
-}, <"LeftDefiner", "foo", 0>);
+});

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -41,7 +41,7 @@ test bool deepModule() = testRenameOccurrences({
     ", {0, 1})
 }, oldName = "Foo", newName = "Bar");
 
-test bool shadowedModule() = testRenameOccurrences({
+test bool shadowedModuleWithVar() = testRenameOccurrences({
     byText("Foo", "
         'data Bool = t() | f();
         'Bool and(Bool l, Bool r) = r is t ? l : f;
@@ -51,6 +51,19 @@ test bool shadowedModule() = testRenameOccurrences({
         'import Foo;
         'void main() {
         '   Foo::Bool b = and(t(), f());
+        '}
+    ", {0, 1})
+}, oldName = "Foo", newName = "Bar");
+
+test bool shadowedModuleWithFunc() = testRenameOccurrences({
+    byText("Foo", "
+        'void f() { fail; }
+        ", {0}, newName = "Bar"),
+    byText("shadow::Foo", "", {}),
+    byText("Main", "
+        'import Foo;
+        'void main() {
+        '   Foo::f();
         '}
     ", {0, 1})
 }, oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -28,20 +28,7 @@ module lang::rascal::tests::rename::Modules
 
 import lang::rascal::tests::rename::TestUtils;
 
-test bool singleModuleFromHeader() = testRenameOccurrences({
-    byText("Foo", "
-        'data Bool = t() | f();
-        'Bool and(Bool l, Bool r) = r is t ? l : f;
-        ", {0}, newName = "Bar"),
-    byText("Main", "
-        'import Foo;
-        'void main() {
-        '   Foo::Bool b = and(t(), f());
-        '}
-    ", {0, 1})
-}, <"Foo", "Foo", 0>, newName = "Bar");
-
-test bool deepModuleFromHeader() = testRenameOccurrences({
+test bool deepModule() = testRenameOccurrences({
     byText("some::path::to::Foo", "
         'data Bool = t() | f();
         'Bool and(Bool l, Bool r) = r is t ? l : f;
@@ -52,9 +39,9 @@ test bool deepModuleFromHeader() = testRenameOccurrences({
         '   some::path::to::Foo::Bool b = and(t(), f());
         '}
     ", {0, 1})
-}, <"some::path::to::Foo", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
-test bool shadowedModuleFromHeader() = testRenameOccurrences({
+test bool shadowedModule() = testRenameOccurrences({
     byText("Foo", "
         'data Bool = t() | f();
         'Bool and(Bool l, Bool r) = r is t ? l : f;
@@ -66,22 +53,9 @@ test bool shadowedModuleFromHeader() = testRenameOccurrences({
         '   Foo::Bool b = and(t(), f());
         '}
     ", {0, 1})
-}, <"Foo", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
-test bool singleModuleFromImport() = testRenameOccurrences({
-    byText("Foo", "
-        'data Bool = t() | f();
-        'Bool and(Bool l, Bool r) = r is t ? l : f;
-        ", {0}, newName = "Bar"),
-    byText("Main", "
-        'import Foo;
-        'void main() {
-        '   Foo::Bool b = and(t(), f());
-        '}
-    ", {0, 1})
-}, <"Main", "Foo", 0>, newName = "Bar");
-
-test bool singleModuleFromReference() = testRenameOccurrences({
+test bool singleModule() = testRenameOccurrences({
     byText("util::Foo", "
         'data Bool = t() | f();
         'Bool and(Bool l, Bool r) = r is t ? l : f;
@@ -92,4 +66,4 @@ test bool singleModuleFromReference() = testRenameOccurrences({
         '   util::Foo::Bool b = and(t(), f());
         '}
     ", {0, 1})
-}, <"Main", "Foo", 1>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
@@ -28,14 +28,16 @@ module lang::rascal::tests::rename::Performance
 
 import lang::rascal::tests::rename::TestUtils;
 
+import List;
+
 int LARGE_TEST_SIZE = 200;
-test bool largeTest() = ({0} | it + {foos + 3, foos + 4, foos + 5} | i <- [0..LARGE_TEST_SIZE], foos := 5 * i) == testRenameOccurrences((
+test bool largeTest() = testRenameOccurrences(({0} | it + {foos + 3, foos + 4, foos + 5} | i <- [0..LARGE_TEST_SIZE], foos := 5 * i), (
     "int foo = 8;"
     | "<it>
       'int f<i>(int foo) = foo;
       'foo = foo + foo;"
     | i <- [0..LARGE_TEST_SIZE])
-);
+, skipCursors = toSet([1..LARGE_TEST_SIZE * 5]));
 
 @expected{unsupportedRename}
 test bool failOnError() = testRename("int foo = x + y;");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -50,8 +50,8 @@ import util::Reflective;
 
 
 //// Fixtures and utility functions
-data TestModule = byText(str name, str body, set[int] expectedRenameOccs, str newName = name)
-                | byLoc(loc file, set[int] expectedRenameOccs, str newName = name);
+data TestModule = byText(str name, str body, set[int] nameOccs, str newName = name)
+                | byLoc(loc file, set[int] nameOccs, str newName = name);
 
 private list[DocumentEdit] sortEdits(list[DocumentEdit] edits) = [sortChanges(e) | e <- edits];
 
@@ -67,8 +67,10 @@ private void verifyTypeCorrectRenaming(loc root, list[DocumentEdit] edits, PathC
     throwAnyErrors(checkAll(root, ccfg));
 }
 
-bool expectEq(&T expected, &T actual) {
+bool expectEq(&T expected, &T actual, str epilogue = "") {
     if (expected != actual) {
+        if (epilogue != "") println(epilogue);
+
         print("EXPECTED: ");
         iprintln(expected);
         println();
@@ -81,63 +83,73 @@ bool expectEq(&T expected, &T actual) {
     return true;
 }
 
-bool testRenameOccurrences(set[TestModule] modules, tuple[str moduleName, str id, int occ] cursor, str newName = "bar") {
-    str testName = "Test<abs(arbInt())>";
-    loc testDir = |memory://tests/rename/<testName>|;
+bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str newName = "bar") {
+    bool success = true;
+    for (mm <- modules, cursorOcc <- mm.nameOccs) {
+        str testName = "Test<abs(arbInt())>";
+        loc testDir = |memory://tests/rename/<testName>|;
 
-    if(any(m <- modules, m is byLoc)) {
-        testDir = cover([m.file | m <- modules, m is byLoc]);
-    } else {
-        // If none of the modules refers to an existing file, clear the test directory before writing files.
+        if(any(m <- modules, m is byLoc)) {
+            testDir = cover([m.file | m <- modules, m is byLoc]);
+        } else {
+            // If none of the modules refers to an existing file, clear the test directory before writing files.
+            remove(testDir);
+        }
+
+        pcfg = getTestPathConfig(testDir);
+        modulesByLocation = {mByLoc | m <- modules, mByLoc := (m is byLoc ? m : byLoc(storeTestModule(testDir, m.name, m.body), m.nameOccs, newName = m.newName))};
+        cursorT = findCursor([m.file | m <- modulesByLocation, getModuleName(m.file, pcfg) == mm.name][0], oldName, cursorOcc);
+
+        println("Renaming \'<oldName>\' from <cursorT.src>");
+        edits = rascalRenameSymbol(cursorT, toSet(pcfg.srcs), newName, PathConfig(loc _) { return pcfg; });
+
+        renamesPerModule = (
+            beforeRename: afterRename
+            | renamed(oldLoc, newLoc) <- edits
+            , beforeRename := getModuleName(oldLoc, pcfg)
+            , afterRename := getModuleName(newLoc, pcfg)
+        );
+
+        replacesPerModule = (
+            name: occs
+            | changed(file, changes) <- edits
+            , name := getModuleName(file, pcfg)
+            , locs := {l | replace(l, _) <- changes}
+            , occs := locsToOccs(parseModuleWithSpaces(file), oldName, locs)
+        );
+
+        editsPerModule = (
+            name : <occs, nameAfterRename>
+            | srcDir <- pcfg.srcs
+            , file <- find(srcDir, "rsc")
+            , name := getModuleName(file, pcfg)
+            , occs := replacesPerModule[name] ? {}
+            , nameAfterRename := renamesPerModule[name] ? name
+        );
+
+        expectedEditsPerModule = (name: <m.nameOccs, m.newName> | m <- modulesByLocation, name := getModuleName(m.file, pcfg));
+
+        if (!expectEq(expectedEditsPerModule, editsPerModule, epilogue = "Rename from cursor <cursorT.src> failed:")) {
+            success = false;
+            println("Unexpected edits: ");
+            iprintln(edits);
+        }
+
+        for (src <- pcfg.srcs) {
+            verifyTypeCorrectRenaming(src, edits, pcfg);
+        }
+
         remove(testDir);
     }
 
-    pcfg = getTestPathConfig(testDir);
-    modulesByLocation = {mByLoc | m <- modules, mByLoc := (m is byLoc ? m : byLoc(storeTestModule(testDir, m.name, m.body), m.expectedRenameOccs, newName = m.newName))};
-    cursorT = findCursor([m.file | m <- modulesByLocation, getModuleName(m.file, pcfg) == cursor.moduleName][0], cursor.id, cursor.occ);
-
-    edits = rascalRenameSymbol(cursorT, toSet(pcfg.srcs), newName, PathConfig(loc _) { return pcfg; });
-
-    renamesPerModule = (
-        beforeRename: afterRename
-        | renamed(oldLoc, newLoc) <- edits
-        , beforeRename := getModuleName(oldLoc, pcfg)
-        , afterRename := getModuleName(newLoc, pcfg)
-    );
-
-    replacesPerModule = (
-        name: occs
-        | changed(file, changes) <- edits
-        , name := getModuleName(file, pcfg)
-        , locs := {l | replace(l, _) <- changes}
-        , occs := locsToOccs(parseModuleWithSpaces(file), cursor.id, locs)
-    );
-
-    editsPerModule = (
-        name : <occs, nameAfterRename>
-        | srcDir <- pcfg.srcs
-        , file <- find(srcDir, "rsc")
-        , name := getModuleName(file, pcfg)
-        , occs := replacesPerModule[name] ? {}
-        , nameAfterRename := renamesPerModule[name] ? name
-    );
-
-    expectedEditsPerModule = (name: <m.expectedRenameOccs, m.newName> | m <- modulesByLocation, name := getModuleName(m.file, pcfg));
-
-    if (!expectEq(expectedEditsPerModule, editsPerModule)) return false;
-
-    for (src <- pcfg.srcs) {
-        verifyTypeCorrectRenaming(src, edits, pcfg);
-    }
-
-    return true;
+    return success;
 }
 
 bool testRenameOccurrences(set[int] oldNameOccurrences, str stmtsStr, str oldName = "foo", str newName = "bar", str decls = "", str imports = "", set[int] skipCursors = {}) {
     bool success = true;
     map[int, set[int]] results = ();
     for (cursor <- oldNameOccurrences - skipCursors) {
-        <_, renamedOccs, _> = getEditsAndModule(stmtsStr, cursor, oldName, newName, decls, imports);
+        <_, renamedOccs> = getEditsAndModule(stmtsStr, cursor, oldName, newName, decls, imports);
         results[cursor] = renamedOccs;
         if (renamedOccs != oldNameOccurrences) success = false;
     }
@@ -233,11 +245,11 @@ tuple[list[DocumentEdit], set[int]] getEditsAndOccurrences(loc singleModule, loc
 }
 
 list[DocumentEdit] getEdits(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports) {
-    <edits, _, _> = getEditsAndModule(stmtsStr, cursorAtOldNameOccurrence, oldName, newName, decls, imports);
+    <edits, _> = getEditsAndModule(stmtsStr, cursorAtOldNameOccurrence, oldName, newName, decls, imports);
     return edits;
 }
 
-private tuple[list[DocumentEdit], set[int], loc] getEditsAndModule(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports, str moduleName = "TestModule<abs(arbInt())>") {
+private tuple[list[DocumentEdit], set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports, str moduleName = "TestModule<abs(arbInt())>") {
     str moduleStr =
     "module <moduleName>
     '<trim(imports)>
@@ -252,7 +264,7 @@ private tuple[list[DocumentEdit], set[int], loc] getEditsAndModule(str stmtsStr,
     writeFile(moduleFileName, moduleStr);
 
     <edits, occs> = getEditsAndOccurrences(moduleFileName, testDir, cursorAtOldNameOccurrence, oldName, newName);
-    return <edits, occs, moduleFileName>;
+    return <edits, occs>;
 }
 
 private set[int] extractRenameOccurrences(loc moduleFileName, list[DocumentEdit] edits, str name) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -133,9 +133,21 @@ bool testRenameOccurrences(set[TestModule] modules, tuple[str moduleName, str id
     return true;
 }
 
-set[int] testRenameOccurrences(str stmtsStr, int cursorAtOldNameOccurrence = 0, str oldName = "foo", str newName = "bar", str decls = "", str imports = "") {
-    <edits, occs, moduleFileName> = getEditsAndModule(stmtsStr, cursorAtOldNameOccurrence, oldName, newName, decls, imports);
-    return occs;
+bool testRenameOccurrences(set[int] oldNameOccurrences, str stmtsStr, str oldName = "foo", str newName = "bar", str decls = "", str imports = "", set[int] skipCursors = {}) {
+    bool success = true;
+    map[int, set[int]] results = ();
+    for (cursor <- oldNameOccurrences - skipCursors) {
+        <_, renamedOccs, _> = getEditsAndModule(stmtsStr, cursor, oldName, newName, decls, imports);
+        results[cursor] = renamedOccs;
+        if (renamedOccs != oldNameOccurrences) success = false;
+    }
+
+    if (!success) {
+        println("Test returned unexpected renames for some possible cursors (expected: <oldNameOccurrences>):");
+        iprintln(results);
+    }
+
+    return success;
 }
 
 // Test renames that are expected to throw an exception

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
@@ -50,7 +50,7 @@ test bool multiModuleAlias() = testRenameOccurrences({
                '   return 0;
                '}"
                , {0})
-    }, <"Main", "Foo", 0>, newName = "Bar");
+    }, oldName = "Foo", newName = "Bar");
 
 test bool globalData() = testRenameOccurrences({0, 1, 2, 3}, "
     'Foo f(Foo x) = x;
@@ -71,25 +71,16 @@ test bool multiModuleData() = testRenameOccurrences({
                '   Bool b = and(t(), f());
                '}"
                , {1})
-    }, <"Main", "Bool", 1>, newName = "Boolean");
+    }, oldName = "Bool", newName = "Boolean");
 
-test bool dataTypesInVModuleStructureFromLeft() = testRenameOccurrences({
+test bool dataTypesInVModuleStructure() = testRenameOccurrences({
     byText("Left", "data Foo = f();", {0}), byText("Right", "data Foo = g();", {0})
                     , byText("Merger",
                         "import Left;
                         'import Right;
                         'bool f(Foo foo) = (foo == f() || foo == g());
                         ", {0})
-}, <"Left", "Foo", 0>, newName = "Bar");
-
-test bool dataTypesInVModuleStructureFromMerger() = testRenameOccurrences({
-    byText("Left", "data Foo = f();", {0}), byText("Right", "data Foo = g();", {0})
-                    , byText("Merger",
-                        "import Left;
-                        'import Right;
-                        'bool f(Foo foo) = (foo == f() || foo == g());
-                        ", {0})
-}, <"Merger", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
 @synopsis{
     (defs)
@@ -110,7 +101,7 @@ test bool dataTypesInWModuleStructureWithoutMerge() = testRenameOccurrences({
                                         "import B;
                                         'import C;
                                         'bool func(Foo foo) = foo == h();", {})
-}, <"D", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
 @synopsis{
     (defs)
@@ -133,7 +124,7 @@ test bool dataTypesInWModuleStructureWithMerge() = testRenameOccurrences({
                                         "import B;
                                         'import C;
                                         'bool func(Foo foo) = foo == h();", {0})
-}, <"D", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
 test bool dataTypesInYModuleStructure() = testRenameOccurrences({
     byText("Left", "data Foo = f();", {0}), byText("Right", "data Foo = g();", {0})
@@ -145,14 +136,14 @@ test bool dataTypesInYModuleStructure() = testRenameOccurrences({
                         "import Merger;
                         'bool f(Foo foo) = (foo == f() || foo == g());
                         ", {0})
-}, <"Left", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
 test bool dataTypesInInvertedVModuleStructure() = testRenameOccurrences({
             byText("Definer", "data Foo = f() | g();", {0}),
     byText("Left", "import Definer;
                    'bool isF(Foo foo) = foo == f();", {0}), byText("Right", "import Definer;
                                                                             'bool isG(Foo foo) = foo == g();", {0})
-}, <"Left", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
 test bool dataTypesInDiamondModuleStructure() = testRenameOccurrences({
             byText("Definer", "data Foo = f() | g();", {0}),
@@ -161,7 +152,7 @@ test bool dataTypesInDiamondModuleStructure() = testRenameOccurrences({
                            'import Right;
                            'bool isF(Foo foo) = foo == f();
                            'bool isG(Foo foo) = foo == g();", {0, 1})
-}, <"Definer", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");
 
 @synopsis{
     Two disjunct module trees. Both trees define `data Foo`. Since the trees are disjunct,
@@ -173,4 +164,4 @@ test bool dataTypesInIIModuleStructure() = testRenameOccurrences({
     byText("LeftUser", "import LeftExtender;
                        'bool func(Foo foo) = foo == f();", {0}),       byText("RightUser", "import RightExtender;
                                                                         'bool func(Foo foo) = foo == g();", {})
-}, <"LeftDefiner", "Foo", 0>, newName = "Bar");
+}, oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
@@ -28,17 +28,11 @@ module lang::rascal::tests::rename::Types
 
 import lang::rascal::tests::rename::TestUtils;
 
-test bool globalAliasFromDef() = {0, 1, 2, 3} == testRenameOccurrences("
+test bool globalAlias() = testRenameOccurrences({0, 1, 2, 3}, "
     'Foo f(Foo x) = x;
     'Foo foo = 8;
     'y = f(foo);
 ", decls = "alias Foo = int;", oldName = "Foo", newName = "Bar");
-
-test bool globalAliasFromUse() = {0, 1, 2, 3} == testRenameOccurrences("
-    'Foo f(Foo x) = x;
-    'Foo foo = 8;
-    'y = f(foo);
-", decls = "alias Foo = int;", oldName = "Foo", newName = "Bar", cursorAtOldNameOccurrence = 1);
 
 test bool multiModuleAlias() = testRenameOccurrences({
     byText("alg::Fib", "alias Foo = int;
@@ -58,7 +52,7 @@ test bool multiModuleAlias() = testRenameOccurrences({
                , {0})
     }, <"Main", "Foo", 0>, newName = "Bar");
 
-test bool globalData() = {0, 1, 2, 3} == testRenameOccurrences("
+test bool globalData() = testRenameOccurrences({0, 1, 2, 3}, "
     'Foo f(Foo x) = x;
     'Foo x = foo();
     'y = f(x);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
@@ -32,19 +32,19 @@ import lang::rascal::lsp::refactor::Exception;
 
 //// Local
 
-test bool freshName() = {0} == testRenameOccurrences("
+test bool freshName() = testRenameOccurrences({0}, "
     'int foo = 8;
     'int qux = 10;
 ");
 
-test bool shadowVariableInInnerScope() = {0} == testRenameOccurrences("
+test bool shadowVariableInInnerScope() = testRenameOccurrences({0}, "
     'int foo = 8;
     '{
     '   int bar = 9;
     '}
 ");
 
-test bool parameterShadowsVariable() = {0} == testRenameOccurrences("
+test bool parameterShadowsVariable() = testRenameOccurrences({0}, "
     'int foo = 8;
     'int f(int bar) {
     '   return bar;
@@ -71,7 +71,7 @@ test bool doubleVariableDeclaration() = testRename("
     'int bar = 9;
 ");
 
-test bool adjacentScopes() = {0} == testRenameOccurrences("
+test bool adjacentScopes() = testRenameOccurrences({0}, "
     '{
     '   int foo = 8;
     '}
@@ -100,14 +100,14 @@ test bool implicitPatterVariableInInnerScopeBecomesUse() = testRename("
     '}
 ");
 
-test bool explicitPatternVariableInInnerScope() = {0} == testRenameOccurrences("
+test bool explicitPatternVariableInInnerScope() = testRenameOccurrences({0}, "
     'int foo = 8;
     'if (int bar := 9) {
     '   bar = 2 * bar;
     '}
 ");
 
-test bool becomesPatternInInnerScope() = {0} == testRenameOccurrences("
+test bool becomesPatternInInnerScope() = testRenameOccurrences({0}, "
     'int foo = 8;
     'if (bar : int _ := 9) {
     '   bar = 2 * bar;
@@ -162,9 +162,9 @@ test bool doubleFunctionAndNestedVariableDeclaration() = testRename("
     '}
 ");
 
-test bool tupleVariable() = {0} == testRenameOccurrences("\<foo, baz\> = \<0, 1\>;");
+test bool tupleVariable() = testRenameOccurrences({0}, "\<foo, baz\> = \<0, 1\>;");
 
-test bool tuplePatternVariable() = {0, 1} == testRenameOccurrences("
+test bool tuplePatternVariable() = testRenameOccurrences({0, 1}, "
     'if (\<foo, baz\> := \<0, 1\>)
     '   qux = foo;
 ");
@@ -172,7 +172,7 @@ test bool tuplePatternVariable() = {0, 1} == testRenameOccurrences("
 
 //// Global
 
-test bool globalVar() = {0, 3} == testRenameOccurrences("
+test bool globalVar() = testRenameOccurrences({0, 3}, "
     'int f(int foo) = foo;
     'foo = 16;
 ", decls = "

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
@@ -196,4 +196,4 @@ test bool multiModuleVar() = testRenameOccurrences({
                '   return 0;
                '}"
                , {0})
-    }, <"Main", "foo", 0>, newName = "Bar");
+    });


### PR DESCRIPTION
Instead of manually writing near-duplicate tests that test several possible cursors, treat the expected rename locations as possible cursor inputs. Certain occurrences are currently not supported as cursors. For this we provide an optional set of `skipCursors`; these occurrences are not used as inputs, but are still expected to be in the output set.

Adds features to #397.