### PR TITLE
Reduce flakyness of the rename test by retrying the command to send the tename

### DIFF
--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -40,7 +40,7 @@ describe('DSL', function () {
     this.timeout(Delays.extremelySlow * 2);
 
 
-    printRascalOutputOnFailure('Parametric Rascal LSP');
+    printRascalOutputOnFailure('Language Parametric Rascal');
 
     async function loadPico() {
         const repl = new RascalREPL(bench, driver);

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -273,7 +273,7 @@ async function showRascalOutput(bbp: BottomBarPanel, channel: string) {
     return outputView;
 }
 
-export function printRascalOutputOnFailure(channel: 'Parametric Rascal LSP' | 'Rascal MPL') {
+export function printRascalOutputOnFailure(channel: 'Language Parametric Rascal' | 'Rascal MPL') {
 
     const ZOOM_OUT_FACTOR = 5;
     afterEach("print output in case of failure", async function () {


### PR DESCRIPTION
After inspect a few of the crashes, it seemed to always fail at the `sendKeys` part. so lets just retry that whole thing on failure, and lets hope the mac tests don't fail again.