### PR TITLE
Fixed incorrect type for the code lenses in LanguageService

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -50,7 +50,7 @@ public interface ILanguageContributions {
     public InterruptibleFuture<IList> outline(ITree input);
     public InterruptibleFuture<IConstructor> analyze(ISourceLocation loc, ITree input);
     public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<ISet> lenses(ITree input);
+    public InterruptibleFuture<IList> lenses(ITree input);
     public InterruptibleFuture<@Nullable IValue> executeCommand(String command);
     public CompletableFuture<IList> parseCodeActions(String command);
     public InterruptibleFuture<IList> inlayHint(@Nullable ITree input);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -281,9 +281,9 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<ISet> lenses(ITree input) {
+    public InterruptibleFuture<IList> lenses(ITree input) {
         debug(LanguageContributions.LENS_DETECTOR, TreeAdapter.getLocation(input));
-        return execFunction(LanguageContributions.LENS_DETECTOR, lenses, VF.set(), input);
+        return execFunction(LanguageContributions.LENS_DETECTOR, lenses, VF.list(), input);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -247,7 +247,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<ISet> lenses(ITree input) {
+    public InterruptibleFuture<IList> lenses(ITree input) {
         return flatten(lensDetector, c -> c.lenses(input));
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -129,8 +129,8 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public InterruptibleFuture<ISet> lenses(ITree input) {
-        return InterruptibleFuture.completedFuture(VF.set());
+    public InterruptibleFuture<IList> lenses(ITree input) {
+        return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -26,6 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 @contributor{Jurgen J. Vinju - Jurgen.Vinju@cwi.nl - CWI}
 @contributor{Davy Landman - davy.landman@swat.engineering - Swat.engineering BV}
+@contributor{Sung-Shik Jongmans - sung-shik.jongmans@swat.engineering - Swat.engineering BV}
 @synopsis{Bridges {DSL,PL,Modeling} language features to the language server protocol.}
 @description{
 Using the ((registerLanguage)) function you can connect any parsers, checkers,
@@ -127,7 +128,11 @@ alias Focus = list[Tree];
 alias Outliner         = list[DocumentSymbol] (Tree _input);
 
 @synopsis{Function profile for lenses contributions to a language server}
+@deprecated{The ((OrderedLensDetector)) has replaced this type}
 alias LensDetector     = rel[loc src, Command lens] (Tree _input);
+
+@synopsis{Function profile for lenses contributions to a language server}
+alias OrderedLensDetector     = lrel[loc src, Command lens] (Tree _input);
 
 @synopsis{Function profile for executor contributions to a language server}
 alias CommandExecutor  = value (Command _command);
@@ -298,7 +303,7 @@ data LanguageService
         , bool providesReferences = true
         , bool providesImplementations = true)
     | outliner(Outliner outliner)
-    | lenses(LensDetector detector)
+    | lenses(OrderedLensDetector detector)
     | inlayHinter(InlayHinter hinter)
     | executor(CommandExecutor executor)
     | documenter(FocusDocumenter documenter)
@@ -307,6 +312,17 @@ data LanguageService
     | implementer(FocusImplementer implementer)
     | actions(CodeActionContributor actions)
     ;
+
+
+@deprecated{
+This is a backward compatibility layer for the pre-existing ((LensDetector)) alias.
+
+The primary change is that lenses are now ordered, such that you have control over in which order they appear in the client.
+
+To adapt to the new one, use a function that generates a `lrel` instead of a `rel`.
+}
+LanguageService lenses(LensDetector oldDetector)
+    = lenses(lrel[loc src, Command lens] (Tree input) { return [*oldDetector(input)]; });
 
 @deprecated{
 This is a backward compatibility layer for the pre-existing ((Documenter)) alias.


### PR DESCRIPTION
The set would make 2 code lenses on the same line flip around arbitrarly (or at least, between runs of the lsp server). And the user has no control on the order.

Thanks @tvdstorm for pointing this out.