### PR TITLE
Debounce the parser

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -200,7 +200,7 @@ class Debouncer<T> {
     // A debouncer is implemented using a *delayed executor* as `scheduler`. The
     // idea is to *periodically* check the state of the underlying resource
     // provider. More precisely, each time when the resource is requested,
-    // immediately check if case 1 or case 3 (above) are applicable. If so,
+    // immediately check if case 2 or case 3 (above) are applicable. If so,
     // return. If not, schedule a *delayed future* to retry the request, to be
     // completed after a small `period` (e.g., 50 milliseconds).
     //
@@ -222,7 +222,7 @@ class Debouncer<T> {
     // The underlying resource provider is represented abstractly in terms of
     // two suppliers, each of which corresponds with a state of the underlying
     // resource provider. `getIfInitialized` should return `null` iff the
-    // underlying resource provided is not-initialized.
+    // underlying resource provider is not-initialized.
 
     private final Supplier<@Nullable CompletableFuture<T>> getIfInitialized;
     private final Supplier<CompletableFuture<T>> initializeAndGet;
@@ -260,7 +260,7 @@ class Debouncer<T> {
         var oldStamp = scheduled.getStamp();
         while (!scheduled.compareAndSet(oldRef, oldRef, oldStamp, oldStamp));
 
-        // Compute a new reference (delayed future to retry this method)
+        // Compute a new reference (= delayed future to retry this method)
         var delayArg = new CompletableFuture<Integer>();
         var newRef = delayArg
             .thenApplyAsync(this::reschedule, scheduler)
@@ -294,7 +294,7 @@ class Debouncer<T> {
 
         // Otherwise (i.e, the delay is not yet over, but a delayed future has
         // been scheduled already), then update the remaining delay; it will be
-        // used to complete the already-scheduled delayed future.
+        // used by the already-scheduled delayed future.
         if (scheduled.attemptStamp(oldRef, newStamp)) {
             return oldRef;
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -26,17 +26,27 @@
  */
 package org.rascalmpl.vscode.lsp;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicStampedReference;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.Diagnostic;
 import org.rascalmpl.library.util.ErrorRecovery;
 import org.rascalmpl.values.RascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 
-import io.usethesource.vallang.IList;
 import io.usethesource.vallang.ISourceLocation;
 
 /**
@@ -49,75 +59,253 @@ import io.usethesource.vallang.ISourceLocation;
  * and ParametricTextDocumentService.
  */
 public class TextDocumentState {
+
+    private static final ErrorRecovery RECOVERY =
+        new ErrorRecovery((RascalValueFactory) ValueFactoryFactory.getValueFactory());
+
     private final BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser;
+    private final ISourceLocation location;
 
-    private final ISourceLocation file;
-    @SuppressWarnings("java:S3077") // we are use volatile correctly
-    private volatile Versioned<String> currentContent;
-    @SuppressWarnings("java:S3077") // we are use volatile correctly
-    private volatile @MonotonicNonNull Versioned<ITree> lastTree;
-    @SuppressWarnings("java:S3077") // we are use volatile correctly
-    private volatile @MonotonicNonNull Versioned<ITree> lastTreeWithoutErrors;
-    @SuppressWarnings("java:S3077") // we are use volatile correctly
-    private volatile CompletableFuture<Versioned<ITree>> currentTree;
+    @SuppressWarnings("java:S3077") // Visibility of writes is enough
+    private volatile Update current;
+    private final Debouncer<Versioned<ITree>> currentTreeAsyncDebouncer;
 
-    public TextDocumentState(BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser, ISourceLocation file, int initialVersion, String initialContent) {
+    private final AtomicReference<@MonotonicNonNull Versioned<ITree>> lastWithoutErrors;
+    private final AtomicReference<@MonotonicNonNull Versioned<ITree>> last;
+
+    public TextDocumentState(
+            BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser,
+            ISourceLocation location, int initialVersion, String initialContent) {
+
         this.parser = parser;
-        this.file = file;
-        this.currentContent = new Versioned<>(initialVersion, initialContent);
-        this.currentTree = newTreeAsync(initialVersion, initialContent);
-    }
+        this.location = location;
 
-    /**
-     * The current call of this method guarantees that, until the next call,
-     * each intermediate call of `getCurrentTreeAsync` returns (a future for) a
-     * *correct* versioned tree. This means that:
-     *   - the version of the tree is parameter `version`;
-     *   - the tree is produced by parsing parameter `content`.
-     *
-     * Thus, callers of `getCurrentTreeAsync` are guaranteed to obtain a
-     * consistent <version, tree> pair.
-     */
-    public CompletableFuture<Versioned<ITree>> update(int version, String content) {
-        currentContent = new Versioned<>(version, content);
-        var newTree = newTreeAsync(version, content);
-        currentTree = newTree;
-        return newTree;
-    }
+        this.current = new Update(initialVersion, initialContent);
+        this.currentTreeAsyncDebouncer = new Debouncer<>(50,
+            this::getCurrentTreeAsyncIfParsing, this::getCurrentTreeAsync);
 
-    @SuppressWarnings("java:S1181") // we want to catch all Java exceptions from the parser
-    private CompletableFuture<Versioned<ITree>> newTreeAsync(int version, String content) {
-        return parser.apply(file, content)
-            .thenApply(t -> new Versioned<ITree>(version, t))
-            .whenComplete((t, error) -> {
-                if (t != null) {
-                    RascalValueFactory valueFactory = (RascalValueFactory) ValueFactoryFactory.getValueFactory();
-                    IList errors = new ErrorRecovery(valueFactory).findAllErrors(t.get());
-                    if (errors.isEmpty()) {
-                        lastTreeWithoutErrors = t;
-                    }
-                    lastTree = t;
-                }
-            });
-    }
-
-    public CompletableFuture<Versioned<ITree>> getCurrentTreeAsync() {
-        return currentTree;
-    }
-
-    public @MonotonicNonNull Versioned<ITree> getLastTree() {
-        return lastTree;
-    }
-
-    public @MonotonicNonNull Versioned<ITree> getLastTreeWithoutErrors() {
-        return lastTreeWithoutErrors;
+        this.lastWithoutErrors = new AtomicReference<>();
+        this.last = new AtomicReference<>();
     }
 
     public ISourceLocation getLocation() {
-        return file;
+        return location;
+    }
+
+    public void update(int version, String content) {
+        current = new Update(version, content);
+        // The creation of the `Update` object doesn't trigger the parser yet.
+        // This happens only when the tree is requested.
     }
 
     public Versioned<String> getCurrentContent() {
-        return currentContent;
+        return current.getContent();
+    }
+
+    public CompletableFuture<Versioned<ITree>> getCurrentTreeAsync() {
+        return current.getTreeAsync(); // Triggers the parser
+    }
+
+    public CompletableFuture<Versioned<ITree>> getCurrentTreeAsync(Duration delay) {
+        return currentTreeAsyncDebouncer.get(delay);
+    }
+
+    public @Nullable CompletableFuture<Versioned<ITree>> getCurrentTreeAsyncIfParsing() {
+        var update = current;
+        return update.isParsing() ? update.getTreeAsync() : null;
+    }
+
+    public CompletableFuture<Versioned<List<Diagnostic>>> getCurrentDiagnostics() {
+        throw new UnsupportedOperationException();
+        // TODO: In a separate PR
+    }
+
+    public @MonotonicNonNull Versioned<ITree> getLastTree() {
+        return last.get();
+    }
+
+    public @MonotonicNonNull Versioned<ITree> getLastTreeWithoutErrors() {
+        return lastWithoutErrors.get();
+    }
+
+    private class Update {
+        private final int version;
+        private final String content;
+        private final CompletableFuture<Versioned<ITree>> treeAsync;
+        private final AtomicBoolean parsing;
+
+        public Update(int version, String content) {
+            this.version = version;
+            this.content = content;
+            this.treeAsync = new CompletableFuture<>();
+            this.parsing = new AtomicBoolean(false);
+        }
+
+        public Versioned<String> getContent() {
+            return new Versioned<>(version, content);
+        }
+
+        public CompletableFuture<Versioned<ITree>> getTreeAsync() {
+            parseIfNotParsing();
+            return treeAsync;
+        }
+
+        public boolean isParsing() {
+            return parsing.get();
+        }
+
+        private void parseIfNotParsing() {
+            if (parsing.compareAndSet(false, true)) {
+                parser
+                    .apply(location, content)
+                    .thenApply(t -> new Versioned<>(version, t))
+                    .whenComplete((t, error) -> {
+                        if (t != null) {
+                            var errors = RECOVERY.findAllErrors(t.get());
+                            if (errors.isEmpty()) {
+                                Versioned.replaceIfNewer(lastWithoutErrors, t);
+                            }
+                            Versioned.replaceIfNewer(last, t);
+                            treeAsync.complete(t);
+                        }
+                        if (error != null) {
+                            treeAsync.completeExceptionally(error);
+                        }
+                    });
+            }
+        }
+    }
+}
+
+/**
+ * A *debouncer* is an object to get a *resource* from an *underlying resource
+ * provider* with a certain delay. From the perspective of the debouncer, the
+ * underlying resource provider has two states: initialized and not-initialized.
+ *
+ *  1. While the underlying resource provider is not-initialized (e.g., the
+ *     computation of a parse tree has not yet started), the debouncer waits
+ *     until the delay is over.
+ *
+ *  2. When the underlying resource provider becomes initialized (e.g., the
+ *     computation of a parse tree has started, but possibly not yet finished),
+ *     the debouncer returns a future for the resource.
+ *
+ *  3. When the underlying resource provider is not-initialized, but the delay
+ *     is over, the debouncer forcibly initializes the resource (e.g., it starts
+ *     the asynchronous computation of a parse tree) and returns a future for
+ *     the resource.
+ */
+class Debouncer<T> {
+
+    // A debouncer is implemented using a *delayed executor* as `scheduler`. The
+    // idea is to *periodically* check the state of the underlying resource
+    // provider. More precisely, each time when the resource is requested,
+    // immediately check if case 1 or case 3 (above) are applicable. If so,
+    // return. If not, schedule a *delayed future* to retry the request, to be
+    // completed after a small `period` (e.g., 50 milliseconds).
+    //
+    // The reason why multiple futures are scheduled in small periods, instead
+    // of a single future for the entire large delay, is that futures (of type
+    // `CompletableFuture`) cannot be interrupted.
+
+    private final int period; // Milliseconds
+    private final Executor scheduler;
+
+    // At any point in time, only one delayed future to retry the request for
+    // the resource should be `scheduled`, tied with the total remaining delay.
+    // For bookkeeping, a *stamped reference* is used. The reference is the
+    // delayed future, while the stamp is the remaining delay *upon completion
+    // of the delayed future*.
+
+    private final AtomicStampedReference<@Nullable CompletableFuture<T>> scheduled;
+
+    // The underlying resource provider is represented abstractly in terms of
+    // two suppliers, each of which corresponds with a state of the underlying
+    // resource provider. `getIfInitialized` should return `null` iff the
+    // underlying resource provided is not-initialized.
+
+    private final Supplier<@Nullable CompletableFuture<T>> getIfInitialized;
+    private final Supplier<CompletableFuture<T>> initializeAndGet;
+
+    public Debouncer(Duration period,
+            Supplier<@Nullable CompletableFuture<T>> getIfInitialized,
+            Supplier<CompletableFuture<T>> initializeAndGet) {
+
+        this(Math.toIntExact(period.toMillis()), getIfInitialized, initializeAndGet);
+    }
+
+    public Debouncer(int period,
+            Supplier<@Nullable CompletableFuture<T>> getIfInitialized,
+            Supplier<CompletableFuture<T>> initializeAndGet) {
+
+        this.period = period;
+        this.scheduler = CompletableFuture.delayedExecutor(period, TimeUnit.MILLISECONDS);
+        this.scheduled = new AtomicStampedReference<>(null, 0);
+        this.getIfInitialized = getIfInitialized;
+        this.initializeAndGet = initializeAndGet;
+    }
+
+    public CompletableFuture<T> get(Duration delay) {
+        return get(Math.toIntExact(delay.toMillis()));
+    }
+
+    public CompletableFuture<T> get(int delay) {
+        return schedule(delay, false);
+    }
+
+    private CompletableFuture<T> schedule(int delay, boolean reschedule) {
+
+        // Get a consistent old stamp and old reference
+        var oldRef = scheduled.getReference();
+        var oldStamp = scheduled.getStamp();
+        while (!scheduled.weakCompareAndSet(oldRef, oldRef, oldStamp, oldStamp));
+
+        // Compute a new reference (delayed future to retry this method)
+        var delayArg = new CompletableFuture<Integer>();
+        var newRef = delayArg
+            .thenApplyAsync(this::reschedule, scheduler)
+            .thenCompose(Function.identity());
+
+        // Compute a new stamp
+        var delayRemaining = Math.max(oldStamp, delay);
+        var newStamp = delayRemaining - period;
+
+        // If the underlying resource provider is initialized, then return the
+        // future to get the resource
+        var future = getIfInitialized.get();
+        if (future != null && scheduled.weakCompareAndSet(oldRef, null, oldStamp, 0)) {
+            return future;
+        }
+
+        // Otherwise, if the delay is over already, then initialize the
+        // underlying resource provider and return the future to get the
+        // resource
+        if (delayRemaining <= 0 && scheduled.weakCompareAndSet(oldRef, null, oldStamp, 0)) {
+            return initializeAndGet.get();
+        }
+
+        // Otherwise (i.e., the delay isn't over yet), if a delayed future to
+        // retry this method hasn't been scheduled yet, or if it must be
+        // rescheduled regardless, then schedule it
+        if ((oldRef == null || reschedule) && scheduled.weakCompareAndSet(oldRef, newRef, oldStamp, newStamp)) {
+            delayArg.complete(newStamp);
+            return newRef;
+        }
+
+        // Otherwise (i.e, the delay is not yet over, but a delayed future has
+        // been scheduled already), then update the remaining delay; it will be
+        // used to complete the already-scheduled delayed future.
+        if (scheduled.attemptStamp(oldRef, newStamp)) {
+            return oldRef;
+        }
+
+        // When this point is reached, concurrent modifications to the stamp or
+        // the reference in `scheduled` have happened. In that case, retry
+        // immediately.
+        return schedule(delay, reschedule);
+    }
+
+    private CompletableFuture<T> reschedule(int delay) {
+        return schedule(delay, true);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -258,7 +258,7 @@ class Debouncer<T> {
         // Get a consistent old stamp and old reference
         var oldRef = scheduled.getReference();
         var oldStamp = scheduled.getStamp();
-        while (!scheduled.weakCompareAndSet(oldRef, oldRef, oldStamp, oldStamp));
+        while (!scheduled.compareAndSet(oldRef, oldRef, oldStamp, oldStamp));
 
         // Compute a new reference (delayed future to retry this method)
         var delayArg = new CompletableFuture<Integer>();
@@ -273,21 +273,21 @@ class Debouncer<T> {
         // If the underlying resource provider is initialized, then return the
         // future to get the resource
         var future = getIfInitialized.get();
-        if (future != null && scheduled.weakCompareAndSet(oldRef, null, oldStamp, 0)) {
+        if (future != null && scheduled.compareAndSet(oldRef, null, oldStamp, 0)) {
             return future;
         }
 
         // Otherwise, if the delay is over already, then initialize the
         // underlying resource provider and return the future to get the
         // resource
-        if (delayRemaining <= 0 && scheduled.weakCompareAndSet(oldRef, null, oldStamp, 0)) {
+        if (delayRemaining <= 0 && scheduled.compareAndSet(oldRef, null, oldStamp, 0)) {
             return initializeAndGet.get();
         }
 
         // Otherwise (i.e., the delay isn't over yet), if a delayed future to
         // retry this method hasn't been scheduled yet, or if it must be
         // rescheduled regardless, then schedule it
-        if ((oldRef == null || reschedule) && scheduled.weakCompareAndSet(oldRef, newRef, oldStamp, newStamp)) {
+        if ((oldRef == null || reschedule) && scheduled.compareAndSet(oldRef, newRef, oldStamp, newStamp)) {
             delayArg.complete(newStamp);
             return newRef;
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -285,7 +285,8 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     private TextDocumentState updateContents(VersionedTextDocumentIdentifier doc, String newContents) {
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents));
+        file.update(doc.getVersion(), newContents);
+        handleParsingErrors(file, file.getCurrentTreeAsync()); // Warning: Might be a later version (when a concurrent update happened)
         return file;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -28,6 +28,7 @@ package org.rascalmpl.vscode.lsp.rascal;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -213,7 +214,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     private TextDocumentState updateContents(VersionedTextDocumentIdentifier doc, String newContents) {
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents));
+        file.update(doc.getVersion(), newContents);
+        handleParsingErrors(file, file.getCurrentTreeAsync(Duration.ofMillis(800)));
         return file;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Versioned.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Versioned.java
@@ -57,7 +57,7 @@ public class Versioned<T> {
     public static <T> boolean replaceIfNewer(AtomicReference<Versioned<T>> current, Versioned<T> maybeNewer) {
         while (true) {
             var old = current.get();
-            if (old.version() < maybeNewer.version()) {
+            if (old == null || old.version() < maybeNewer.version()) {
                 if (current.compareAndSet(old, maybeNewer)) {
                     return true;
                 }


### PR DESCRIPTION
This PR adds optional debouncing to calls to get the parse tree from a `TextDocumentState`. Specifically, there are now two functions to get a parse tree:

  - `getTreeAsync()` returns a future for the parse tree of the current version of the document (current == the moment `getTreeAsync` is called), and the parser is immediately started. This is the existing behavior (i.e., the API is backward-compatible).
  - `getTreeAsync(delay)` returns a future for the parse tree of the current version of the document *or a future version*, but the parser is started only after a delay. Upon completion, the future provides the parse tree of the version of the document that was current when the parser was started.

The documentation in class `TextDocumentState` provides further details.

This PR also fixes #358.