### PR TITLE
Trying to improve a final issue with the UI tests

### DIFF
--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -166,7 +166,7 @@ describe('DSL', function () {
 
         // finds an open menu with the right item in it (Change to a) and then select
         // the parent that handles UI events like click() and sendKeys()
-        const menuContainer = await ide.hasElement(editor, By.xpath("//div[contains(@class, 'focused') and contains(@class, 'action')]/span[contains(text(), 'Change to a')]//ancestor::*[contains(@class, 'monaco-list')]"), Delays.verySlow,"The Change to a option should be available and focussed by default");
+        const menuContainer = await ide.hasElement(editor, By.xpath("//div[contains(@class, 'focused') and contains(@class, 'action')]/span[contains(text(), 'Change to a')]//ancestor::*[contains(@class, 'monaco-list')]"), Delays.normal, "The Change to a option should be available and focussed by default");
 
         // menu container works a bit strangely, it ask the focus to keep track of it,
         // and manages clicks and menus on the highest level (not per item).

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -166,7 +166,7 @@ describe('DSL', function () {
 
         // finds an open menu with the right item in it (Change to a) and then select
         // the parent that handles UI events like click() and sendKeys()
-        const menuContainer = await ide.hasElement(editor, By.xpath("//div[contains(@class, 'focused') and contains(@class, 'action')]/span[contains(text(), 'Change to a')]//ancestor::*[contains(@class, 'monaco-list')]"), Delays.normal,"The Change to a option should be available and focussed by default");
+        const menuContainer = await ide.hasElement(editor, By.xpath("//div[contains(@class, 'focused') and contains(@class, 'action')]/span[contains(text(), 'Change to a')]//ancestor::*[contains(@class, 'monaco-list')]"), Delays.verySlow,"The Change to a option should be available and focussed by default");
 
         // menu container works a bit strangely, it ask the focus to keep track of it,
         // and manages clicks and menus on the highest level (not per item).


### PR DESCRIPTION
Sometimes on slow machines, it wouldn't work, and this is due to `findElement` throwing an exception that `driver.wait` doesn't swallow.