### PR TITLE
Configuration of Rascal terminal names

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -194,6 +194,12 @@
           ],
           "default": null,
           "description": "Provides the per-thread stack size, in MB, for the Rascal interpreter"
+        },
+        "rascal.terminal.name.originFormat": {
+          "type": "string",
+          "default": "Project root",
+          "enum": ["Project root", "Module"],
+          "markdownDescription": "Specifies the format of `<origin>` in Rascal terminal name `Rascal terminal (<origin>)`"
         }
       }
     }

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -198,7 +198,7 @@
         "rascal.terminal.name.originFormat": {
           "type": "string",
           "default": "Project root",
-          "enum": ["Project root", "Module"],
+          "enum": ["Project root", "Module (qualified)", "Module (unqualified)"],
           "markdownDescription": "Specifies the format of `<origin>` in Rascal terminal name `Rascal terminal (<origin>)`"
         }
       }

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -152,17 +152,20 @@ export class RascalExtension implements vscode.Disposable {
             const config = vscode.workspace.getConfiguration();
             const originFormat = config.get('rascal.terminal.name.originFormat');
             switch (originFormat) {
-                case 'Project root':
+                case 'Project root': {
                     const projectRoot = vscode.workspace.getWorkspaceFolder(uri);
                     if (projectRoot && projectRoot.name) {
                         return projectRoot.name;
                     }
                     break;
-                case 'Module':
+                }
+                case 'Module': {
                     const sep = uri.path.lastIndexOf("/");
                     if (sep !== -1 && uri.path.endsWith(".rsc")) {
                         return uri.path.substring(sep + 1, uri.path.length - 4);
                     }
+                    break;
+                }
                 default:
                     console.log(`Unknown origin format: ${originFormat}`);
             }

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -150,10 +150,10 @@ export class RascalExtension implements vscode.Disposable {
     private getTerminalOrigin(uri: vscode.Uri | undefined): string {
         if (uri) {
             const config = vscode.workspace.getConfiguration();
-            const projectRoot = vscode.workspace.getWorkspaceFolder(uri);
             const originFormat = config.get('rascal.terminal.name.originFormat');
             switch (originFormat) {
                 case 'Project root':
+                    const projectRoot = vscode.workspace.getWorkspaceFolder(uri);
                     if (projectRoot && projectRoot.name) {
                         return projectRoot.name;
                     }


### PR DESCRIPTION
### Context

This PR makes a small improvement to the VS Code extension that would make my life marginally easier 😉 I figured this might be useful to other users as well, so here we go.

### Problem

I have many modules that I need to import in separate terminals for testing purposes. (The modules share some conflicting definitions, so I can't import them in one terminal.) So:

 1. Open the modules:
    ![image](https://github.com/user-attachments/assets/68c226b6-a328-4983-a873-bb867ed03440)

 2. Click this button in each of the modules:
    ![image](https://github.com/user-attachments/assets/86a6ee71-d7f5-4854-9df8-ba3619420477)

 3. Try to find a terminal for a specific module in `O(n)` time (terminals may appear out-of-order in this list):
    ![image](https://github.com/user-attachments/assets/351c05e9-5403-46f7-819d-a8d1f9e9b850)

### Solution

#### Abstract

Instead of giving a terminal the name of the project, give it the name of the module for which it was opened. (I realize this can also be done manually after a terminal is created, but that's a hassle with this many terminals.)

#### Concrete

This PR adds a setting to configure how Rascal terminal names should be formatted:

![image](https://github.com/user-attachments/assets/d7f1a548-a253-45ef-9be1-aa5995826b57)

The default, `Project root`, gives the same behavior as before this PR. So, by default, nothing changes for users. Only when a user explicitly configures it to be `Module (qualified)` or `Module (unqualified)`, the name of the module for which a terminal was opened is inserted.

With `Module (qualified)`:

![image](https://github.com/user-attachments/assets/85262850-7bb9-47bf-907f-7d106ba45b77)

With `Module (unqualified)`:

![image](https://github.com/user-attachments/assets/4bb73dc2-178b-4364-92dc-39315a23784b)
