### PR TITLE
Show skipped part and use error tree for outlining

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -280,7 +280,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         TextDocumentState file = getFile(params.getTextDocument());
         return file.getCurrentTreeAsync()
             .thenApply(Versioned::get)
-            .handle((t, r) -> (t == null ? (file.getLastTreeWithoutErrors().get()) : t))
+            .handle((t, r) -> (t == null ? (file.getLastTree().get()) : t))
             .thenCompose(tr -> rascalServices.getOutline(tr).get())
             .thenApply(c -> Outline.buildOutline(c, columns.get(file.getLocation())))
             ;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -77,7 +77,9 @@ public class Diagnostics {
     }
 
     public static Diagnostic translateErrorRecoveryDiagnostic(ITree errorTree, ColumnMaps cm) {
-        return new Diagnostic(toRange(errorTree, cm), "Parse error", DiagnosticSeverity.Error, "parser");
+        IList args = TreeAdapter.getArgs(errorTree);
+        ITree skipped = (ITree) args.get(args.size()-1);
+        return new Diagnostic(toRange(skipped, cm), "Parse error", DiagnosticSeverity.Error, "parser");
     }
 
     public static Diagnostic translateRascalParseError(IValue e, ColumnMaps cm) {


### PR DESCRIPTION
Instead of highlighting the complete error tree, only the skipped part is now highlighted.
Also, the outliner now uses the error tree when it is available.