### PR TITLE
Improving the UI test runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
         working-directory: ./rascal-vscode-extension
         env:
           DELAY_FACTOR: 15
-          _JAVA_OPTIONS: '-Xmx5G'
+          _JAVA_OPTIONS: '-Xmx4G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   actions: read
   contents: write
+  #pull-requests: write
   
 jobs:
   ui-test:
@@ -37,6 +38,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: rascal-vscode-extension/package-lock.json
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          metric_frequency: 2
 
       - name: Package & compile rascal-lsp
         working-directory: ./rascal-lsp

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
         working-directory: ./rascal-vscode-extension
         env:
           DELAY_FACTOR: 10
-          _JAVA_OPTIONS: '-Xmx2G'
+          _JAVA_OPTIONS: '-Xmx5G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (mac)"
@@ -75,7 +75,7 @@ jobs:
         working-directory: ./rascal-vscode-extension
         env:
           DELAY_FACTOR: 15
-          _JAVA_OPTIONS: '-Xmx4G'
+          _JAVA_OPTIONS: '-Xmx5G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 5
+          DELAY_FACTOR: 10
           _JAVA_OPTIONS: '-Xmx5G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
@@ -112,16 +112,16 @@ jobs:
         if: matrix.os == 'macos-latest'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 5
+          DELAY_FACTOR: 15
           _JAVA_OPTIONS: '-Xmx5G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"
         shell: bash
-        if: matrix.os == 'buildjet-4vcpu-ubuntu-2204'
+        if: matrix.os == 'buildjet-2vcpu-ubuntu-2204'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 3
+          DELAY_FACTOR: 5
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
         run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,6 @@ on:
 permissions:
   actions: read
   contents: write
-  #pull-requests: write
   
 jobs:
   normal-tests:
@@ -34,11 +33,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: rascal-vscode-extension/package-lock.json
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          metric_frequency: 2
 
       - name: Run java tests
         working-directory: ./rascal-lsp
@@ -76,11 +70,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: rascal-vscode-extension/package-lock.json
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          metric_frequency: 2
 
       - name: Package & compile rascal-lsp
         working-directory: ./rascal-lsp

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,7 +121,7 @@ jobs:
         if: matrix.os == 'buildjet-4vcpu-ubuntu-2204'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 5
+          DELAY_FACTOR: 8
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
         run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run java tests
         working-directory: ./rascal-lsp
-        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' test
+        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' test -DargLine="-Xmx4G"
 
       - name: VS Code tests
         working-directory: ./rascal-vscode-extension
@@ -54,7 +54,7 @@ jobs:
   ui-test:
     strategy:
       matrix:
-        os: [buildjet-2vcpu-ubuntu-2204, windows-latest, macos-latest]
+        os: [buildjet-4vcpu-ubuntu-2204, windows-latest, macos-latest]
       fail-fast: true
     env:
       CODE_VERSION: "1.82.3"
@@ -118,7 +118,7 @@ jobs:
 
       - name: "UI test (ubuntu)"
         shell: bash
-        if: matrix.os == 'buildjet-2vcpu-ubuntu-2204'
+        if: matrix.os == 'buildjet-4vcpu-ubuntu-2204'
         working-directory: ./rascal-vscode-extension
         env:
           DELAY_FACTOR: 5
@@ -159,7 +159,7 @@ jobs:
 
       - name: Package & compile rascal-lsp
         working-directory: ./rascal-lsp
-        run: mvn -B clean verify
+        run: mvn -B clean verify -DskipTests
         env:
           MAVEN_OPTS: "-Xmx6G"
 
@@ -175,9 +175,6 @@ jobs:
           npm run license-check
           npm run esbuild
           npm run lint 
-          npm run compile-tests
-          npm run normalTest
-          # disable vs-code test npm run test
 
       - name: package extension
         working-directory: rascal-vscode-extension

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
   ui-test:
     strategy:
       matrix:
