### PR TITLE
Fix flaky detection of source path caused by VS Code flipping the case of drive letters sometimes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,10 @@ extra_flags=''
 clean="clean"
 while getopts 'fd' flag; do
   case "${flag}" in
-    f) extra_flags='-Drascal.compile.skip -Drascal.tutor.skip' ;;
+    f) extra_flags='-Drascal.compile.skip -Drascal.tutor.skip -DskipTests' ;;
     d) clean='' ;;
     *) printf "incorrect param, valid params:
-    Use -f to skip rascal-compile
+    Use -f to skip rascal-compile and tests
     Use -d to skip cleaning the target folder"
         exit 1 ;;
   esac

--- a/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
@@ -165,10 +165,20 @@ async function reportMissingFile(file: vscode.Uri, project: vscode.WorkspaceFold
     return true;
 }
 
-function isChild(parent: Uri, child: Uri): unknown {
-    return parent.scheme === child.scheme
-        && parent.authority === child.authority
-        && child.path.startsWith(parent.path.endsWith('/') ? parent.path : (parent.path + '/'));
+function isChild(parent: Uri, child: Uri): boolean {
+    if (parent.scheme !== child.scheme) {
+        return false;
+    }
+    parent = parent.path.endsWith('/') ? parent : parent.with({path: parent.path + '/'});
+    if (parent.scheme === 'file') {
+        // to make sure we can deal with case-sensitivity issues, we have to normalize
+        // to the file system path
+        // note, this might also have to be done for virtual file systems, but VS Code has no public API for that (IExtUri would be nice!)
+        return child.fsPath.startsWith(parent.fsPath);
+    }
+    else {
+        return parent.authority === child.authority && child.path.startsWith(parent.path);
+    }
 }
 
 // TODO: at a later point, merge this with code in the RascalMF validator


### PR DESCRIPTION

Fixes #442