-        os: [buildjet-4vcpu-ubuntu-2204, windows-latest, macos-latest]
+        os: [buildjet-2vcpu-ubuntu-2204, windows-latest, macos-latest]
       fail-fast: true
     env:
       CODE_VERSION: "1.82.3"
@@ -103,7 +103,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 10
+          DELAY_FACTOR: 5
           _JAVA_OPTIONS: '-Xmx5G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
@@ -112,8 +112,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 15
-          _JAVA_OPTIONS: '-Xmx4G'
+          DELAY_FACTOR: 5
+          _JAVA_OPTIONS: '-Xmx5G'
         run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"
@@ -121,7 +121,7 @@ jobs:
         if: matrix.os == 'buildjet-4vcpu-ubuntu-2204'
         working-directory: ./rascal-vscode-extension
         env:
-          DELAY_FACTOR: 8
+          DELAY_FACTOR: 3
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
         run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Package & compile rascal-lsp
         working-directory: ./rascal-lsp
-        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' clean package
+        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' -DskipTests clean package
 
       - name: Package & compile extension 
         working-directory: ./rascal-vscode-extension

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,8 @@ jobs:
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
+      - name: Assure different pom cache hit
+        run: echo "  " >> rascal-lsp/pom.xml
       - uses: actions/setup-java@v4
         with:
           java-version: 11
@@ -59,6 +61,8 @@ jobs:
     runs-on:  ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Assure different pom cache hit
+        run: echo " " >> rascal-lsp/pom.xml
       - uses: actions/setup-java@v4
         with:
           java-version: 11

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,40 @@ permissions:
   #pull-requests: write
   
 jobs:
+  normal-tests:
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+          cache-dependency-path: rascal-vscode-extension/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          metric_frequency: 2
+
+      - name: Run java tests
+        working-directory: ./rascal-lsp
+        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' test
+
+      - name: VS Code tests
+        working-directory: ./rascal-vscode-extension
+        run: |
+          npm ci
+          npm run compile-tests
+          npm run normalTest
+      
   ui-test:
     strategy:
       matrix:
@@ -101,7 +135,7 @@ jobs:
         run: rm -rf ./rascal-vscode-extension/uitests/screenshots
 
   build:
-    needs: [ui-test]
+    needs: [ui-test, normal-tests]
     runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -42,7 +42,7 @@ describe('DSL', function () {
     this.timeout(Delays.extremelySlow * 2);
 
     function log(text: string) {
-        console.log(`${Date.now()}: ${text}`);
+        console.log(`${Date.now() / 1000}: ${text}`);
     }
 
     printRascalOutputOnFailure('Language Parametric Rascal');

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -86,36 +86,24 @@ describe('DSL', function () {
     });
 
     it("have highlighting and parse errors", async function () {
-        log("Start with parse test");
         const editor = await ide.openModule(TestWorkspace.picoFile);
-        log("Waiting for ide to have no syntax highlighting");
         await ide.hasSyntaxHighlighting(editor);
         try {
-            log("Update a line of text");
             await editor.setTextAtLine(10, "b := ;");
-            log("Detect errors");
             await ide.hasErrorSquiggly(editor, 15_000);
-            log("Done finding fault");
         } finally {
             await ide.revertOpenChanges();
-            log("Done reverting changes");
         }
     });
 
     it("have highlighting and parse errors for second extension", async function () {
-        log("Start with parse2 test");
         const editor = await ide.openModule(TestWorkspace.picoNewFile);
-        log("Waiting for ide to have no syntax highlighting");
         await ide.hasSyntaxHighlighting(editor);
         try {
-            log("Update a line of text");
             await editor.setTextAtLine(10, "b := ;");
-            log("Detect errors");
             await ide.hasErrorSquiggly(editor, 15_000);
-            log("Done finding fault");
         } finally {
             await ide.revertOpenChanges();
-            log("Done reverting changes");
         }
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -41,6 +41,10 @@ describe('DSL', function () {
 
     this.timeout(Delays.extremelySlow * 2);
 
+    function log(text: string) {
+        console.log(`${Date.now()}: ${text}`);
+    }
+
     printRascalOutputOnFailure('Language Parametric Rascal');
 
     async function loadPico() {
@@ -48,7 +52,7 @@ describe('DSL', function () {
         await repl.start();
         await repl.execute("import demo::lang::pico::LanguageServer;");
         repl.execute("main();"); // we don't wait, be cause we might miss pico loading window
-        const ide = new IDEOperations(browser, bench);
+        const ide = new IDEOperations(browser);
         const isPicoLoading = ide.statusContains("Pico");
         await driver.wait(isPicoLoading, Delays.slow, "Pico DSL should start loading");
         await repl.terminate();
@@ -62,11 +66,11 @@ describe('DSL', function () {
         driver = browser.driver;
         bench = new Workbench();
         await ignoreFails(browser.waitForWorkbench());
-        ide = new IDEOperations(browser, bench);
+        ide = new IDEOperations(browser);
         await ide.load();
         await loadPico();
         picoFileBackup = await fs.readFile(TestWorkspace.picoFile);
-        ide = new IDEOperations(browser, bench);
+        ide = new IDEOperations(browser);
         await ide.load();
     });
 
@@ -82,10 +86,14 @@ describe('DSL', function () {
     });
 
     it("have highlighting and parse errors", async function () {
+        log("Start with parse test");
         const editor = await ide.openModule(TestWorkspace.picoFile);
+        log("Waiting for ide to have no syntax highlighting");
         await ide.hasSyntaxHighlighting(editor);
         try {
+            log("Update a line of text");
             await editor.setTextAtLine(10, "b := ;");
+            log("Detect errors");
             await ide.hasErrorSquiggly(editor, 15_000);
         } finally {
             await ide.revertOpenChanges();

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -95,8 +95,10 @@ describe('DSL', function () {
             await editor.setTextAtLine(10, "b := ;");
             log("Detect errors");
             await ide.hasErrorSquiggly(editor, 15_000);
+            log("Done finding fault");
         } finally {
             await ide.revertOpenChanges();
+            log("Done reverting changes");
         }
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -103,13 +103,19 @@ describe('DSL', function () {
     });
 
     it("have highlighting and parse errors for second extension", async function () {
+        log("Start with parse2 test");
         const editor = await ide.openModule(TestWorkspace.picoNewFile);
+        log("Waiting for ide to have no syntax highlighting");
         await ide.hasSyntaxHighlighting(editor);
         try {
+            log("Update a line of text");
             await editor.setTextAtLine(10, "b := ;");
+            log("Detect errors");
             await ide.hasErrorSquiggly(editor, 15_000);
+            log("Done finding fault");
         } finally {
             await ide.revertOpenChanges();
+            log("Done reverting changes");
         }
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -41,10 +41,6 @@ describe('DSL', function () {
 
     this.timeout(Delays.extremelySlow * 2);
 
-    function log(text: string) {
-        console.log(`${Date.now()}: ${text}`);
-    }
-
     printRascalOutputOnFailure('Language Parametric Rascal');
 
     async function loadPico() {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -50,7 +50,7 @@ describe('IDE', function () {
         driver = browser.driver;
         bench = new Workbench();
         await browser.waitForWorkbench();
-        ide = new IDEOperations(browser, bench);
+        ide = new IDEOperations(browser);
         await ide.load();
         // trigger rascal type checker to be sure
         for (const f of protectFiles) {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -152,8 +152,10 @@ describe('IDE', function () {
         const outline = await driver.wait(() => explorer.getContent().getSection("Outline"), Delays.normal) as ViewSection;
         await outline.expand();
         const mainItem = await driver.wait(async() => ignoreFails(outline.findItem("main()", 0)), Delays.slow, "Main function should show in the outline");
-        await driver.actions().doubleClick(mainItem!).perform();
-        await driver.wait(async ()=> (await editor.getCoordinates())[0] === 5, Delays.normal, "Cursor should have moved to line that contains the println function");
+        await driver.wait(async () => {
+            await driver.actions().doubleClick(mainItem!).perform();
+            return (await editor.getCoordinates())[0] === 5;
+        }, Delays.normal, "Cursor should have moved to line that contains the println function");
     });
 
     it ("rename works", async() => {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -80,20 +80,20 @@ describe('IDE', function () {
             const checkRascalStatus = ide.statusContains("Loading Rascal");
 
             for (let tries = 0; tries < 10 && !statusBarSeen; tries++) {
-                await sleep(delay / 80);
                 if (await checkRascalStatus()) {
                     statusBarSeen = true;
                     break;
                 }
+                await sleep(delay / 80);
             }
 
             if (statusBarSeen) {
                 console.log("Waiting for startup of rascal core");
                 for (let tries = 0; tries < 70; tries++) {
-                    await sleep(delay / 80);
                     if (!await checkRascalStatus()) {
                         return;
                     }
+                    await sleep(delay / 80);
                 }
                 console.log("*** warning, loading rascal-core is still running, but we will continue anyway");
             }
@@ -149,8 +149,7 @@ describe('IDE', function () {
         const editor = await ide.openModule(TestWorkspace.mainFile);
         await editor.moveCursor(1,1);
         const explorer = await (await bench.getActivityBar().getViewControl("Explorer"))!.openView();
-        await sleep(Delays.normal);
-        const outline = await explorer.getContent().getSection("Outline") as ViewSection;
+        const outline = await driver.wait(() => explorer.getContent().getSection("Outline"), Delays.normal) as ViewSection;
         await outline.expand();
         const mainItem = await driver.wait(async() => ignoreFails(outline.findItem("main()", 0)), Delays.slow, "Main function should show in the outline");
         await driver.actions().doubleClick(mainItem!).perform();

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -43,7 +43,7 @@ describe('REPL', function () {
         browser = VSBrowser.instance;
         driver = browser.driver;
         bench = new Workbench();
-        ide = new IDEOperations(browser, bench);
+        ide = new IDEOperations(browser);
         await ide.load();
         await ide.cleanup();
         await browser.waitForWorkbench();

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -83,8 +83,8 @@ describe('REPL', function () {
     it("edit call module via repl", async() => {
         const repl = new RascalREPL(bench, driver);
         await repl.start();
-        await repl.execute(":edit demo::lang::pico::LanguageServer");
+        await repl.execute(":edit demo::lang::pico::LanguageServer", true, Delays.extremelySlow);
 
-        await driver.wait(async () => await (await bench.getEditorView().getActiveTab())?.getTitle() === "LanguageServer.rsc", Delays.normal, "LanguageServer should be opened");
+        await driver.wait(async () => await (await bench.getEditorView().getActiveTab())?.getTitle() === "LanguageServer.rsc", Delays.slow, "LanguageServer should be opened");
     });
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -93,14 +93,17 @@ export class RascalREPL {
     async waitForReplReady() {
         let output = "";
         try {
-            for (let tries = 0; tries < 5; tries++) {
-                await sleep(100);
-                output = await this.terminal.getText();
-                if (/rascal>\s*$/.test(output)) {
-                    return true;
-                }
+            try {
+                return await this.driver.wait(async () => {
+                    output = await this.terminal.getText();
+                    if (/rascal>\s*$/.test(output)) {
+                        return true;
+                    }
+                    return false;
+                }, Delays.verySlow, "Rascal prompt", 500);
+            } catch (_ignored) {
+                return false;
             }
-            return false;
         }
         finally {
             const lines = output.split('\n').map(l => l.trimEnd());

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -94,12 +94,11 @@ export class RascalREPL {
         let output = "";
         try {
             for (let tries = 0; tries < 5; tries++) {
-                await sleep(Delays.slow / 10);
+                await sleep(100);
                 output = await this.terminal.getText();
                 if (/rascal>\s*$/.test(output)) {
                     return true;
                 }
-                await sleep(Delays.slow / 10);
             }
             return false;
         }

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -217,11 +217,19 @@ export class IDEOperations {
         return new Workbench().executeCommand("workbench.action.revertAndCloseActiveEditor");
     }
 
+    log(text: string) {
+        console.log(`${Date.now() / 1000}: ${text}`);
+    }
+
     async openModule(file: string): Promise<TextEditor> {
         return this.driver.wait(async () => {
+            this.log("OM: Opening resource");
             await ignoreFails(this.browser.openResources(file));
+            this.log("OM: opening editor");
             const result = await ignoreFails(new Workbench().getEditorView().openEditor(path.basename(file))) as TextEditor;
+            this.log("OM: getting title");
             if (result && await ignoreFails(result.getTitle()) === path.basename(file)) {
+                this.log("OM: found editor");
                 return result;
             }
             return undefined;

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -200,7 +200,7 @@ export class IDEOperations {
     }
 
     hasErrorSquiggly(_editor: TextEditor, timeout = Delays.normal, message = "Missing error squiggly"): Promise<WebElement> {
-        return this.driver.wait(until.elementLocated(By.className("squiggly-error")), timeout, message);
+        return this.driver.wait(until.elementLocated(By.className("squiggly-error")), timeout, message, 100);
     }
 
     hasSyntaxHighlighting(editor: TextEditor, timeout = Delays.normal, message = "Syntax highlighting should be present"): Promise<WebElement> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -216,16 +216,14 @@ export class IDEOperations {
     }
 
     async openModule(file: string): Promise<TextEditor> {
-        for (let tries = 0; tries < 10; tries++) {
+        return this.driver.wait(async () => {
             await ignoreFails(this.browser.openResources(file));
-            await sleep(Delays.fast);
             const result = await ignoreFails(new Workbench().getEditorView().openEditor(path.basename(file))) as TextEditor;
-            await sleep(Delays.fast);
             if (result && await ignoreFails(result.getTitle()) === path.basename(file)) {
                 return result;
             }
-        }
-        throw new Error("Could not open file " + file);
+            return undefined;
+        }, Delays.normal, "Could not open file") as Promise<TextEditor>;
     }
 
     async triggerTypeChecker(editor: TextEditor, { checkName = "Rascal check", waitForFinish = false, timeout = Delays.verySlow, tplFile = "" } = {}) {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -192,7 +192,7 @@ export class IDEOperations {
     }
 
     hasElement(editor: TextEditor, selector: Locator, timeout: number, message: string): Promise<WebElement> {
-        return this.driver.wait(() => editor.findElement(selector), timeout, message );
+        return this.driver.wait(() => editor.findElement(selector), timeout, message, 50);
     }
 
     hasWarningSquiggly(_editor: TextEditor, timeout = Delays.normal, message = "Missing warning squiggly"): Promise<WebElement> {
@@ -200,7 +200,7 @@ export class IDEOperations {
     }
 
     hasErrorSquiggly(_editor: TextEditor, timeout = Delays.normal, message = "Missing error squiggly"): Promise<WebElement> {
-        return this.driver.wait(until.elementLocated(By.className("squiggly-error")), timeout, message, 100);
+        return this.driver.wait(until.elementLocated(By.className("squiggly-error")), timeout, message, 50);
     }
 
     hasSyntaxHighlighting(editor: TextEditor, timeout = Delays.normal, message = "Syntax highlighting should be present"): Promise<WebElement> {


### PR DESCRIPTION
The UI test were taking too long to run, locally and on CI.

I dove in and started measure what was taking long, and bit by bit removing generic sleeps and replacing them by `driver.wait` calls. It also involved tuning memory and splitting of non UI tests to a separate stage.

Before (30min total time):
![image](https://github.com/user-attachments/assets/a03058a0-aae9-4724-a4b5-b237e1413711)


Now (13min total time):

![image](https://github.com/user-attachments/assets/6bff5208-d77a-4e39-a008-d70d76658da6)

