### PR TITLE
Rename Java identifiers to be consistent with LSP

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -46,49 +46,50 @@ import io.usethesource.vallang.type.TypeStore;
 public interface ILanguageContributions {
     public String getName();
 
-    public CompletableFuture<ITree> parseSourceFile(ISourceLocation loc, String input);
-    public InterruptibleFuture<IList> outline(ITree input);
-    public InterruptibleFuture<IConstructor> analyze(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<IList> lenses(ITree input);
-    public InterruptibleFuture<@Nullable IValue> executeCommand(String command);
-    public CompletableFuture<IList> parseCodeActions(String command);
-    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input);
-    public InterruptibleFuture<ISet> documentation(IList focus);
-    public InterruptibleFuture<ISet> definitions(IList focus);
-    public InterruptibleFuture<ISet> references(IList focus);
-    public InterruptibleFuture<ISet> implementations(IList focus);
-    public InterruptibleFuture<IList> codeActions(IList focus);
+    public CompletableFuture<ITree>              runParsingService(ISourceLocation loc, String input);
+    public InterruptibleFuture<IConstructor>     runAnalysisService(ISourceLocation loc, ITree input);
+    public InterruptibleFuture<IConstructor>     runBuildService(ISourceLocation loc, ITree input);
+    public InterruptibleFuture<IList>            runDocumentSymbolService(ITree input);
+    public InterruptibleFuture<IList>            runCodeLensService(ITree input);
+    public InterruptibleFuture<IList>            runInlayHintService(@Nullable ITree input);
+    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command);
+    public InterruptibleFuture<ISet>             runHoverService(IList focus);
+    public InterruptibleFuture<ISet>             runDefinitionService(IList focus);
+    public InterruptibleFuture<ISet>             runReferencesService(IList focus);
+    public InterruptibleFuture<ISet>             runImplementationService(IList focus);
+    public InterruptibleFuture<IList>            runCodeActionService(IList focus);
 
-    public CompletableFuture<Boolean> hasAnalyzer();
-    public CompletableFuture<Boolean> hasBuilder();
-    public CompletableFuture<Boolean> hasOutliner();
-    public CompletableFuture<Boolean> hasLensDetector();
-    public CompletableFuture<Boolean> hasInlayHinter();
-    public CompletableFuture<Boolean> hasCommandExecutor();
-    public CompletableFuture<Boolean> hasDocumenter();
-    public CompletableFuture<Boolean> hasDefiner();
-    public CompletableFuture<Boolean> hasReferrer();
-    public CompletableFuture<Boolean> hasImplementer();
-    public CompletableFuture<Boolean> hasCodeActionsContributor();
+    public CompletableFuture<IList> parseCodeActions(String command);
+
+    public CompletableFuture<Boolean> hasAnalysisService();
+    public CompletableFuture<Boolean> hasBuildService();
+    public CompletableFuture<Boolean> hasDocumentSymbolService();
+    public CompletableFuture<Boolean> hasCodeLensDetector();
+    public CompletableFuture<Boolean> hasInlayHintService();
+    public CompletableFuture<Boolean> hasExecutionService();
+    public CompletableFuture<Boolean> hasHoverService();
+    public CompletableFuture<Boolean> hasDefinitionService();
+    public CompletableFuture<Boolean> hasReferencesService();
+    public CompletableFuture<Boolean> hasImplementationService();
+    public CompletableFuture<Boolean> hasCodeActionService();
 
     public CompletableFuture<SummaryConfig> getAnalyzerSummaryConfig();
     public CompletableFuture<SummaryConfig> getBuilderSummaryConfig();
     public CompletableFuture<SummaryConfig> getOndemandSummaryConfig();
 
     public static class SummaryConfig {
-        public final boolean providesDocumentation;
+        public final boolean providesHovers;
         public final boolean providesDefinitions;
         public final boolean providesReferences;
         public final boolean providesImplementations;
 
         public SummaryConfig(
-                boolean providesDocumentation,
+                boolean providesHovers,
                 boolean providesDefinitions,
                 boolean providesReferences,
                 boolean providesImplementations) {
 
-            this.providesDocumentation = providesDocumentation;
+            this.providesHovers = providesHovers;
             this.providesDefinitions = providesDefinitions;
             this.providesReferences = providesReferences;
             this.providesImplementations = providesImplementations;
@@ -98,13 +99,12 @@ public interface ILanguageContributions {
 
         public static SummaryConfig or(SummaryConfig a, SummaryConfig b) {
             return new SummaryConfig(
-                a.providesDocumentation || b.providesDocumentation,
+                a.providesHovers || b.providesHovers,
                 a.providesDefinitions || b.providesDefinitions,
                 a.providesReferences || b.providesReferences,
                 a.providesImplementations || b.providesImplementations);
         }
     }
-
 
     @FunctionalInterface // Type alias to conveniently pass methods `analyze`and `build` as parameters
     public static interface ScheduledCalculator extends BiFunction<ISourceLocation, ITree, InterruptibleFuture<IConstructor>> {}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -46,18 +46,18 @@ import io.usethesource.vallang.type.TypeStore;
 public interface ILanguageContributions {
     public String getName();
 
-    public CompletableFuture<ITree>              parsing(ISourceLocation loc, String input);
-    public InterruptibleFuture<IConstructor>     analysis(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<IConstructor>     build(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<IList>            documentSymbol(ITree input);
-    public InterruptibleFuture<IList>            codeLens(ITree input);
-    public InterruptibleFuture<IList>            inlayHint(@Nullable ITree input);
+    public CompletableFuture<ITree> parsing(ISourceLocation loc, String input);
+    public InterruptibleFuture<IConstructor> analysis(ISourceLocation loc, ITree input);
+    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input);
+    public InterruptibleFuture<IList> documentSymbol(ITree input);
+    public InterruptibleFuture<IList> codeLens(ITree input);
+    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input);
     public InterruptibleFuture<@Nullable IValue> execution(String command);
-    public InterruptibleFuture<ISet>             hover(IList focus);
-    public InterruptibleFuture<ISet>             definition(IList focus);
-    public InterruptibleFuture<ISet>             references(IList focus);
-    public InterruptibleFuture<ISet>             implementation(IList focus);
-    public InterruptibleFuture<IList>            codeAction(IList focus);
+    public InterruptibleFuture<ISet> hover(IList focus);
+    public InterruptibleFuture<ISet> definition(IList focus);
+    public InterruptibleFuture<ISet> references(IList focus);
+    public InterruptibleFuture<ISet> implementation(IList focus);
+    public InterruptibleFuture<IList> codeAction(IList focus);
 
     public CompletableFuture<IList> parseCodeActions(String command);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -64,7 +64,7 @@ public interface ILanguageContributions {
     public CompletableFuture<Boolean> hasAnalysisService();
     public CompletableFuture<Boolean> hasBuildService();
     public CompletableFuture<Boolean> hasDocumentSymbolService();
-    public CompletableFuture<Boolean> hasCodeLensDetector();
+    public CompletableFuture<Boolean> hasCodeLensService();
     public CompletableFuture<Boolean> hasInlayHintService();
     public CompletableFuture<Boolean> hasExecutionService();
     public CompletableFuture<Boolean> hasHoverService();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -46,32 +46,32 @@ import io.usethesource.vallang.type.TypeStore;
 public interface ILanguageContributions {
     public String getName();
 
-    public CompletableFuture<ITree>              runParsingService(ISourceLocation loc, String input);
-    public InterruptibleFuture<IConstructor>     runAnalysisService(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<IConstructor>     runBuildService(ISourceLocation loc, ITree input);
-    public InterruptibleFuture<IList>            runDocumentSymbolService(ITree input);
-    public InterruptibleFuture<IList>            runCodeLensService(ITree input);
-    public InterruptibleFuture<IList>            runInlayHintService(@Nullable ITree input);
-    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command);
-    public InterruptibleFuture<ISet>             runHoverService(IList focus);
-    public InterruptibleFuture<ISet>             runDefinitionService(IList focus);
-    public InterruptibleFuture<ISet>             runReferencesService(IList focus);
-    public InterruptibleFuture<ISet>             runImplementationService(IList focus);
-    public InterruptibleFuture<IList>            runCodeActionService(IList focus);
+    public CompletableFuture<ITree>              parsing(ISourceLocation loc, String input);
+    public InterruptibleFuture<IConstructor>     analysis(ISourceLocation loc, ITree input);
+    public InterruptibleFuture<IConstructor>     build(ISourceLocation loc, ITree input);
+    public InterruptibleFuture<IList>            documentSymbol(ITree input);
+    public InterruptibleFuture<IList>            codeLens(ITree input);
+    public InterruptibleFuture<IList>            inlayHint(@Nullable ITree input);
+    public InterruptibleFuture<@Nullable IValue> execution(String command);
+    public InterruptibleFuture<ISet>             hover(IList focus);
+    public InterruptibleFuture<ISet>             definition(IList focus);
+    public InterruptibleFuture<ISet>             references(IList focus);
+    public InterruptibleFuture<ISet>             implementation(IList focus);
+    public InterruptibleFuture<IList>            codeAction(IList focus);
 
     public CompletableFuture<IList> parseCodeActions(String command);
 
-    public CompletableFuture<Boolean> hasAnalysisService();
-    public CompletableFuture<Boolean> hasBuildService();
-    public CompletableFuture<Boolean> hasDocumentSymbolService();
-    public CompletableFuture<Boolean> hasCodeLensService();
-    public CompletableFuture<Boolean> hasInlayHintService();
-    public CompletableFuture<Boolean> hasExecutionService();
-    public CompletableFuture<Boolean> hasHoverService();
-    public CompletableFuture<Boolean> hasDefinitionService();
-    public CompletableFuture<Boolean> hasReferencesService();
-    public CompletableFuture<Boolean> hasImplementationService();
-    public CompletableFuture<Boolean> hasCodeActionService();
+    public CompletableFuture<Boolean> hasAnalysis();
+    public CompletableFuture<Boolean> hasBuild();
+    public CompletableFuture<Boolean> hasDocumentSymbol();
+    public CompletableFuture<Boolean> hasCodeLens();
+    public CompletableFuture<Boolean> hasInlayHint();
+    public CompletableFuture<Boolean> hasExecution();
+    public CompletableFuture<Boolean> hasHover();
+    public CompletableFuture<Boolean> hasDefinition();
+    public CompletableFuture<Boolean> hasReferences();
+    public CompletableFuture<Boolean> hasImplementation();
+    public CompletableFuture<Boolean> hasCodeAction();
 
     public CompletableFuture<SummaryConfig> getAnalyzerSummaryConfig();
     public CompletableFuture<SummaryConfig> getBuilderSummaryConfig();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -125,34 +125,34 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
 
             this.store = eval.thenApply(e -> ((ModuleEnvironment)e.getModule(mainModule)).getStore());
 
-            this.parsing        = getFunctionFor(contributions, LanguageContributions.PARSING);
-            this.analysis       = getFunctionFor(contributions, LanguageContributions.ANALYSIS);
-            this.build          = getFunctionFor(contributions, LanguageContributions.BUILD);
+            this.parsing = getFunctionFor(contributions, LanguageContributions.PARSING);
+            this.analysis = getFunctionFor(contributions, LanguageContributions.ANALYSIS);
+            this.build = getFunctionFor(contributions, LanguageContributions.BUILD);
             this.documentSymbol = getFunctionFor(contributions, LanguageContributions.DOCUMENT_SYMBOL);
-            this.codeLens       = getFunctionFor(contributions, LanguageContributions.CODE_LENS);
-            this.inlayHint      = getFunctionFor(contributions, LanguageContributions.INLAY_HINT);
-            this.execution      = getFunctionFor(contributions, LanguageContributions.EXECUTION);
-            this.hover          = getFunctionFor(contributions, LanguageContributions.HOVER);
-            this.definition     = getFunctionFor(contributions, LanguageContributions.DEFINITION);
-            this.references     = getFunctionFor(contributions, LanguageContributions.REFERENCES);
+            this.codeLens = getFunctionFor(contributions, LanguageContributions.CODE_LENS);
+            this.inlayHint = getFunctionFor(contributions, LanguageContributions.INLAY_HINT);
+            this.execution = getFunctionFor(contributions, LanguageContributions.EXECUTION);
+            this.hover = getFunctionFor(contributions, LanguageContributions.HOVER);
+            this.definition = getFunctionFor(contributions, LanguageContributions.DEFINITION);
+            this.references = getFunctionFor(contributions, LanguageContributions.REFERENCES);
             this.implementation = getFunctionFor(contributions, LanguageContributions.IMPLEMENTATION);
-            this.codeAction     = getFunctionFor(contributions, LanguageContributions.CODE_ACTION);
+            this.codeAction = getFunctionFor(contributions, LanguageContributions.CODE_ACTION);
 
             // assign boolean properties once instead of wasting futures all the time
-            this.hasAnalysis       = nonNull(this.analysis);
-            this.hasBuild          = nonNull(this.build);
+            this.hasAnalysis = nonNull(this.analysis);
+            this.hasBuild = nonNull(this.build);
             this.hasDocumentSymbol = nonNull(this.documentSymbol);
-            this.hasCodeLens       = nonNull(this.codeLens);
-            this.hasInlayHint      = nonNull(this.inlayHint);
-            this.hasExecution      = nonNull(this.execution);
-            this.hasHover          = nonNull(this.hover);
-            this.hasDefinition     = nonNull(this.definition);
-            this.hasReferences     = nonNull(this.references);
+            this.hasCodeLens = nonNull(this.codeLens);
+            this.hasInlayHint = nonNull(this.inlayHint);
+            this.hasExecution = nonNull(this.execution);
+            this.hasHover = nonNull(this.hover);
+            this.hasDefinition = nonNull(this.definition);
+            this.hasReferences = nonNull(this.references);
             this.hasImplementation = nonNull(this.implementation);
-            this.hasCodeAction     = nonNull(this.codeAction);
+            this.hasCodeAction = nonNull(this.codeAction);
 
             this.analyzerSummaryConfig = scheduledSummaryConfig(contributions, LanguageContributions.ANALYSIS);
-            this.builderSummaryConfig  = scheduledSummaryConfig(contributions, LanguageContributions.BUILD);
+            this.builderSummaryConfig = scheduledSummaryConfig(contributions, LanguageContributions.BUILD);
             this.ondemandSummaryConfig = ondemandSummaryConfig(contributions);
 
         } catch (IOException e1) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -75,30 +75,30 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private final CompletableFuture<Evaluator> eval;
     private final CompletableFuture<TypeStore> store;
 
-    private final CompletableFuture<IFunction> parsingService;
-    private final CompletableFuture<@Nullable IFunction> analysisService;
-    private final CompletableFuture<@Nullable IFunction> buildService;
-    private final CompletableFuture<@Nullable IFunction> documentSymbolService;
-    private final CompletableFuture<@Nullable IFunction> codeLensService;
-    private final CompletableFuture<@Nullable IFunction> inlayHintService;
-    private final CompletableFuture<@Nullable IFunction> executionService;
-    private final CompletableFuture<@Nullable IFunction> hoverService;
-    private final CompletableFuture<@Nullable IFunction> definitionService;
-    private final CompletableFuture<@Nullable IFunction> referencesService;
-    private final CompletableFuture<@Nullable IFunction> implementationService;
-    private final CompletableFuture<@Nullable IFunction> codeActionService;
+    private final CompletableFuture<IFunction> parsing;
+    private final CompletableFuture<@Nullable IFunction> analysis;
+    private final CompletableFuture<@Nullable IFunction> build;
+    private final CompletableFuture<@Nullable IFunction> documentSymbol;
+    private final CompletableFuture<@Nullable IFunction> codeLens;
+    private final CompletableFuture<@Nullable IFunction> inlayHint;
+    private final CompletableFuture<@Nullable IFunction> execution;
+    private final CompletableFuture<@Nullable IFunction> hover;
+    private final CompletableFuture<@Nullable IFunction> definition;
+    private final CompletableFuture<@Nullable IFunction> references;
+    private final CompletableFuture<@Nullable IFunction> implementation;
+    private final CompletableFuture<@Nullable IFunction> codeAction;
 
-    private final CompletableFuture<Boolean> hasAnalysisService;
-    private final CompletableFuture<Boolean> hasBuildService;
-    private final CompletableFuture<Boolean> hasDocumentSymbolService;
-    private final CompletableFuture<Boolean> hasCodeLensService;
-    private final CompletableFuture<Boolean> hasInlayHintService;
-    private final CompletableFuture<Boolean> hasExecutionService;
-    private final CompletableFuture<Boolean> hasHoverService;
-    private final CompletableFuture<Boolean> hasDefinitionService;
-    private final CompletableFuture<Boolean> hasReferencesService;
-    private final CompletableFuture<Boolean> hasImplementationService;
-    private final CompletableFuture<Boolean> hasCodeActionService;
+    private final CompletableFuture<Boolean> hasAnalysis;
+    private final CompletableFuture<Boolean> hasBuild;
+    private final CompletableFuture<Boolean> hasDocumentSymbol;
+    private final CompletableFuture<Boolean> hasCodeLens;
+    private final CompletableFuture<Boolean> hasInlayHint;
+    private final CompletableFuture<Boolean> hasExecution;
+    private final CompletableFuture<Boolean> hasHover;
+    private final CompletableFuture<Boolean> hasDefinition;
+    private final CompletableFuture<Boolean> hasReferences;
+    private final CompletableFuture<Boolean> hasImplementation;
+    private final CompletableFuture<Boolean> hasCodeAction;
 
     private final CompletableFuture<SummaryConfig> analyzerSummaryConfig;
     private final CompletableFuture<SummaryConfig> builderSummaryConfig;
@@ -125,31 +125,31 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
 
             this.store = eval.thenApply(e -> ((ModuleEnvironment)e.getModule(mainModule)).getStore());
 
-            this.parsingService        = getFunctionFor(contributions, LanguageContributions.PARSING);
-            this.analysisService       = getFunctionFor(contributions, LanguageContributions.ANALYSIS);
-            this.buildService          = getFunctionFor(contributions, LanguageContributions.BUILD);
-            this.documentSymbolService = getFunctionFor(contributions, LanguageContributions.DOCUMENT_SYMBOL);
-            this.codeLensService       = getFunctionFor(contributions, LanguageContributions.CODE_LENS);
-            this.inlayHintService      = getFunctionFor(contributions, LanguageContributions.INLAY_HINT);
-            this.executionService      = getFunctionFor(contributions, LanguageContributions.EXECUTION);
-            this.hoverService          = getFunctionFor(contributions, LanguageContributions.HOVER);
-            this.definitionService     = getFunctionFor(contributions, LanguageContributions.DEFINITION);
-            this.referencesService     = getFunctionFor(contributions, LanguageContributions.REFERENCES);
-            this.implementationService = getFunctionFor(contributions, LanguageContributions.IMPLEMENTATION);
-            this.codeActionService     = getFunctionFor(contributions, LanguageContributions.CODE_ACTION);
+            this.parsing        = getFunctionFor(contributions, LanguageContributions.PARSING);
+            this.analysis       = getFunctionFor(contributions, LanguageContributions.ANALYSIS);
+            this.build          = getFunctionFor(contributions, LanguageContributions.BUILD);
+            this.documentSymbol = getFunctionFor(contributions, LanguageContributions.DOCUMENT_SYMBOL);
+            this.codeLens       = getFunctionFor(contributions, LanguageContributions.CODE_LENS);
+            this.inlayHint      = getFunctionFor(contributions, LanguageContributions.INLAY_HINT);
+            this.execution      = getFunctionFor(contributions, LanguageContributions.EXECUTION);
+            this.hover          = getFunctionFor(contributions, LanguageContributions.HOVER);
+            this.definition     = getFunctionFor(contributions, LanguageContributions.DEFINITION);
+            this.references     = getFunctionFor(contributions, LanguageContributions.REFERENCES);
+            this.implementation = getFunctionFor(contributions, LanguageContributions.IMPLEMENTATION);
+            this.codeAction     = getFunctionFor(contributions, LanguageContributions.CODE_ACTION);
 
             // assign boolean properties once instead of wasting futures all the time
-            this.hasAnalysisService       = nonNull(this.analysisService);
-            this.hasBuildService          = nonNull(this.buildService);
-            this.hasDocumentSymbolService = nonNull(this.documentSymbolService);
-            this.hasCodeLensService       = nonNull(this.codeLensService);
-            this.hasInlayHintService      = nonNull(this.inlayHintService);
-            this.hasExecutionService      = nonNull(this.executionService);
-            this.hasHoverService          = nonNull(this.hoverService);
-            this.hasDefinitionService     = nonNull(this.definitionService);
-            this.hasReferencesService     = nonNull(this.referencesService);
-            this.hasImplementationService = nonNull(this.implementationService);
-            this.hasCodeActionService     = nonNull(this.codeActionService);
+            this.hasAnalysis       = nonNull(this.analysis);
+            this.hasBuild          = nonNull(this.build);
+            this.hasDocumentSymbol = nonNull(this.documentSymbol);
+            this.hasCodeLens       = nonNull(this.codeLens);
+            this.hasInlayHint      = nonNull(this.inlayHint);
+            this.hasExecution      = nonNull(this.execution);
+            this.hasHover          = nonNull(this.hover);
+            this.hasDefinition     = nonNull(this.definition);
+            this.hasReferences     = nonNull(this.references);
+            this.hasImplementation = nonNull(this.implementation);
+            this.hasCodeAction     = nonNull(this.codeAction);
 
             this.analyzerSummaryConfig = scheduledSummaryConfig(contributions, LanguageContributions.ANALYSIS);
             this.builderSummaryConfig  = scheduledSummaryConfig(contributions, LanguageContributions.BUILD);
@@ -260,69 +260,69 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
+    public CompletableFuture<ITree> parsing(ISourceLocation loc, String input) {
         debug(LanguageContributions.PARSING, loc, input);
-        return parsingService.thenApplyAsync(p -> p.call(VF.string(input), loc), exec);
+        return parsing.thenApplyAsync(p -> p.call(VF.string(input), loc), exec);
     }
 
     @Override
-    public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
+    public InterruptibleFuture<IList> documentSymbol(ITree input) {
         debug(LanguageContributions.DOCUMENT_SYMBOL, TreeAdapter.getLocation(input));
-        return execFunction(LanguageContributions.DOCUMENT_SYMBOL, documentSymbolService, VF.list(), input);
+        return execFunction(LanguageContributions.DOCUMENT_SYMBOL, documentSymbol, VF.list(), input);
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation src, ITree input) {
+    public InterruptibleFuture<IConstructor> analysis(ISourceLocation src, ITree input) {
         debug(LanguageContributions.ANALYSIS, src);
-        return execFunction(LanguageContributions.ANALYSIS, analysisService, EmptySummary.newInstance(src), src, input);
+        return execFunction(LanguageContributions.ANALYSIS, analysis, EmptySummary.newInstance(src), src, input);
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation src, ITree input) {
+    public InterruptibleFuture<IConstructor> build(ISourceLocation src, ITree input) {
         debug(LanguageContributions.BUILD, src);
-        return execFunction(LanguageContributions.BUILD, buildService, EmptySummary.newInstance(src), src, input);
+        return execFunction(LanguageContributions.BUILD, build, EmptySummary.newInstance(src), src, input);
     }
 
     @Override
-    public InterruptibleFuture<IList> runCodeLensService(ITree input) {
+    public InterruptibleFuture<IList> codeLens(ITree input) {
         debug(LanguageContributions.CODE_LENS, TreeAdapter.getLocation(input));
-        return execFunction(LanguageContributions.CODE_LENS, codeLensService, VF.list(), input);
+        return execFunction(LanguageContributions.CODE_LENS, codeLens, VF.list(), input);
     }
 
     @Override
-    public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
+    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input) {
         debug(LanguageContributions.INLAY_HINT, input != null ? TreeAdapter.getLocation(input) : null);
-        return execFunction(LanguageContributions.INLAY_HINT, inlayHintService, VF.list(), input);
+        return execFunction(LanguageContributions.INLAY_HINT, inlayHint, VF.list(), input);
     }
 
     @Override
-    public InterruptibleFuture<ISet> runHoverService(IList focus) {
+    public InterruptibleFuture<ISet> hover(IList focus) {
         debug(LanguageContributions.HOVER, focus.length());
-        return execFunction(LanguageContributions.HOVER, hoverService, VF.set(), focus);
+        return execFunction(LanguageContributions.HOVER, hover, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
+    public InterruptibleFuture<ISet> definition(IList focus) {
         debug(LanguageContributions.DEFINITION, focus.length());
-        return execFunction(LanguageContributions.DEFINITION, definitionService, VF.set(), focus);
+        return execFunction(LanguageContributions.DEFINITION, definition, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<ISet> runImplementationService(IList focus) {
+    public InterruptibleFuture<ISet> implementation(IList focus) {
         debug(LanguageContributions.IMPLEMENTATION, focus.length());
-        return execFunction(LanguageContributions.IMPLEMENTATION, implementationService, VF.set(), focus);
+        return execFunction(LanguageContributions.IMPLEMENTATION, implementation, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<ISet> runReferencesService(IList focus) {
+    public InterruptibleFuture<ISet> references(IList focus) {
         debug(LanguageContributions.REFERENCES, focus.length());
-        return execFunction(LanguageContributions.REFERENCES, referencesService, VF.set(), focus);
+        return execFunction(LanguageContributions.REFERENCES, references, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<IList> runCodeActionService(IList focus) {
+    public InterruptibleFuture<IList> codeAction(IList focus) {
         debug(LanguageContributions.CODE_ACTION, focus.length());
-        return execFunction(LanguageContributions.CODE_ACTION, codeActionService, VF.list(), focus);
+        return execFunction(LanguageContributions.CODE_ACTION, codeAction, VF.list(), focus);
     }
 
     private void debug(String name, Object param) {
@@ -334,58 +334,58 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefinitionService() {
-        return hasDefinitionService;
+    public CompletableFuture<Boolean> hasDefinition() {
+        return hasDefinition;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferencesService() {
-        return hasReferencesService;
+    public CompletableFuture<Boolean> hasReferences() {
+        return hasReferences;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementationService() {
-        return hasImplementationService;
+    public CompletableFuture<Boolean> hasImplementation() {
+        return hasImplementation;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasHoverService() {
-        return hasHoverService;
+    public CompletableFuture<Boolean> hasHover() {
+        return hasHover;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasExecutionService() {
-        return hasExecutionService;
+    public CompletableFuture<Boolean> hasExecution() {
+        return hasExecution;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHintService() {
-        return hasInlayHintService;
+    public CompletableFuture<Boolean> hasInlayHint() {
+        return hasInlayHint;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLensService() {
-        return hasCodeLensService;
+    public CompletableFuture<Boolean> hasCodeLens() {
+        return hasCodeLens;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumentSymbolService() {
-        return hasDocumentSymbolService;
+    public CompletableFuture<Boolean> hasDocumentSymbol() {
+        return hasDocumentSymbol;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeActionService() {
-        return hasCodeActionService;
+    public CompletableFuture<Boolean> hasCodeAction() {
+        return hasCodeAction;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalysisService() {
-        return hasAnalysisService;
+    public CompletableFuture<Boolean> hasAnalysis() {
+        return hasAnalysis;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuildService() {
-        return hasBuildService;
+    public CompletableFuture<Boolean> hasBuild() {
+        return hasBuild;
     }
 
     @Override
@@ -404,12 +404,12 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
+    public InterruptibleFuture<@Nullable IValue> execution(String command) {
         logger.debug("executeCommand({}...) (full command value in TRACE level)", () -> command.substring(0, Math.min(10, command.length())));
         logger.trace("Full command: {}", command);
 
         return InterruptibleFuture.flatten(parseCommand(command).thenCombine(
-            executionService,
+            execution,
             (cons, func) -> {
 
                 if (func == null) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -74,30 +74,31 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
 
     private final CompletableFuture<Evaluator> eval;
     private final CompletableFuture<TypeStore> store;
-    private final CompletableFuture<IFunction> parser;
-    private final CompletableFuture<@Nullable IFunction> outliner;
-    private final CompletableFuture<@Nullable IFunction> analyzer;
-    private final CompletableFuture<@Nullable IFunction> builder;
-    private final CompletableFuture<@Nullable IFunction> lenses;
-    private final CompletableFuture<@Nullable IFunction> commandExecutor;
-    private final CompletableFuture<@Nullable IFunction> inlayHinter;
-    private final CompletableFuture<@Nullable IFunction> documenter;
-    private final CompletableFuture<@Nullable IFunction> definer;
-    private final CompletableFuture<@Nullable IFunction> referrer;
-    private final CompletableFuture<@Nullable IFunction> implementer;
-    private final CompletableFuture<@Nullable IFunction> codeActionContributor;
 
-    private final CompletableFuture<Boolean> hasOutliner;
-    private final CompletableFuture<Boolean> hasAnalyzer;
-    private final CompletableFuture<Boolean> hasBuilder;
-    private final CompletableFuture<Boolean> hasLensDetector;
-    private final CompletableFuture<Boolean> hasCommandExecutor;
-    private final CompletableFuture<Boolean> hasInlayHinter;
-    private final CompletableFuture<Boolean> hasDocumenter;
-    private final CompletableFuture<Boolean> hasDefiner;
-    private final CompletableFuture<Boolean> hasReferrer;
-    private final CompletableFuture<Boolean> hasImplementer;
-    private final CompletableFuture<Boolean> hasCodeActionContributor;
+    private final CompletableFuture<IFunction> parsingService;
+    private final CompletableFuture<@Nullable IFunction> analysisService;
+    private final CompletableFuture<@Nullable IFunction> buildService;
+    private final CompletableFuture<@Nullable IFunction> documentSymbolService;
+    private final CompletableFuture<@Nullable IFunction> codeLensService;
+    private final CompletableFuture<@Nullable IFunction> inlayHintService;
+    private final CompletableFuture<@Nullable IFunction> executionService;
+    private final CompletableFuture<@Nullable IFunction> hoverService;
+    private final CompletableFuture<@Nullable IFunction> definitionService;
+    private final CompletableFuture<@Nullable IFunction> referencesService;
+    private final CompletableFuture<@Nullable IFunction> implementationService;
+    private final CompletableFuture<@Nullable IFunction> codeActionService;
+
+    private final CompletableFuture<Boolean> hasAnalysisService;
+    private final CompletableFuture<Boolean> hasBuildService;
+    private final CompletableFuture<Boolean> hasDocumentSymbolService;
+    private final CompletableFuture<Boolean> hasCodeLensService;
+    private final CompletableFuture<Boolean> hasInlayHintService;
+    private final CompletableFuture<Boolean> hasExecutionService;
+    private final CompletableFuture<Boolean> hasHoverService;
+    private final CompletableFuture<Boolean> hasDefinitionService;
+    private final CompletableFuture<Boolean> hasReferencesService;
+    private final CompletableFuture<Boolean> hasImplementationService;
+    private final CompletableFuture<Boolean> hasCodeActionService;
 
     private final CompletableFuture<SummaryConfig> analyzerSummaryConfig;
     private final CompletableFuture<SummaryConfig> builderSummaryConfig;
@@ -122,31 +123,31 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
                 ValueFactoryFactory.getValueFactory().set(),
                 exec, true, client).get();
             this.store = eval.thenApply(e -> ((ModuleEnvironment)e.getModule(mainModule)).getStore());
-            this.parser = getFunctionFor(contributions, LanguageContributions.PARSER);
-            this.outliner = getFunctionFor(contributions, LanguageContributions.OUTLINER);
-            this.analyzer = getFunctionFor(contributions, LanguageContributions.ANALYZER);
-            this.builder = getFunctionFor(contributions, LanguageContributions.BUILDER);
-            this.lenses = getFunctionFor(contributions, LanguageContributions.LENS_DETECTOR);
-            this.commandExecutor = getFunctionFor(contributions, LanguageContributions.COMMAND_EXECUTOR);
-            this.inlayHinter = getFunctionFor(contributions, LanguageContributions.INLAY_HINTER);
-            this.documenter = getFunctionFor(contributions, LanguageContributions.DOCUMENTER);
-            this.definer = getFunctionFor(contributions, LanguageContributions.DEFINER);
-            this.referrer = getFunctionFor(contributions, LanguageContributions.REFERRER);
-            this.implementer = getFunctionFor(contributions, LanguageContributions.IMPLEMENTER);
-            this.codeActionContributor = getFunctionFor(contributions, LanguageContributions.CODE_ACTION_CONTRIBUTOR);
+            this.parsingService = getFunctionFor(contributions, LanguageContributions.PARSER);
+            this.analysisService = getFunctionFor(contributions, LanguageContributions.ANALYZER);
+            this.buildService = getFunctionFor(contributions, LanguageContributions.BUILDER);
+            this.documentSymbolService = getFunctionFor(contributions, LanguageContributions.OUTLINER);
+            this.codeLensService = getFunctionFor(contributions, LanguageContributions.LENS_DETECTOR);
+            this.inlayHintService = getFunctionFor(contributions, LanguageContributions.INLAY_HINTER);
+            this.executionService = getFunctionFor(contributions, LanguageContributions.COMMAND_EXECUTOR);
+            this.hoverService = getFunctionFor(contributions, LanguageContributions.DOCUMENTER);
+            this.definitionService = getFunctionFor(contributions, LanguageContributions.DEFINER);
+            this.referencesService = getFunctionFor(contributions, LanguageContributions.REFERRER);
+            this.implementationService = getFunctionFor(contributions, LanguageContributions.IMPLEMENTER);
+            this.codeActionService = getFunctionFor(contributions, LanguageContributions.CODE_ACTION_CONTRIBUTOR);
 
             // assign boolean properties once instead of wasting futures all the time
-            this.hasOutliner = nonNull(this.outliner);
-            this.hasAnalyzer = nonNull(this.analyzer);
-            this.hasBuilder = nonNull(this.builder);
-            this.hasLensDetector = nonNull(this.lenses);
-            this.hasCommandExecutor = nonNull(this.commandExecutor);
-            this.hasInlayHinter = nonNull(this.inlayHinter);
-            this.hasDocumenter = nonNull(this.documenter);
-            this.hasDefiner = nonNull(this.definer);
-            this.hasReferrer = nonNull(this.referrer);
-            this.hasImplementer = nonNull(this.implementer);
-            this.hasCodeActionContributor = nonNull(this.codeActionContributor);
+            this.hasAnalysisService = nonNull(this.analysisService);
+            this.hasBuildService = nonNull(this.buildService);
+            this.hasDocumentSymbolService = nonNull(this.documentSymbolService);
+            this.hasCodeLensService = nonNull(this.codeLensService);
+            this.hasInlayHintService = nonNull(this.inlayHintService);
+            this.hasExecutionService = nonNull(this.executionService);
+            this.hasHoverService = nonNull(this.hoverService);
+            this.hasDefinitionService = nonNull(this.definitionService);
+            this.hasReferencesService = nonNull(this.referencesService);
+            this.hasImplementationService = nonNull(this.implementationService);
+            this.hasCodeActionService = nonNull(this.codeActionService);
 
             this.analyzerSummaryConfig = scheduledSummaryConfig(contributions, LanguageContributions.ANALYZER);
             this.builderSummaryConfig = scheduledSummaryConfig(contributions, LanguageContributions.BUILDER);
@@ -259,67 +260,67 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     @Override
     public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
         debug(LanguageContributions.PARSER, loc, input);
-        return parser.thenApplyAsync(p -> p.call(VF.string(input), loc), exec);
+        return parsingService.thenApplyAsync(p -> p.call(VF.string(input), loc), exec);
     }
 
     @Override
     public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
         debug(LanguageContributions.OUTLINER, TreeAdapter.getLocation(input));
-        return execFunction(LanguageContributions.OUTLINER, outliner, VF.list(), input);
+        return execFunction(LanguageContributions.OUTLINER, documentSymbolService, VF.list(), input);
     }
 
     @Override
     public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation src, ITree input) {
         debug(LanguageContributions.ANALYZER, src);
-        return execFunction(LanguageContributions.ANALYZER, analyzer, EmptySummary.newInstance(src), src, input);
+        return execFunction(LanguageContributions.ANALYZER, analysisService, EmptySummary.newInstance(src), src, input);
     }
 
     @Override
     public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation src, ITree input) {
         debug(LanguageContributions.BUILDER, src);
-        return execFunction(LanguageContributions.BUILDER, builder, EmptySummary.newInstance(src), src, input);
+        return execFunction(LanguageContributions.BUILDER, buildService, EmptySummary.newInstance(src), src, input);
     }
 
     @Override
     public InterruptibleFuture<IList> runCodeLensService(ITree input) {
         debug(LanguageContributions.LENS_DETECTOR, TreeAdapter.getLocation(input));
-        return execFunction(LanguageContributions.LENS_DETECTOR, lenses, VF.list(), input);
+        return execFunction(LanguageContributions.LENS_DETECTOR, codeLensService, VF.list(), input);
     }
 
     @Override
     public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
         debug(LanguageContributions.INLAY_HINTER, input != null ? TreeAdapter.getLocation(input) : null);
-        return execFunction(LanguageContributions.INLAY_HINTER, inlayHinter, VF.list(), input);
+        return execFunction(LanguageContributions.INLAY_HINTER, inlayHintService, VF.list(), input);
     }
 
     @Override
     public InterruptibleFuture<ISet> runHoverService(IList focus) {
         debug(LanguageContributions.DOCUMENTER, focus.length());
-        return execFunction(LanguageContributions.DOCUMENTER, documenter, VF.set(), focus);
+        return execFunction(LanguageContributions.DOCUMENTER, hoverService, VF.set(), focus);
     }
 
     @Override
     public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
         debug(LanguageContributions.DEFINER, focus.length());
-        return execFunction(LanguageContributions.DEFINER, definer, VF.set(), focus);
+        return execFunction(LanguageContributions.DEFINER, definitionService, VF.set(), focus);
     }
 
     @Override
     public InterruptibleFuture<ISet> runImplementationService(IList focus) {
         debug(LanguageContributions.IMPLEMENTER, focus.length());
-        return execFunction(LanguageContributions.IMPLEMENTER, implementer, VF.set(), focus);
+        return execFunction(LanguageContributions.IMPLEMENTER, implementationService, VF.set(), focus);
     }
 
     @Override
     public InterruptibleFuture<ISet> runReferencesService(IList focus) {
         debug(LanguageContributions.REFERRER, focus.length());
-        return execFunction(LanguageContributions.REFERRER, referrer, VF.set(), focus);
+        return execFunction(LanguageContributions.REFERRER, referencesService, VF.set(), focus);
     }
 
     @Override
     public InterruptibleFuture<IList> runCodeActionService(IList focus) {
         debug(LanguageContributions.CODE_ACTION_CONTRIBUTOR, focus.length());
-        return execFunction(LanguageContributions.CODE_ACTION_CONTRIBUTOR, codeActionContributor, VF.list(), focus);
+        return execFunction(LanguageContributions.CODE_ACTION_CONTRIBUTOR, codeActionService, VF.list(), focus);
     }
 
     private void debug(String name, Object param) {
@@ -332,57 +333,57 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
 
     @Override
     public CompletableFuture<Boolean> hasDefinitionService() {
-        return hasDefiner;
+        return hasDefinitionService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasReferencesService() {
-        return hasReferrer;
+        return hasReferencesService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasImplementationService() {
-        return hasImplementer;
+        return hasImplementationService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasHoverService() {
-        return hasDocumenter;
+        return hasHoverService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasExecutionService() {
-        return hasCommandExecutor;
+        return hasExecutionService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasInlayHintService() {
-        return hasInlayHinter;
+        return hasInlayHintService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasCodeLensDetector() {
-        return hasLensDetector;
+        return hasCodeLensService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasDocumentSymbolService() {
-        return hasOutliner;
+        return hasDocumentSymbolService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasCodeActionService() {
-        return hasCodeActionContributor;
+        return hasCodeActionService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasAnalysisService() {
-        return hasAnalyzer;
+        return hasAnalysisService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasBuildService() {
-        return hasBuilder;
+        return hasBuildService;
     }
 
     @Override
@@ -406,7 +407,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
         logger.trace("Full command: {}", command);
 
         return InterruptibleFuture.flatten(parseCommand(command).thenCombine(
-            commandExecutor,
+            executionService,
             (cons, func) -> {
 
                 if (func == null) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -364,7 +364,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLensDetector() {
+    public CompletableFuture<Boolean> hasCodeLensService() {
         return hasCodeLensService;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -257,67 +257,67 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<ITree> parseSourceFile(ISourceLocation loc, String input) {
+    public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
         debug(LanguageContributions.PARSER, loc, input);
         return parser.thenApplyAsync(p -> p.call(VF.string(input), loc), exec);
     }
 
     @Override
-    public InterruptibleFuture<IList> outline(ITree input) {
+    public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
         debug(LanguageContributions.OUTLINER, TreeAdapter.getLocation(input));
         return execFunction(LanguageContributions.OUTLINER, outliner, VF.list(), input);
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> analyze(ISourceLocation src, ITree input) {
+    public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation src, ITree input) {
         debug(LanguageContributions.ANALYZER, src);
         return execFunction(LanguageContributions.ANALYZER, analyzer, EmptySummary.newInstance(src), src, input);
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> build(ISourceLocation src, ITree input) {
+    public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation src, ITree input) {
         debug(LanguageContributions.BUILDER, src);
         return execFunction(LanguageContributions.BUILDER, builder, EmptySummary.newInstance(src), src, input);
     }
 
     @Override
-    public InterruptibleFuture<IList> lenses(ITree input) {
+    public InterruptibleFuture<IList> runCodeLensService(ITree input) {
         debug(LanguageContributions.LENS_DETECTOR, TreeAdapter.getLocation(input));
         return execFunction(LanguageContributions.LENS_DETECTOR, lenses, VF.list(), input);
     }
 
     @Override
-    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input) {
+    public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
         debug(LanguageContributions.INLAY_HINTER, input != null ? TreeAdapter.getLocation(input) : null);
         return execFunction(LanguageContributions.INLAY_HINTER, inlayHinter, VF.list(), input);
     }
 
     @Override
-    public InterruptibleFuture<ISet> documentation(IList focus) {
+    public InterruptibleFuture<ISet> runHoverService(IList focus) {
         debug(LanguageContributions.DOCUMENTER, focus.length());
         return execFunction(LanguageContributions.DOCUMENTER, documenter, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<ISet> definitions(IList focus) {
+    public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
         debug(LanguageContributions.DEFINER, focus.length());
         return execFunction(LanguageContributions.DEFINER, definer, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<ISet> implementations(IList focus) {
+    public InterruptibleFuture<ISet> runImplementationService(IList focus) {
         debug(LanguageContributions.IMPLEMENTER, focus.length());
         return execFunction(LanguageContributions.IMPLEMENTER, implementer, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<ISet> references(IList focus) {
+    public InterruptibleFuture<ISet> runReferencesService(IList focus) {
         debug(LanguageContributions.REFERRER, focus.length());
         return execFunction(LanguageContributions.REFERRER, referrer, VF.set(), focus);
     }
 
     @Override
-    public InterruptibleFuture<IList> codeActions(IList focus) {
+    public InterruptibleFuture<IList> runCodeActionService(IList focus) {
         debug(LanguageContributions.CODE_ACTION_CONTRIBUTOR, focus.length());
         return execFunction(LanguageContributions.CODE_ACTION_CONTRIBUTOR, codeActionContributor, VF.list(), focus);
     }
@@ -331,57 +331,57 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefiner() {
+    public CompletableFuture<Boolean> hasDefinitionService() {
         return hasDefiner;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferrer() {
+    public CompletableFuture<Boolean> hasReferencesService() {
         return hasReferrer;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementer() {
+    public CompletableFuture<Boolean> hasImplementationService() {
         return hasImplementer;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumenter() {
+    public CompletableFuture<Boolean> hasHoverService() {
         return hasDocumenter;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCommandExecutor() {
+    public CompletableFuture<Boolean> hasExecutionService() {
         return hasCommandExecutor;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHinter() {
+    public CompletableFuture<Boolean> hasInlayHintService() {
         return hasInlayHinter;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasLensDetector() {
+    public CompletableFuture<Boolean> hasCodeLensDetector() {
         return hasLensDetector;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasOutliner() {
+    public CompletableFuture<Boolean> hasDocumentSymbolService() {
         return hasOutliner;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeActionsContributor() {
+    public CompletableFuture<Boolean> hasCodeActionService() {
         return hasCodeActionContributor;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalyzer() {
+    public CompletableFuture<Boolean> hasAnalysisService() {
         return hasAnalyzer;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuilder() {
+    public CompletableFuture<Boolean> hasBuildService() {
         return hasBuilder;
     }
 
@@ -401,7 +401,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<@Nullable IValue> executeCommand(String command) {
+    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
         logger.debug("executeCommand({}...) (full command value in TRACE level)", () -> command.substring(0, Math.min(10, command.length())));
         logger.trace("Full command: {}", command);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -224,7 +224,6 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         return p.runParsingService(loc, input);
     }
 
-
     private <T> InterruptibleFuture<T> flatten(CompletableFuture<ILanguageContributions> target, Function<ILanguageContributions, InterruptibleFuture<T>> call) {
         return InterruptibleFuture.flatten(target.thenApply(call), ownExecuter);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -51,31 +51,32 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         return CompletableFuture.failedFuture(new RuntimeException("No contributions registered"));
     }
 
-    private volatile @MonotonicNonNull ILanguageContributions parser = null;
-    private volatile CompletableFuture<ILanguageContributions> outliner = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> analyzer = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> builder = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> lensDetector = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> commandExecutor = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> inlayHinter = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> definer = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> documenter = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> referrer = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> implementer = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> codeActionContributor = failedInitialization();
+    private volatile @MonotonicNonNull ILanguageContributions  parsingService = null;
 
-    private volatile CompletableFuture<Boolean> hasDocumenter = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasDefiner = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasReferrer = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasImplementer = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getAnalysisService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getBuildService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getDocumentSymbolService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getCodeLensService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getInlayHintService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getExecutionService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getHoverService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getDefinitionService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getReferencesService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getImplementationService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> getCodeActionService = failedInitialization();
 
-    private volatile CompletableFuture<Boolean> hasOutliner = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasAnalyzer = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasBuilder = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasLensDetector = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCommandExecutor = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasInlayHinter = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCodeActionContributor = failedInitialization();
+
+    private volatile CompletableFuture<Boolean> hasAnalysisService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasBuildService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasDocumentSymbolService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasCodeLensService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasInlayHintService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasExecutionService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasHoverService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasDefinitionService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasReferencesService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasImplementationService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasCodeActionService = failedInitialization();
 
     private volatile CompletableFuture<SummaryConfig> analyzerSummaryConfig;
     private volatile CompletableFuture<SummaryConfig> builderSummaryConfig;
@@ -134,30 +135,30 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // this is to avoid doing this lookup every time we get a request
         // we calculate the "route" once, and then just chain onto the completed
         // future
-        parser = firstOrFail();
-        outliner = findFirstOrDefault(ILanguageContributions::hasDocumentSymbolService);
-        analyzer = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
-        builder = findFirstOrDefault(ILanguageContributions::hasBuildService);
-        lensDetector = findFirstOrDefault(ILanguageContributions::hasCodeLensDetector);
-        commandExecutor = findFirstOrDefault(ILanguageContributions::hasExecutionService);
-        inlayHinter = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
-        definer = findFirstOrDefault(ILanguageContributions::hasDefinitionService);
-        documenter = findFirstOrDefault(ILanguageContributions::hasHoverService);
-        referrer = findFirstOrDefault(ILanguageContributions::hasReferencesService);
-        implementer = findFirstOrDefault(ILanguageContributions::hasImplementationService);
-        codeActionContributor = findFirstOrDefault(ILanguageContributions::hasCodeActionService);
+        parsingService = firstOrFail();
+        getAnalysisService = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
+        getBuildService = findFirstOrDefault(ILanguageContributions::hasBuildService);
+        getDocumentSymbolService = findFirstOrDefault(ILanguageContributions::hasDocumentSymbolService);
+        getCodeLensService = findFirstOrDefault(ILanguageContributions::hasCodeLensDetector);
+        getInlayHintService = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
+        getExecutionService = findFirstOrDefault(ILanguageContributions::hasExecutionService);
+        getHoverService = findFirstOrDefault(ILanguageContributions::hasHoverService);
+        getDefinitionService = findFirstOrDefault(ILanguageContributions::hasDefinitionService);
+        getReferencesService = findFirstOrDefault(ILanguageContributions::hasReferencesService);
+        getImplementationService = findFirstOrDefault(ILanguageContributions::hasImplementationService);
+        getCodeActionService = findFirstOrDefault(ILanguageContributions::hasCodeActionService);
 
-        hasDocumenter = anyTrue(ILanguageContributions::hasHoverService);
-        hasDefiner = anyTrue(ILanguageContributions::hasDefinitionService);
-        hasReferrer = anyTrue(ILanguageContributions::hasReferencesService);
-        hasImplementer = anyTrue(ILanguageContributions::hasImplementationService);
 
-        hasOutliner = anyTrue(ILanguageContributions::hasDocumentSymbolService);
-        hasAnalyzer = anyTrue(ILanguageContributions::hasAnalysisService);
-        hasBuilder = anyTrue(ILanguageContributions::hasBuildService);
-        hasLensDetector = anyTrue(ILanguageContributions::hasCodeLensDetector);
-        hasCommandExecutor = anyTrue(ILanguageContributions::hasExecutionService);
-        hasInlayHinter = anyTrue(ILanguageContributions::hasInlayHintService);
+        hasAnalysisService = anyTrue(ILanguageContributions::hasAnalysisService);
+        hasBuildService = anyTrue(ILanguageContributions::hasBuildService);
+        hasDocumentSymbolService = anyTrue(ILanguageContributions::hasDocumentSymbolService);
+        hasCodeLensService = anyTrue(ILanguageContributions::hasCodeLensDetector);
+        hasInlayHintService = anyTrue(ILanguageContributions::hasInlayHintService);
+        hasExecutionService = anyTrue(ILanguageContributions::hasExecutionService);
+        hasHoverService = anyTrue(ILanguageContributions::hasHoverService);
+        hasDefinitionService = anyTrue(ILanguageContributions::hasDefinitionService);
+        hasReferencesService = anyTrue(ILanguageContributions::hasReferencesService);
+        hasImplementationService = anyTrue(ILanguageContributions::hasImplementationService);
 
         analyzerSummaryConfig = anyTrue(ILanguageContributions::getAnalyzerSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
         builderSummaryConfig = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
@@ -171,8 +172,6 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         }
         return it.next().contrib;
     }
-
-
 
     private CompletableFuture<ILanguageContributions> findFirstOrDefault(Function<ILanguageContributions, CompletableFuture<Boolean>> filter) {
         return CompletableFuture.supplyAsync(() -> {
@@ -219,7 +218,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
 
     @Override
     public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
-        var p = parser;
+        var p = parsingService;
         if (p == null) {
             return failedInitialization();
         }
@@ -233,117 +232,117 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
 
     @Override
     public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
-        return flatten(outliner, c -> c.runDocumentSymbolService(input));
+        return flatten(getDocumentSymbolService, c -> c.runDocumentSymbolService(input));
     }
 
     @Override
     public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation loc, ITree input) {
-        return flatten(analyzer, c -> c.runAnalysisService(loc, input));
+        return flatten(getAnalysisService, c -> c.runAnalysisService(loc, input));
     }
 
     @Override
     public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation loc, ITree input) {
-        return flatten(builder, c -> c.runBuildService(loc, input));
+        return flatten(getBuildService, c -> c.runBuildService(loc, input));
     }
 
     @Override
     public InterruptibleFuture<IList> runCodeLensService(ITree input) {
-        return flatten(lensDetector, c -> c.runCodeLensService(input));
+        return flatten(getCodeLensService, c -> c.runCodeLensService(input));
     }
 
     @Override
     public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
-        return flatten(commandExecutor, c -> c.runExecutionService(command));
+        return flatten(getExecutionService, c -> c.runExecutionService(command));
     }
 
     @Override
     public CompletableFuture<IList> parseCodeActions(String command) {
-        return commandExecutor.thenApply(c -> c.parseCodeActions(command)).thenCompose(Function.identity());
+        return getExecutionService.thenApply(c -> c.parseCodeActions(command)).thenCompose(Function.identity());
     }
 
     @Override
     public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
-        return flatten(inlayHinter, c -> c.runInlayHintService(input));
+        return flatten(getInlayHintService, c -> c.runInlayHintService(input));
     }
 
     @Override
     public InterruptibleFuture<ISet> runHoverService(IList focus) {
-        return flatten(documenter, c -> c.runHoverService(focus));
+        return flatten(getHoverService, c -> c.runHoverService(focus));
     }
 
     @Override
     public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
-        return flatten(definer, c -> c.runDefinitionService(focus));
+        return flatten(getDefinitionService, c -> c.runDefinitionService(focus));
     }
 
     @Override
     public InterruptibleFuture<ISet> runReferencesService(IList focus) {
-        return flatten(referrer, c -> c.runReferencesService(focus));
+        return flatten(getReferencesService, c -> c.runReferencesService(focus));
     }
 
     @Override
     public InterruptibleFuture<ISet> runImplementationService(IList focus) {
-        return flatten(implementer, c -> c.runImplementationService(focus));
+        return flatten(getImplementationService, c -> c.runImplementationService(focus));
     }
 
     @Override
     public InterruptibleFuture<IList> runCodeActionService(IList focus) {
-        return flatten(codeActionContributor, c -> c.runCodeActionService(focus));
+        return flatten(getCodeActionService, c -> c.runCodeActionService(focus));
     }
 
     @Override
     public CompletableFuture<Boolean> hasCodeActionService() {
-        return hasCodeActionContributor;
+        return hasCodeActionService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasHoverService() {
-        return hasDocumenter;
+        return hasHoverService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasDefinitionService() {
-        return hasDefiner;
+        return hasDefinitionService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasReferencesService() {
-        return hasReferrer;
+        return hasReferencesService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasImplementationService() {
-        return hasImplementer;
+        return hasImplementationService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasDocumentSymbolService() {
-        return hasOutliner;
+        return hasDocumentSymbolService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasAnalysisService() {
-        return hasAnalyzer;
+        return hasAnalysisService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasBuildService() {
-        return hasBuilder;
+        return hasBuildService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasCodeLensDetector() {
-        return hasLensDetector;
+        return hasCodeLensService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasExecutionService() {
-        return hasCommandExecutor;
+        return hasExecutionService;
     }
 
     @Override
     public CompletableFuture<Boolean> hasInlayHintService() {
-        return hasInlayHinter;
+        return hasInlayHintService;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -136,31 +136,31 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // future
         parsing = firstOrFail();
 
-        analysis       = findFirstOrDefault(ILanguageContributions::hasAnalysis);
-        build          = findFirstOrDefault(ILanguageContributions::hasBuild);
+        analysis = findFirstOrDefault(ILanguageContributions::hasAnalysis);
+        build = findFirstOrDefault(ILanguageContributions::hasBuild);
         documentSymbol = findFirstOrDefault(ILanguageContributions::hasDocumentSymbol);
-        codeLens       = findFirstOrDefault(ILanguageContributions::hasCodeLens);
-        inlayHint      = findFirstOrDefault(ILanguageContributions::hasInlayHint);
-        execution      = findFirstOrDefault(ILanguageContributions::hasExecution);
-        hover          = findFirstOrDefault(ILanguageContributions::hasHover);
-        definition     = findFirstOrDefault(ILanguageContributions::hasDefinition);
-        references     = findFirstOrDefault(ILanguageContributions::hasReferences);
+        codeLens = findFirstOrDefault(ILanguageContributions::hasCodeLens);
+        inlayHint = findFirstOrDefault(ILanguageContributions::hasInlayHint);
+        execution = findFirstOrDefault(ILanguageContributions::hasExecution);
+        hover = findFirstOrDefault(ILanguageContributions::hasHover);
+        definition = findFirstOrDefault(ILanguageContributions::hasDefinition);
+        references = findFirstOrDefault(ILanguageContributions::hasReferences);
         implementation = findFirstOrDefault(ILanguageContributions::hasImplementation);
-        codeAction     = findFirstOrDefault(ILanguageContributions::hasCodeAction);
+        codeAction = findFirstOrDefault(ILanguageContributions::hasCodeAction);
 
-        hasAnalysis       = anyTrue(ILanguageContributions::hasAnalysis);
-        hasBuild          = anyTrue(ILanguageContributions::hasBuild);
+        hasAnalysis = anyTrue(ILanguageContributions::hasAnalysis);
+        hasBuild = anyTrue(ILanguageContributions::hasBuild);
         hasDocumentSymbol = anyTrue(ILanguageContributions::hasDocumentSymbol);
-        hasCodeLens       = anyTrue(ILanguageContributions::hasCodeLens);
-        hasInlayHint      = anyTrue(ILanguageContributions::hasInlayHint);
-        hasExecution      = anyTrue(ILanguageContributions::hasExecution);
-        hasHover          = anyTrue(ILanguageContributions::hasHover);
-        hasDefinition     = anyTrue(ILanguageContributions::hasDefinition);
-        hasReferences     = anyTrue(ILanguageContributions::hasReferences);
+        hasCodeLens = anyTrue(ILanguageContributions::hasCodeLens);
+        hasInlayHint = anyTrue(ILanguageContributions::hasInlayHint);
+        hasExecution = anyTrue(ILanguageContributions::hasExecution);
+        hasHover = anyTrue(ILanguageContributions::hasHover);
+        hasDefinition = anyTrue(ILanguageContributions::hasDefinition);
+        hasReferences = anyTrue(ILanguageContributions::hasReferences);
         hasImplementation = anyTrue(ILanguageContributions::hasImplementation);
 
         analyzerSummaryConfig = anyTrue(ILanguageContributions::getAnalyzerSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
-        builderSummaryConfig  = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
+        builderSummaryConfig = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
         ondemandSummaryConfig = anyTrue(ILanguageContributions::getOndemandSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -139,7 +139,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         getAnalysisService = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
         getBuildService = findFirstOrDefault(ILanguageContributions::hasBuildService);
         getDocumentSymbolService = findFirstOrDefault(ILanguageContributions::hasDocumentSymbolService);
-        getCodeLensService = findFirstOrDefault(ILanguageContributions::hasCodeLensDetector);
+        getCodeLensService = findFirstOrDefault(ILanguageContributions::hasCodeLensService);
         getInlayHintService = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
         getExecutionService = findFirstOrDefault(ILanguageContributions::hasExecutionService);
         getHoverService = findFirstOrDefault(ILanguageContributions::hasHoverService);
@@ -152,7 +152,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         hasAnalysisService = anyTrue(ILanguageContributions::hasAnalysisService);
         hasBuildService = anyTrue(ILanguageContributions::hasBuildService);
         hasDocumentSymbolService = anyTrue(ILanguageContributions::hasDocumentSymbolService);
-        hasCodeLensService = anyTrue(ILanguageContributions::hasCodeLensDetector);
+        hasCodeLensService = anyTrue(ILanguageContributions::hasCodeLensService);
         hasInlayHintService = anyTrue(ILanguageContributions::hasInlayHintService);
         hasExecutionService = anyTrue(ILanguageContributions::hasExecutionService);
         hasHoverService = anyTrue(ILanguageContributions::hasHoverService);
@@ -331,7 +331,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLensDetector() {
+    public CompletableFuture<Boolean> hasCodeLensService() {
         return hasCodeLensService;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -135,29 +135,29 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // we calculate the "route" once, and then just chain onto the completed
         // future
         parser = firstOrFail();
-        outliner = findFirstOrDefault(ILanguageContributions::hasOutliner);
-        analyzer = findFirstOrDefault(ILanguageContributions::hasAnalyzer);
-        builder = findFirstOrDefault(ILanguageContributions::hasBuilder);
-        lensDetector = findFirstOrDefault(ILanguageContributions::hasLensDetector);
-        commandExecutor = findFirstOrDefault(ILanguageContributions::hasCommandExecutor);
-        inlayHinter = findFirstOrDefault(ILanguageContributions::hasInlayHinter);
-        definer = findFirstOrDefault(ILanguageContributions::hasDefiner);
-        documenter = findFirstOrDefault(ILanguageContributions::hasDocumenter);
-        referrer = findFirstOrDefault(ILanguageContributions::hasReferrer);
-        implementer = findFirstOrDefault(ILanguageContributions::hasImplementer);
-        codeActionContributor = findFirstOrDefault(ILanguageContributions::hasCodeActionsContributor);
+        outliner = findFirstOrDefault(ILanguageContributions::hasDocumentSymbolService);
+        analyzer = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
+        builder = findFirstOrDefault(ILanguageContributions::hasBuildService);
+        lensDetector = findFirstOrDefault(ILanguageContributions::hasCodeLensDetector);
+        commandExecutor = findFirstOrDefault(ILanguageContributions::hasExecutionService);
+        inlayHinter = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
+        definer = findFirstOrDefault(ILanguageContributions::hasDefinitionService);
+        documenter = findFirstOrDefault(ILanguageContributions::hasHoverService);
+        referrer = findFirstOrDefault(ILanguageContributions::hasReferencesService);
+        implementer = findFirstOrDefault(ILanguageContributions::hasImplementationService);
+        codeActionContributor = findFirstOrDefault(ILanguageContributions::hasCodeActionService);
 
-        hasDocumenter = anyTrue(ILanguageContributions::hasDocumenter);
-        hasDefiner = anyTrue(ILanguageContributions::hasDefiner);
-        hasReferrer = anyTrue(ILanguageContributions::hasReferrer);
-        hasImplementer = anyTrue(ILanguageContributions::hasImplementer);
+        hasDocumenter = anyTrue(ILanguageContributions::hasHoverService);
+        hasDefiner = anyTrue(ILanguageContributions::hasDefinitionService);
+        hasReferrer = anyTrue(ILanguageContributions::hasReferencesService);
+        hasImplementer = anyTrue(ILanguageContributions::hasImplementationService);
 
-        hasOutliner = anyTrue(ILanguageContributions::hasOutliner);
-        hasAnalyzer = anyTrue(ILanguageContributions::hasAnalyzer);
-        hasBuilder = anyTrue(ILanguageContributions::hasBuilder);
-        hasLensDetector = anyTrue(ILanguageContributions::hasLensDetector);
-        hasCommandExecutor = anyTrue(ILanguageContributions::hasCommandExecutor);
-        hasInlayHinter = anyTrue(ILanguageContributions::hasInlayHinter);
+        hasOutliner = anyTrue(ILanguageContributions::hasDocumentSymbolService);
+        hasAnalyzer = anyTrue(ILanguageContributions::hasAnalysisService);
+        hasBuilder = anyTrue(ILanguageContributions::hasBuildService);
+        hasLensDetector = anyTrue(ILanguageContributions::hasCodeLensDetector);
+        hasCommandExecutor = anyTrue(ILanguageContributions::hasExecutionService);
+        hasInlayHinter = anyTrue(ILanguageContributions::hasInlayHintService);
 
         analyzerSummaryConfig = anyTrue(ILanguageContributions::getAnalyzerSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
         builderSummaryConfig = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
@@ -218,12 +218,12 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<ITree> parseSourceFile(ISourceLocation loc, String input) {
+    public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
         var p = parser;
         if (p == null) {
             return failedInitialization();
         }
-        return p.parseSourceFile(loc, input);
+        return p.runParsingService(loc, input);
     }
 
 
@@ -232,28 +232,28 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<IList> outline(ITree input) {
-        return flatten(outliner, c -> c.outline(input));
+    public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
+        return flatten(outliner, c -> c.runDocumentSymbolService(input));
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> analyze(ISourceLocation loc, ITree input) {
-        return flatten(analyzer, c -> c.analyze(loc, input));
+    public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation loc, ITree input) {
+        return flatten(analyzer, c -> c.runAnalysisService(loc, input));
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
-        return flatten(builder, c -> c.build(loc, input));
+    public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation loc, ITree input) {
+        return flatten(builder, c -> c.runBuildService(loc, input));
     }
 
     @Override
-    public InterruptibleFuture<IList> lenses(ITree input) {
-        return flatten(lensDetector, c -> c.lenses(input));
+    public InterruptibleFuture<IList> runCodeLensService(ITree input) {
+        return flatten(lensDetector, c -> c.runCodeLensService(input));
     }
 
     @Override
-    public InterruptibleFuture<@Nullable IValue> executeCommand(String command) {
-        return flatten(commandExecutor, c -> c.executeCommand(command));
+    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
+        return flatten(commandExecutor, c -> c.runExecutionService(command));
     }
 
     @Override
@@ -262,87 +262,87 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input) {
-        return flatten(inlayHinter, c -> c.inlayHint(input));
+    public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
+        return flatten(inlayHinter, c -> c.runInlayHintService(input));
     }
 
     @Override
-    public InterruptibleFuture<ISet> documentation(IList focus) {
-        return flatten(documenter, c -> c.documentation(focus));
+    public InterruptibleFuture<ISet> runHoverService(IList focus) {
+        return flatten(documenter, c -> c.runHoverService(focus));
     }
 
     @Override
-    public InterruptibleFuture<ISet> definitions(IList focus) {
-        return flatten(definer, c -> c.definitions(focus));
+    public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
+        return flatten(definer, c -> c.runDefinitionService(focus));
     }
 
     @Override
-    public InterruptibleFuture<ISet> references(IList focus) {
-        return flatten(referrer, c -> c.references(focus));
+    public InterruptibleFuture<ISet> runReferencesService(IList focus) {
+        return flatten(referrer, c -> c.runReferencesService(focus));
     }
 
     @Override
-    public InterruptibleFuture<ISet> implementations(IList focus) {
-        return flatten(implementer, c -> c.implementations(focus));
+    public InterruptibleFuture<ISet> runImplementationService(IList focus) {
+        return flatten(implementer, c -> c.runImplementationService(focus));
     }
 
     @Override
-    public InterruptibleFuture<IList> codeActions(IList focus) {
-        return flatten(codeActionContributor, c -> c.codeActions(focus));
+    public InterruptibleFuture<IList> runCodeActionService(IList focus) {
+        return flatten(codeActionContributor, c -> c.runCodeActionService(focus));
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeActionsContributor() {
+    public CompletableFuture<Boolean> hasCodeActionService() {
         return hasCodeActionContributor;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumenter() {
+    public CompletableFuture<Boolean> hasHoverService() {
         return hasDocumenter;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefiner() {
+    public CompletableFuture<Boolean> hasDefinitionService() {
         return hasDefiner;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferrer() {
+    public CompletableFuture<Boolean> hasReferencesService() {
         return hasReferrer;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementer() {
+    public CompletableFuture<Boolean> hasImplementationService() {
         return hasImplementer;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasOutliner() {
+    public CompletableFuture<Boolean> hasDocumentSymbolService() {
         return hasOutliner;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalyzer() {
+    public CompletableFuture<Boolean> hasAnalysisService() {
         return hasAnalyzer;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuilder() {
+    public CompletableFuture<Boolean> hasBuildService() {
         return hasBuilder;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasLensDetector() {
+    public CompletableFuture<Boolean> hasCodeLensDetector() {
         return hasLensDetector;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCommandExecutor() {
+    public CompletableFuture<Boolean> hasExecutionService() {
         return hasCommandExecutor;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHinter() {
+    public CompletableFuture<Boolean> hasInlayHintService() {
         return hasInlayHinter;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -65,7 +65,6 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     private volatile CompletableFuture<ILanguageContributions> getImplementationService = failedInitialization();
     private volatile CompletableFuture<ILanguageContributions> getCodeActionService = failedInitialization();
 
-
     private volatile CompletableFuture<Boolean> hasAnalysisService = failedInitialization();
     private volatile CompletableFuture<Boolean> hasBuildService = failedInitialization();
     private volatile CompletableFuture<Boolean> hasDocumentSymbolService = failedInitialization();
@@ -136,32 +135,32 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // we calculate the "route" once, and then just chain onto the completed
         // future
         parsingService = firstOrFail();
-        getAnalysisService = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
-        getBuildService = findFirstOrDefault(ILanguageContributions::hasBuildService);
+
+        getAnalysisService       = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
+        getBuildService          = findFirstOrDefault(ILanguageContributions::hasBuildService);
         getDocumentSymbolService = findFirstOrDefault(ILanguageContributions::hasDocumentSymbolService);
-        getCodeLensService = findFirstOrDefault(ILanguageContributions::hasCodeLensService);
-        getInlayHintService = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
-        getExecutionService = findFirstOrDefault(ILanguageContributions::hasExecutionService);
-        getHoverService = findFirstOrDefault(ILanguageContributions::hasHoverService);
-        getDefinitionService = findFirstOrDefault(ILanguageContributions::hasDefinitionService);
-        getReferencesService = findFirstOrDefault(ILanguageContributions::hasReferencesService);
+        getCodeLensService       = findFirstOrDefault(ILanguageContributions::hasCodeLensService);
+        getInlayHintService      = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
+        getExecutionService      = findFirstOrDefault(ILanguageContributions::hasExecutionService);
+        getHoverService          = findFirstOrDefault(ILanguageContributions::hasHoverService);
+        getDefinitionService     = findFirstOrDefault(ILanguageContributions::hasDefinitionService);
+        getReferencesService     = findFirstOrDefault(ILanguageContributions::hasReferencesService);
         getImplementationService = findFirstOrDefault(ILanguageContributions::hasImplementationService);
-        getCodeActionService = findFirstOrDefault(ILanguageContributions::hasCodeActionService);
+        getCodeActionService     = findFirstOrDefault(ILanguageContributions::hasCodeActionService);
 
-
-        hasAnalysisService = anyTrue(ILanguageContributions::hasAnalysisService);
-        hasBuildService = anyTrue(ILanguageContributions::hasBuildService);
+        hasAnalysisService       = anyTrue(ILanguageContributions::hasAnalysisService);
+        hasBuildService          = anyTrue(ILanguageContributions::hasBuildService);
         hasDocumentSymbolService = anyTrue(ILanguageContributions::hasDocumentSymbolService);
-        hasCodeLensService = anyTrue(ILanguageContributions::hasCodeLensService);
-        hasInlayHintService = anyTrue(ILanguageContributions::hasInlayHintService);
-        hasExecutionService = anyTrue(ILanguageContributions::hasExecutionService);
-        hasHoverService = anyTrue(ILanguageContributions::hasHoverService);
-        hasDefinitionService = anyTrue(ILanguageContributions::hasDefinitionService);
-        hasReferencesService = anyTrue(ILanguageContributions::hasReferencesService);
+        hasCodeLensService       = anyTrue(ILanguageContributions::hasCodeLensService);
+        hasInlayHintService      = anyTrue(ILanguageContributions::hasInlayHintService);
+        hasExecutionService      = anyTrue(ILanguageContributions::hasExecutionService);
+        hasHoverService          = anyTrue(ILanguageContributions::hasHoverService);
+        hasDefinitionService     = anyTrue(ILanguageContributions::hasDefinitionService);
+        hasReferencesService     = anyTrue(ILanguageContributions::hasReferencesService);
         hasImplementationService = anyTrue(ILanguageContributions::hasImplementationService);
 
         analyzerSummaryConfig = anyTrue(ILanguageContributions::getAnalyzerSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
-        builderSummaryConfig = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
+        builderSummaryConfig  = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
         ondemandSummaryConfig = anyTrue(ILanguageContributions::getOndemandSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -51,31 +51,31 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         return CompletableFuture.failedFuture(new RuntimeException("No contributions registered"));
     }
 
-    private volatile @MonotonicNonNull ILanguageContributions  parsingService = null;
+    private volatile @MonotonicNonNull ILanguageContributions  parsing = null;
 
-    private volatile CompletableFuture<ILanguageContributions> getAnalysisService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getBuildService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getDocumentSymbolService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getCodeLensService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getInlayHintService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getExecutionService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getHoverService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getDefinitionService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getReferencesService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getImplementationService = failedInitialization();
-    private volatile CompletableFuture<ILanguageContributions> getCodeActionService = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> analysis = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> build = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> documentSymbol = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> codeLens = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> inlayHint = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> execution = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> hover = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> definition = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> references = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> implementation = failedInitialization();
+    private volatile CompletableFuture<ILanguageContributions> codeAction = failedInitialization();
 
-    private volatile CompletableFuture<Boolean> hasAnalysisService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasBuildService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasDocumentSymbolService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCodeLensService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasInlayHintService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasExecutionService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasHoverService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasDefinitionService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasReferencesService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasImplementationService = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCodeActionService = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasAnalysis = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasBuild = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasDocumentSymbol = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasCodeLens = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasInlayHint = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasExecution = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasHover = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasDefinition = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasReferences = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasImplementation = failedInitialization();
+    private volatile CompletableFuture<Boolean> hasCodeAction = failedInitialization();
 
     private volatile CompletableFuture<SummaryConfig> analyzerSummaryConfig;
     private volatile CompletableFuture<SummaryConfig> builderSummaryConfig;
@@ -134,30 +134,30 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // this is to avoid doing this lookup every time we get a request
         // we calculate the "route" once, and then just chain onto the completed
         // future
-        parsingService = firstOrFail();
+        parsing = firstOrFail();
 
-        getAnalysisService       = findFirstOrDefault(ILanguageContributions::hasAnalysisService);
-        getBuildService          = findFirstOrDefault(ILanguageContributions::hasBuildService);
-        getDocumentSymbolService = findFirstOrDefault(ILanguageContributions::hasDocumentSymbolService);
-        getCodeLensService       = findFirstOrDefault(ILanguageContributions::hasCodeLensService);
-        getInlayHintService      = findFirstOrDefault(ILanguageContributions::hasInlayHintService);
-        getExecutionService      = findFirstOrDefault(ILanguageContributions::hasExecutionService);
-        getHoverService          = findFirstOrDefault(ILanguageContributions::hasHoverService);
-        getDefinitionService     = findFirstOrDefault(ILanguageContributions::hasDefinitionService);
-        getReferencesService     = findFirstOrDefault(ILanguageContributions::hasReferencesService);
-        getImplementationService = findFirstOrDefault(ILanguageContributions::hasImplementationService);
-        getCodeActionService     = findFirstOrDefault(ILanguageContributions::hasCodeActionService);
+        analysis       = findFirstOrDefault(ILanguageContributions::hasAnalysis);
+        build          = findFirstOrDefault(ILanguageContributions::hasBuild);
+        documentSymbol = findFirstOrDefault(ILanguageContributions::hasDocumentSymbol);
+        codeLens       = findFirstOrDefault(ILanguageContributions::hasCodeLens);
+        inlayHint      = findFirstOrDefault(ILanguageContributions::hasInlayHint);
+        execution      = findFirstOrDefault(ILanguageContributions::hasExecution);
+        hover          = findFirstOrDefault(ILanguageContributions::hasHover);
+        definition     = findFirstOrDefault(ILanguageContributions::hasDefinition);
+        references     = findFirstOrDefault(ILanguageContributions::hasReferences);
+        implementation = findFirstOrDefault(ILanguageContributions::hasImplementation);
+        codeAction     = findFirstOrDefault(ILanguageContributions::hasCodeAction);
 
-        hasAnalysisService       = anyTrue(ILanguageContributions::hasAnalysisService);
-        hasBuildService          = anyTrue(ILanguageContributions::hasBuildService);
-        hasDocumentSymbolService = anyTrue(ILanguageContributions::hasDocumentSymbolService);
-        hasCodeLensService       = anyTrue(ILanguageContributions::hasCodeLensService);
-        hasInlayHintService      = anyTrue(ILanguageContributions::hasInlayHintService);
-        hasExecutionService      = anyTrue(ILanguageContributions::hasExecutionService);
-        hasHoverService          = anyTrue(ILanguageContributions::hasHoverService);
-        hasDefinitionService     = anyTrue(ILanguageContributions::hasDefinitionService);
-        hasReferencesService     = anyTrue(ILanguageContributions::hasReferencesService);
-        hasImplementationService = anyTrue(ILanguageContributions::hasImplementationService);
+        hasAnalysis       = anyTrue(ILanguageContributions::hasAnalysis);
+        hasBuild          = anyTrue(ILanguageContributions::hasBuild);
+        hasDocumentSymbol = anyTrue(ILanguageContributions::hasDocumentSymbol);
+        hasCodeLens       = anyTrue(ILanguageContributions::hasCodeLens);
+        hasInlayHint      = anyTrue(ILanguageContributions::hasInlayHint);
+        hasExecution      = anyTrue(ILanguageContributions::hasExecution);
+        hasHover          = anyTrue(ILanguageContributions::hasHover);
+        hasDefinition     = anyTrue(ILanguageContributions::hasDefinition);
+        hasReferences     = anyTrue(ILanguageContributions::hasReferences);
+        hasImplementation = anyTrue(ILanguageContributions::hasImplementation);
 
         analyzerSummaryConfig = anyTrue(ILanguageContributions::getAnalyzerSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
         builderSummaryConfig  = anyTrue(ILanguageContributions::getBuilderSummaryConfig, SummaryConfig.FALSY, SummaryConfig::or);
@@ -216,12 +216,12 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
-        var p = parsingService;
+    public CompletableFuture<ITree> parsing(ISourceLocation loc, String input) {
+        var p = parsing;
         if (p == null) {
             return failedInitialization();
         }
-        return p.runParsingService(loc, input);
+        return p.parsing(loc, input);
     }
 
     private <T> InterruptibleFuture<T> flatten(CompletableFuture<ILanguageContributions> target, Function<ILanguageContributions, InterruptibleFuture<T>> call) {
@@ -229,118 +229,118 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
-        return flatten(getDocumentSymbolService, c -> c.runDocumentSymbolService(input));
+    public InterruptibleFuture<IList> documentSymbol(ITree input) {
+        return flatten(documentSymbol, c -> c.documentSymbol(input));
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation loc, ITree input) {
-        return flatten(getAnalysisService, c -> c.runAnalysisService(loc, input));
+    public InterruptibleFuture<IConstructor> analysis(ISourceLocation loc, ITree input) {
+        return flatten(analysis, c -> c.analysis(loc, input));
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation loc, ITree input) {
-        return flatten(getBuildService, c -> c.runBuildService(loc, input));
+    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
+        return flatten(build, c -> c.build(loc, input));
     }
 
     @Override
-    public InterruptibleFuture<IList> runCodeLensService(ITree input) {
-        return flatten(getCodeLensService, c -> c.runCodeLensService(input));
+    public InterruptibleFuture<IList> codeLens(ITree input) {
+        return flatten(codeLens, c -> c.codeLens(input));
     }
 
     @Override
-    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
-        return flatten(getExecutionService, c -> c.runExecutionService(command));
+    public InterruptibleFuture<@Nullable IValue> execution(String command) {
+        return flatten(execution, c -> c.execution(command));
     }
 
     @Override
     public CompletableFuture<IList> parseCodeActions(String command) {
-        return getExecutionService.thenApply(c -> c.parseCodeActions(command)).thenCompose(Function.identity());
+        return execution.thenApply(c -> c.parseCodeActions(command)).thenCompose(Function.identity());
     }
 
     @Override
-    public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
-        return flatten(getInlayHintService, c -> c.runInlayHintService(input));
+    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input) {
+        return flatten(inlayHint, c -> c.inlayHint(input));
     }
 
     @Override
-    public InterruptibleFuture<ISet> runHoverService(IList focus) {
-        return flatten(getHoverService, c -> c.runHoverService(focus));
+    public InterruptibleFuture<ISet> hover(IList focus) {
+        return flatten(hover, c -> c.hover(focus));
     }
 
     @Override
-    public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
-        return flatten(getDefinitionService, c -> c.runDefinitionService(focus));
+    public InterruptibleFuture<ISet> definition(IList focus) {
+        return flatten(definition, c -> c.definition(focus));
     }
 
     @Override
-    public InterruptibleFuture<ISet> runReferencesService(IList focus) {
-        return flatten(getReferencesService, c -> c.runReferencesService(focus));
+    public InterruptibleFuture<ISet> references(IList focus) {
+        return flatten(references, c -> c.references(focus));
     }
 
     @Override
-    public InterruptibleFuture<ISet> runImplementationService(IList focus) {
-        return flatten(getImplementationService, c -> c.runImplementationService(focus));
+    public InterruptibleFuture<ISet> implementation(IList focus) {
+        return flatten(implementation, c -> c.implementation(focus));
     }
 
     @Override
-    public InterruptibleFuture<IList> runCodeActionService(IList focus) {
-        return flatten(getCodeActionService, c -> c.runCodeActionService(focus));
+    public InterruptibleFuture<IList> codeAction(IList focus) {
+        return flatten(codeAction, c -> c.codeAction(focus));
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeActionService() {
-        return hasCodeActionService;
+    public CompletableFuture<Boolean> hasCodeAction() {
+        return hasCodeAction;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasHoverService() {
-        return hasHoverService;
+    public CompletableFuture<Boolean> hasHover() {
+        return hasHover;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefinitionService() {
-        return hasDefinitionService;
+    public CompletableFuture<Boolean> hasDefinition() {
+        return hasDefinition;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferencesService() {
-        return hasReferencesService;
+    public CompletableFuture<Boolean> hasReferences() {
+        return hasReferences;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementationService() {
-        return hasImplementationService;
+    public CompletableFuture<Boolean> hasImplementation() {
+        return hasImplementation;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumentSymbolService() {
-        return hasDocumentSymbolService;
+    public CompletableFuture<Boolean> hasDocumentSymbol() {
+        return hasDocumentSymbol;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalysisService() {
-        return hasAnalysisService;
+    public CompletableFuture<Boolean> hasAnalysis() {
+        return hasAnalysis;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuildService() {
-        return hasBuildService;
+    public CompletableFuture<Boolean> hasBuild() {
+        return hasBuild;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLensService() {
-        return hasCodeLensService;
+    public CompletableFuture<Boolean> hasCodeLens() {
+        return hasCodeLens;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasExecutionService() {
-        return hasExecutionService;
+    public CompletableFuture<Boolean> hasExecution() {
+        return hasExecution;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHintService() {
-        return hasInlayHintService;
+    public CompletableFuture<Boolean> hasInlayHint() {
+        return hasInlayHint;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -370,7 +370,6 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         var toolTip = (IString)t.asWithKeywordParameters().getParameter("toolTip");
         var atEnd = (IBool)t.asWithKeywordParameters().getParameter("atEnd");
 
-
         // translate to lsp
         var result = new InlayHint(Locations.toPosition(loc, columns, atEnd.getValue()), Either.forLeft(label.trim()));
         result.setKind(kind.getName().equals("type") ? InlayHintKind.Type : InlayHintKind.Parameter);
@@ -678,7 +677,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
 
     @Override
     public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
-        logger.debug("Implementation: {} at {}", params.getTextDocument(), params.getPosition());
+        logger.debug("References: {} at {}", params.getTextDocument(), params.getPosition());
         return recoverExceptions(
             lookup(ParametricSummary::references, params.getTextDocument(), params.getPosition())
             .thenApply(l -> l) // hack to help compiler see type
@@ -696,7 +695,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
 
     @Override
     public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
-        logger.debug("textDocument/foldingRange: {}", params.getTextDocument());
+        logger.debug("Folding range: {}", params.getTextDocument());
         TextDocumentState file = getFile(params.getTextDocument());
         return recoverExceptions(file.getCurrentTreeAsync().thenApply(Versioned::get).thenApplyAsync(FoldingRanges::getFoldingRanges)
             .whenComplete((r, e) ->
@@ -785,5 +784,4 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             return CompletableFuture.completedFuture(null);
         }
     }
-
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -114,7 +114,7 @@ import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.util.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.DocumentChanges;
 import org.rascalmpl.vscode.lsp.util.FoldingRanges;
-import org.rascalmpl.vscode.lsp.util.Outline;
+import org.rascalmpl.vscode.lsp.util.DocumentSymbols;
 import org.rascalmpl.vscode.lsp.util.SemanticTokenizer;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
@@ -578,7 +578,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             .thenApply(Versioned::get)
             .thenApply(contrib::runDocumentSymbolService)
             .thenCompose(InterruptibleFuture::get)
-            .thenApply(documentSymbols -> Outline.toLSP(documentSymbols, columns.get(file.getLocation())))
+            .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, columns.get(file.getLocation())))
             , Collections::emptyList);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -578,7 +578,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             .thenApply(Versioned::get)
             .thenApply(contrib::runDocumentSymbolService)
             .thenCompose(InterruptibleFuture::get)
-            .thenApply(c -> Outline.buildOutline(c, columns.get(file.getLocation())))
+            .thenApply(documentSymbols -> Outline.toLSP(documentSymbols, columns.get(file.getLocation())))
             , Collections::emptyList);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -689,7 +689,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public CompletableFuture<Hover> hover(HoverParams params) {
         logger.debug("Hover: {} at {}", params.getTextDocument(), params.getPosition());
         return recoverExceptions(
-            lookup(ParametricSummary::documentation, params.getTextDocument(), params.getPosition())
+            lookup(ParametricSummary::hovers, params.getTextDocument(), params.getPosition())
             .thenApply(Hover::new)
             , () -> null);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -214,7 +214,7 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLensDetector() {
+    public CompletableFuture<Boolean> hasCodeLensService() {
         return CompletableFuture.completedFuture(false);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -75,7 +75,7 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
+    public CompletableFuture<ITree> parsing(ISourceLocation loc, String input) {
         if (loadingParserError != null || parser == null) {
             return CompletableFuture.failedFuture(new RuntimeException("Parser function did not load", loadingParserError));
         }
@@ -114,27 +114,27 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
+    public InterruptibleFuture<IList> documentSymbol(ITree input) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation loc, ITree input) {
+    public InterruptibleFuture<IConstructor> analysis(ISourceLocation loc, ITree input) {
         return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc));
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation loc, ITree input) {
+    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
         return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc));
     }
 
     @Override
-    public InterruptibleFuture<IList> runCodeLensService(ITree input) {
+    public InterruptibleFuture<IList> codeLens(ITree input) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
+    public InterruptibleFuture<@Nullable IValue> execution(String command) {
         return InterruptibleFuture.completedFuture(VF.bool(false));
     }
 
@@ -144,87 +144,87 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
+    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<ISet> runHoverService(IList focus) {
+    public InterruptibleFuture<ISet> hover(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
+    public InterruptibleFuture<ISet> definition(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public InterruptibleFuture<ISet> runReferencesService(IList focus) {
+    public InterruptibleFuture<ISet> references(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public InterruptibleFuture<IList> runCodeActionService(IList focus) {
+    public InterruptibleFuture<IList> codeAction(IList focus) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<ISet> runImplementationService(IList focus) {
+    public InterruptibleFuture<ISet> implementation(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public CompletableFuture<Boolean> hasHoverService() {
+    public CompletableFuture<Boolean> hasHover() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefinitionService() {
+    public CompletableFuture<Boolean> hasDefinition() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferencesService() {
+    public CompletableFuture<Boolean> hasReferences() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementationService() {
+    public CompletableFuture<Boolean> hasImplementation() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumentSymbolService() {
+    public CompletableFuture<Boolean> hasDocumentSymbol() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalysisService() {
+    public CompletableFuture<Boolean> hasAnalysis() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuildService() {
+    public CompletableFuture<Boolean> hasBuild() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeActionService() {
+    public CompletableFuture<Boolean> hasCodeAction() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLensService() {
+    public CompletableFuture<Boolean> hasCodeLens() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasExecutionService() {
+    public CompletableFuture<Boolean> hasExecution() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHintService() {
+    public CompletableFuture<Boolean> hasInlayHint() {
         return CompletableFuture.completedFuture(false);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -75,7 +75,7 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public CompletableFuture<ITree> parseSourceFile(ISourceLocation loc, String input) {
+    public CompletableFuture<ITree> runParsingService(ISourceLocation loc, String input) {
         if (loadingParserError != null || parser == null) {
             return CompletableFuture.failedFuture(new RuntimeException("Parser function did not load", loadingParserError));
         }
@@ -114,27 +114,27 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public InterruptibleFuture<IList> outline(ITree input) {
+    public InterruptibleFuture<IList> runDocumentSymbolService(ITree input) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> analyze(ISourceLocation loc, ITree input) {
+    public InterruptibleFuture<IConstructor> runAnalysisService(ISourceLocation loc, ITree input) {
         return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc));
     }
 
     @Override
-    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
+    public InterruptibleFuture<IConstructor> runBuildService(ISourceLocation loc, ITree input) {
         return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc));
     }
 
     @Override
-    public InterruptibleFuture<IList> lenses(ITree input) {
+    public InterruptibleFuture<IList> runCodeLensService(ITree input) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<@Nullable IValue> executeCommand(String command) {
+    public InterruptibleFuture<@Nullable IValue> runExecutionService(String command) {
         return InterruptibleFuture.completedFuture(VF.bool(false));
     }
 
@@ -144,87 +144,87 @@ public class ParserOnlyContribution implements ILanguageContributions {
     }
 
     @Override
-    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input) {
+    public InterruptibleFuture<IList> runInlayHintService(@Nullable ITree input) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<ISet> documentation(IList focus) {
+    public InterruptibleFuture<ISet> runHoverService(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public InterruptibleFuture<ISet> definitions(IList focus) {
+    public InterruptibleFuture<ISet> runDefinitionService(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public InterruptibleFuture<ISet> references(IList focus) {
+    public InterruptibleFuture<ISet> runReferencesService(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public InterruptibleFuture<IList> codeActions(IList focus) {
+    public InterruptibleFuture<IList> runCodeActionService(IList focus) {
         return InterruptibleFuture.completedFuture(VF.list());
     }
 
     @Override
-    public InterruptibleFuture<ISet> implementations(IList focus) {
+    public InterruptibleFuture<ISet> runImplementationService(IList focus) {
         return InterruptibleFuture.completedFuture(VF.set());
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumenter() {
+    public CompletableFuture<Boolean> hasHoverService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefiner() {
+    public CompletableFuture<Boolean> hasDefinitionService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferrer() {
+    public CompletableFuture<Boolean> hasReferencesService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementer() {
+    public CompletableFuture<Boolean> hasImplementationService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasOutliner() {
+    public CompletableFuture<Boolean> hasDocumentSymbolService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalyzer() {
+    public CompletableFuture<Boolean> hasAnalysisService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuilder() {
+    public CompletableFuture<Boolean> hasBuildService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeActionsContributor() {
+    public CompletableFuture<Boolean> hasCodeActionService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasLensDetector() {
+    public CompletableFuture<Boolean> hasCodeLensDetector() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCommandExecutor() {
+    public CompletableFuture<Boolean> hasExecutionService() {
         return CompletableFuture.completedFuture(false);
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHinter() {
+    public CompletableFuture<Boolean> hasInlayHintService() {
         return CompletableFuture.completedFuture(false);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
@@ -114,9 +114,9 @@ public class ParametricFileFacts {
 
     public void reloadContributions() {
         analyzerSummaryFactory = contrib.getAnalyzerSummaryConfig().thenApply(config ->
-            new ScheduledSummaryFactory(config, exec, columns, contrib::runAnalysisService));
+            new ScheduledSummaryFactory(config, exec, columns, contrib::analysis));
         builderSummaryFactory = contrib.getBuilderSummaryConfig().thenApply(config ->
-            new ScheduledSummaryFactory(config, exec, columns, contrib::runBuildService));
+            new ScheduledSummaryFactory(config, exec, columns, contrib::build));
         ondemandSummaryFactory = contrib.getOndemandSummaryConfig().thenApply(config ->
             new OndemandSummaryFactory(config, exec, columns, contrib));
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
@@ -114,9 +114,9 @@ public class ParametricFileFacts {
 
     public void reloadContributions() {
         analyzerSummaryFactory = contrib.getAnalyzerSummaryConfig().thenApply(config ->
-            new ScheduledSummaryFactory(config, exec, columns, contrib::analyze));
+            new ScheduledSummaryFactory(config, exec, columns, contrib::runAnalysisService));
         builderSummaryFactory = contrib.getBuilderSummaryConfig().thenApply(config ->
-            new ScheduledSummaryFactory(config, exec, columns, contrib::build));
+            new ScheduledSummaryFactory(config, exec, columns, contrib::runBuildService));
         ondemandSummaryFactory = contrib.getOndemandSummaryConfig().thenApply(config ->
             new OndemandSummaryFactory(config, exec, columns, contrib));
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
@@ -435,22 +435,22 @@ class OndemandSummaryFactory extends ParametricSummaryFactory {
         @Override
         @SuppressWarnings("deprecation") // For `MarkedString`
         public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getHovers(Position cursor) {
-            return get(config.providesHovers, cursor, contrib::runHoverService, ParametricSummaryFactory::mapValueToString, SummaryFields.HOVERS);
+            return get(config.providesHovers, cursor, contrib::hover, ParametricSummaryFactory::mapValueToString, SummaryFields.HOVERS);
         }
 
         @Override
         public @Nullable InterruptibleFuture<List<Location>> getDefinitions(Position cursor) {
-            return get(config.providesDefinitions, cursor, contrib::runDefinitionService, locationMapper(columns), SummaryFields.DEFINITIONS);
+            return get(config.providesDefinitions, cursor, contrib::definition, locationMapper(columns), SummaryFields.DEFINITIONS);
         }
 
         @Override
         public @Nullable InterruptibleFuture<List<Location>> getReferences(Position cursor) {
-            return get(config.providesReferences, cursor, contrib::runReferencesService, locationMapper(columns), SummaryFields.REFERENCES);
+            return get(config.providesReferences, cursor, contrib::references, locationMapper(columns), SummaryFields.REFERENCES);
         }
 
         @Override
         public @Nullable InterruptibleFuture<List<Location>> getImplementations(Position cursor) {
-            return get(config.providesImplementations, cursor, contrib::runImplementationService, locationMapper(columns), SummaryFields.IMPLEMENTATIONS);
+            return get(config.providesImplementations, cursor, contrib::implementation, locationMapper(columns), SummaryFields.IMPLEMENTATIONS);
         }
 
         @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
@@ -268,17 +268,17 @@ class ScheduledSummaryFactory extends ParametricSummaryFactory {
         public FullScheduledSummary(InterruptibleFuture<IConstructor> calculation) {
             super(calculation);
 
-            // for temporary backward compatibility between SummaryFields.DOCUMENTATION and SummaryFields.DEPRECATED_DOCUMENTATION
+            // for temporary backward compatibility between SummaryFields.HOVERS and SummaryFields.DEPRECATED_DOCUMENTATION
             calculation = calculation.thenApply(summary -> {
                 var kws = summary.asWithKeywordParameters();
-                if (kws.hasParameter(SummaryFields.DEPRECATED_DOCUMENTATION) && !kws.hasParameter(SummaryFields.DOCUMENTATION)) {
-                    return kws.setParameter(SummaryFields.DOCUMENTATION, kws.getParameter(SummaryFields.DEPRECATED_DOCUMENTATION));
+                if (kws.hasParameter(SummaryFields.DEPRECATED_DOCUMENTATION) && !kws.hasParameter(SummaryFields.HOVERS)) {
+                    return kws.setParameter(SummaryFields.HOVERS, kws.getParameter(SummaryFields.DEPRECATED_DOCUMENTATION));
                 }
                 return summary;
             });
 
             this.documentation = config.providesHovers ?
-                mapCalculation(SummaryFields.DOCUMENTATION, calculation, SummaryFields.DOCUMENTATION, ParametricSummaryFactory::mapValueToString) : null;
+                mapCalculation(SummaryFields.HOVERS, calculation, SummaryFields.HOVERS, ParametricSummaryFactory::mapValueToString) : null;
             this.definitions = config.providesDefinitions ?
                 mapCalculation(SummaryFields.DEFINITIONS, calculation, SummaryFields.DEFINITIONS, locationMapper(columns)) : null;
             this.references = config.providesReferences ?
@@ -435,7 +435,7 @@ class OndemandSummaryFactory extends ParametricSummaryFactory {
         @Override
         @SuppressWarnings("deprecation") // For `MarkedString`
         public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getDocumentation(Position cursor) {
-            return get(config.providesHovers, cursor, contrib::runHoverService, ParametricSummaryFactory::mapValueToString, SummaryFields.DOCUMENTATION);
+            return get(config.providesHovers, cursor, contrib::runHoverService, ParametricSummaryFactory::mapValueToString, SummaryFields.HOVERS);
         }
 
         @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
@@ -72,7 +72,7 @@ import io.usethesource.vallang.IWithKeywordParameters;
 
 /**
  * The purpose of this interface is to provide a general abstraction for
- * `Position`-based look-ups of documentation, definitions, references, and
+ * `Position`-based look-ups of hovers, definitions, references, and
  * implementations, regardless of which component calculates the requested
  * information. There are two implementations:
  *
@@ -96,7 +96,7 @@ public interface ParametricSummary {
     // this happens when no on-demand summarizer exists for the requested
     // information.
     @SuppressWarnings("deprecation") // For `MarkedString`
-    @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getDocumentation(Position cursor);
+    @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getHovers(Position cursor);
     @Nullable InterruptibleFuture<List<Location>> getDefinitions(Position cursor);
     @Nullable InterruptibleFuture<List<Location>> getReferences(Position cursor);
     @Nullable InterruptibleFuture<List<Location>> getImplementations(Position cursor);
@@ -113,8 +113,8 @@ public interface ParametricSummary {
     // (i.e., it later comes from the analyzer, builder, or an on-demand
     // summarizer).
     @SuppressWarnings("deprecation") // For `MarkedString`
-    public static @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> documentation(ParametricSummary summary, Position position) {
-        return summary.getDocumentation(position);
+    public static @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> hovers(ParametricSummary summary, Position position) {
+        return summary.getHovers(position);
     }
     public static @Nullable InterruptibleFuture<List<Location>> definitions(ParametricSummary summary, Position position) {
         return summary.getDefinitions(position);
@@ -139,7 +139,7 @@ public interface ParametricSummary {
 class NullSummary implements ParametricSummary {
     @Override
     @SuppressWarnings("deprecation") // For `MarkedString`
-    public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getDocumentation(Position cursor) {
+    public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getHovers(Position cursor) {
         return null;
     }
 
@@ -260,7 +260,7 @@ class ScheduledSummaryFactory extends ParametricSummaryFactory {
 
     public class FullScheduledSummary extends MessagesOnlyScheduledSummary {
         @SuppressWarnings("deprecation") // For `MarkedString`
-        private final @Nullable InterruptibleFuture<Lazy<IRangeMap<List<Either<String, MarkedString>>>>> documentation;
+        private final @Nullable InterruptibleFuture<Lazy<IRangeMap<List<Either<String, MarkedString>>>>> hovers;
         private final @Nullable InterruptibleFuture<Lazy<IRangeMap<List<Location>>>> definitions;
         private final @Nullable InterruptibleFuture<Lazy<IRangeMap<List<Location>>>> references;
         private final @Nullable InterruptibleFuture<Lazy<IRangeMap<List<Location>>>> implementations;
@@ -277,7 +277,7 @@ class ScheduledSummaryFactory extends ParametricSummaryFactory {
                 return summary;
             });
 
-            this.documentation = config.providesHovers ?
+            this.hovers = config.providesHovers ?
                 mapCalculation(SummaryFields.HOVERS, calculation, SummaryFields.HOVERS, ParametricSummaryFactory::mapValueToString) : null;
             this.definitions = config.providesDefinitions ?
                 mapCalculation(SummaryFields.DEFINITIONS, calculation, SummaryFields.DEFINITIONS, locationMapper(columns)) : null;
@@ -289,8 +289,8 @@ class ScheduledSummaryFactory extends ParametricSummaryFactory {
 
         @Override
         @SuppressWarnings("deprecation") // For `MarkedString`
-        public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getDocumentation(Position cursor) {
-            return get(documentation, cursor);
+        public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getHovers(Position cursor) {
+            return get(hovers, cursor);
         }
 
         @Override
@@ -311,7 +311,7 @@ class ScheduledSummaryFactory extends ParametricSummaryFactory {
         @Override
         public void invalidate() {
             super.invalidate();
-            documentation.interrupt();
+            hovers.interrupt();
             definitions.interrupt();
             references.interrupt();
             implementations.interrupt();
@@ -434,7 +434,7 @@ class OndemandSummaryFactory extends ParametricSummaryFactory {
 
         @Override
         @SuppressWarnings("deprecation") // For `MarkedString`
-        public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getDocumentation(Position cursor) {
+        public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getHovers(Position cursor) {
             return get(config.providesHovers, cursor, contrib::runHoverService, ParametricSummaryFactory::mapValueToString, SummaryFields.HOVERS);
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
@@ -277,7 +277,7 @@ class ScheduledSummaryFactory extends ParametricSummaryFactory {
                 return summary;
             });
 
-            this.documentation = config.providesDocumentation ?
+            this.documentation = config.providesHovers ?
                 mapCalculation(SummaryFields.DOCUMENTATION, calculation, SummaryFields.DOCUMENTATION, ParametricSummaryFactory::mapValueToString) : null;
             this.definitions = config.providesDefinitions ?
                 mapCalculation(SummaryFields.DEFINITIONS, calculation, SummaryFields.DEFINITIONS, locationMapper(columns)) : null;
@@ -435,22 +435,22 @@ class OndemandSummaryFactory extends ParametricSummaryFactory {
         @Override
         @SuppressWarnings("deprecation") // For `MarkedString`
         public @Nullable InterruptibleFuture<List<Either<String, MarkedString>>> getDocumentation(Position cursor) {
-            return get(config.providesDocumentation, cursor, contrib::documentation, ParametricSummaryFactory::mapValueToString, SummaryFields.DOCUMENTATION);
+            return get(config.providesHovers, cursor, contrib::runHoverService, ParametricSummaryFactory::mapValueToString, SummaryFields.DOCUMENTATION);
         }
 
         @Override
         public @Nullable InterruptibleFuture<List<Location>> getDefinitions(Position cursor) {
-            return get(config.providesDefinitions, cursor, contrib::definitions, locationMapper(columns), SummaryFields.DEFINITIONS);
+            return get(config.providesDefinitions, cursor, contrib::runDefinitionService, locationMapper(columns), SummaryFields.DEFINITIONS);
         }
 
         @Override
         public @Nullable InterruptibleFuture<List<Location>> getReferences(Position cursor) {
-            return get(config.providesReferences, cursor, contrib::references, locationMapper(columns), SummaryFields.REFERENCES);
+            return get(config.providesReferences, cursor, contrib::runReferencesService, locationMapper(columns), SummaryFields.REFERENCES);
         }
 
         @Override
         public @Nullable InterruptibleFuture<List<Location>> getImplementations(Position cursor) {
-            return get(config.providesImplementations, cursor, contrib::implementations, locationMapper(columns), SummaryFields.IMPLEMENTATIONS);
+            return get(config.providesImplementations, cursor, contrib::runImplementationService, locationMapper(columns), SummaryFields.IMPLEMENTATIONS);
         }
 
         @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/RascalADTs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/RascalADTs.java
@@ -34,25 +34,25 @@ public class RascalADTs {
     public static class LanguageContributions {
         private LanguageContributions () {}
 
-        public static final String PARSING         = "parsing";
-        public static final String ANALYSIS        = "analysis";
-        public static final String BUILD           = "build";
+        public static final String PARSING = "parsing";
+        public static final String ANALYSIS = "analysis";
+        public static final String BUILD = "build";
         public static final String DOCUMENT_SYMBOL = "documentSymbol";
-        public static final String CODE_LENS       = "codeLens";
-        public static final String INLAY_HINT      = "inlayHint";
-        public static final String EXECUTION       = "execution";
-        public static final String HOVER           = "hover";
-        public static final String DEFINITION      = "definition";
-        public static final String REFERENCES      = "references";
-        public static final String IMPLEMENTATION  = "implementation";
-        public static final String CODE_ACTION     = "codeAction";
+        public static final String CODE_LENS = "codeLens";
+        public static final String INLAY_HINT = "inlayHint";
+        public static final String EXECUTION = "execution";
+        public static final String HOVER = "hover";
+        public static final String DEFINITION = "definition";
+        public static final String REFERENCES = "references";
+        public static final String IMPLEMENTATION = "implementation";
+        public static final String CODE_ACTION = "codeAction";
 
         public static class Summarizers {
             private Summarizers() {}
 
-            public static final String PROVIDES_HOVERS          = "providesHovers";
-            public static final String PROVIDES_DEFINITIONS     = "providesDefinitions";
-            public static final String PROVIDES_REFERENCES      = "providesReferences";
+            public static final String PROVIDES_HOVERS = "providesHovers";
+            public static final String PROVIDES_DEFINITIONS = "providesDefinitions";
+            public static final String PROVIDES_REFERENCES = "providesReferences";
             public static final String PROVIDES_IMPLEMENTATIONS = "providesImplementations";
         }
     }
@@ -62,9 +62,9 @@ public class RascalADTs {
 
         public static final String DEPRECATED_DOCUMENTATION = "documentation";
 
-        public static final String HOVERS          = "hovers";
-        public static final String DEFINITIONS     = "definitions";
-        public static final String REFERENCES      = "references";
+        public static final String HOVERS = "hovers";
+        public static final String DEFINITIONS = "definitions";
+        public static final String REFERENCES = "references";
         public static final String IMPLEMENTATIONS = "implementations";
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/RascalADTs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/RascalADTs.java
@@ -33,26 +33,27 @@ public class RascalADTs {
     private RascalADTs() {}
     public static class LanguageContributions {
         private LanguageContributions () {}
-        public static final String PARSER = "parsing";
-        public static final String ANALYZER = "analysis";
-        public static final String BUILDER = "build";
-        public static final String OUTLINER = "documentSymbol";
-        public static final String LENS_DETECTOR = "codeLens";
-        public static final String INLAY_HINTER = "inlayHint";
-        public static final String COMMAND_EXECUTOR = "execution";
-        public static final String DOCUMENTER = "hover";
-        public static final String DEFINER = "definition";
-        public static final String REFERRER = "references";
-        public static final String IMPLEMENTER = "implementation";
-        public static final String CODE_ACTION_CONTRIBUTOR = "codeAction";
+
+        public static final String PARSING         = "parsing";
+        public static final String ANALYSIS        = "analysis";
+        public static final String BUILD           = "build";
+        public static final String DOCUMENT_SYMBOL = "documentSymbol";
+        public static final String CODE_LENS       = "codeLens";
+        public static final String INLAY_HINT      = "inlayHint";
+        public static final String EXECUTION       = "execution";
+        public static final String HOVER           = "hover";
+        public static final String DEFINITION      = "definition";
+        public static final String REFERENCES      = "references";
+        public static final String IMPLEMENTATION  = "implementation";
+        public static final String CODE_ACTION     = "codeAction";
 
         public static class Summarizers {
             private Summarizers() {}
 
+            public static final String PROVIDES_HOVERS          = "providesHovers";
+            public static final String PROVIDES_DEFINITIONS     = "providesDefinitions";
+            public static final String PROVIDES_REFERENCES      = "providesReferences";
             public static final String PROVIDES_IMPLEMENTATIONS = "providesImplementations";
-            public static final String PROVIDES_REFERENCES = "providesReferences";
-            public static final String PROVIDES_DEFINITIONS = "providesDefinitions";
-            public static final String PROVIDES_DOCUMENTATION = "providesDocumentation";
         }
     }
 
@@ -60,11 +61,11 @@ public class RascalADTs {
         private SummaryFields() {}
 
         public static final String DEPRECATED_DOCUMENTATION = "documentation";
-        public static final String DOCUMENTATION = "hovers";
-        public static final String DEFINITIONS = "definitions";
-        public static final String REFERENCES = "references";
-        public static final String IMPLEMENTATIONS = "implementations";
 
+        public static final String HOVERS          = "hovers";
+        public static final String DEFINITIONS     = "definitions";
+        public static final String REFERENCES      = "references";
+        public static final String IMPLEMENTATIONS = "implementations";
     }
 
     public static class CommandFields {
@@ -81,5 +82,4 @@ public class RascalADTs {
         public static final String TITLE = "title";
         public static final String KIND = "kind";
     }
-
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -79,7 +79,7 @@ public class RascalLanguageServices {
 
     private static final Logger logger = LogManager.getLogger(RascalLanguageServices.class);
 
-    private final CompletableFuture<Evaluator> outlineEvaluator;
+    private final CompletableFuture<Evaluator> documentSymbolEvaluator;
     private final CompletableFuture<Evaluator> semanticEvaluator;
     private final CompletableFuture<Evaluator> compilerEvaluator;
 
@@ -97,7 +97,7 @@ public class RascalLanguageServices {
 
         var monitor = new RascalLSPMonitor(client, logger);
 
-        outlineEvaluator = makeFutureEvaluator(exec, docService, workspaceService, client, "Rascal outline", monitor, null, false, "lang::rascal::lsp::DocumentSymbols");
+        documentSymbolEvaluator = makeFutureEvaluator(exec, docService, workspaceService, client, "Rascal document symbols", monitor, null, false, "lang::rascal::lsp::DocumentSymbols");
         semanticEvaluator = makeFutureEvaluator(exec, docService, workspaceService, client, "Rascal semantics", monitor, null, true, "lang::rascalcore::check::Summary", "lang::rascal::lsp::refactor::Rename");
         compilerEvaluator = makeFutureEvaluator(exec, docService, workspaceService, client, "Rascal compiler", monitor, null, true, "lang::rascalcore::check::Checker");
     }
@@ -181,14 +181,14 @@ public class RascalLanguageServices {
     }
 
 
-    public InterruptibleFuture<IList> getOutline(IConstructor module) {
+    public InterruptibleFuture<IList> getDocumentSymbols(IConstructor module) {
         ISourceLocation loc = getFileLoc((ITree) module);
         if (loc == null) {
             return new InterruptibleFuture<>(CompletableFuture.completedFuture(VF.list()), () -> {
             });
         }
 
-        return runEvaluator("Rascal Document Symbols", outlineEvaluator, eval -> (IList) eval.call("documentRascalSymbols", module),
+        return runEvaluator("Rascal Document Symbols", documentSymbolEvaluator, eval -> (IList) eval.call("documentRascalSymbols", module),
             VF.list(), exec, false, client);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -269,7 +269,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .thenApply(Versioned::get)
             .handle((t, r) -> (t == null ? (file.getMostRecentTree().get()) : t))
             .thenCompose(tr -> rascalServices.getDocumentSymbols(tr).get())
-            .thenApply(c -> Outline.buildOutline(c, columns.get(file.getLocation())))
+            .thenApply(documentSymbols -> Outline.toLSP(documentSymbols, columns.get(file.getLocation())))
             ;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -98,7 +98,7 @@ import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.util.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.DocumentChanges;
 import org.rascalmpl.vscode.lsp.util.FoldingRanges;
-import org.rascalmpl.vscode.lsp.util.Outline;
+import org.rascalmpl.vscode.lsp.util.DocumentSymbols;
 import org.rascalmpl.vscode.lsp.util.SemanticTokenizer;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
@@ -269,7 +269,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .thenApply(Versioned::get)
             .handle((t, r) -> (t == null ? (file.getMostRecentTree().get()) : t))
             .thenCompose(tr -> rascalServices.getDocumentSymbols(tr).get())
-            .thenApply(documentSymbols -> Outline.toLSP(documentSymbols, columns.get(file.getLocation())))
+            .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, columns.get(file.getLocation())))
             ;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -268,7 +268,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return file.getCurrentTreeAsync()
             .thenApply(Versioned::get)
             .handle((t, r) -> (t == null ? (file.getMostRecentTree().get()) : t))
-            .thenCompose(tr -> rascalServices.getOutline(tr).get())
+            .thenCompose(tr -> rascalServices.getDocumentSymbols(tr).get())
             .thenApply(c -> Outline.buildOutline(c, columns.get(file.getLocation())))
             ;
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -158,6 +158,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         result.setFoldingRangeProvider(true);
         result.setRenameProvider(true);
     }
+
     @Override
     public void pair(BaseWorkspaceService workspaceService) {
         this.workspaceService = workspaceService;
@@ -176,14 +177,14 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     @Override
     public void didOpen(DidOpenTextDocumentParams params) {
-        logger.debug("Open file: {}", params.getTextDocument());
+        logger.debug("Open: {}", params.getTextDocument());
         TextDocumentState file = open(params.getTextDocument());
         handleParsingErrors(file);
     }
 
     @Override
     public void didChange(DidChangeTextDocumentParams params) {
-        logger.trace("Change contents: {}", params.getTextDocument());
+        logger.trace("Change: {}", params.getTextDocument());
         updateContents(params.getTextDocument(), last(params.getContentChanges()).getText());
     }
 
@@ -244,10 +245,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         handleParsingErrors(file,file.getCurrentTreeAsync());
     }
 
-
     @Override
     public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(DefinitionParams params) {
-        logger.debug("Definition: {} at {}", params.getTextDocument(), params.getPosition());
+        logger.debug("textDocument/definition: {} at {}", params.getTextDocument(), params.getPosition());
 
         if (facts != null) {
             return facts.getSummary(Locations.toLoc(params.getTextDocument()))
@@ -263,7 +263,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     @Override
     public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>>
         documentSymbol(DocumentSymbolParams params) {
-        logger.debug("Outline/documentSymbol: {}", params.getTextDocument());
+        logger.debug("textDocument/documentSymbol: {}", params.getTextDocument());
         TextDocumentState file = getFile(params.getTextDocument());
         return file.getCurrentTreeAsync()
             .thenApply(Versioned::get)
@@ -429,6 +429,4 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         logger.warn("ignoring execute command in Rascal LSP: {}, {}", extension, command);
         return CompletableFuture.completedFuture(null);
     }
-
-
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentSymbols.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentSymbols.java
@@ -42,9 +42,9 @@ import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IString;
 import io.usethesource.vallang.IWithKeywordParameters;
 
-public class Outline {
+public class DocumentSymbols {
     // hide constructor for static class
-    private Outline() {}
+    private DocumentSymbols() {}
 
     private static String capitalize(String kindName) {
         return kindName.substring(0,1).toUpperCase() + kindName.substring(1);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Outline.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Outline.java
@@ -53,29 +53,29 @@ public class Outline {
     /**
      * Converts a list of Rascal DocumentSymbols (@see util::IDE) to LSP DocumentSymbols
      * @param symbols list of Rascal DocumentSymbols
-     * @param om line/column offset map
+     * @param om      line/column offset map
      * @return list of LSP DocumentSymbols
      */
-    public static List<Either<SymbolInformation, DocumentSymbol>> buildOutline(IList symbols, LineColumnOffsetMap om) {
+    public static List<Either<SymbolInformation, DocumentSymbol>> toLSP(IList symbols, LineColumnOffsetMap om) {
         return symbols.stream()
-                .map(s -> buildParametricOutline((IConstructor) s, om))
+                .map(s -> toLSP((IConstructor) s, om))
                 .map(Either::<SymbolInformation, DocumentSymbol>forRight)
                 .collect(Collectors.toList());
     }
 
     /**
-     * Converts a constructor tree of Rascal type DocumentSymbol from util::IDE to an LSP DocumentSymbol
+     * Converts a constructor tree of Rascal type DocumentSymbol (@see util::IDE) to an LSP DocumentSymbol
      * @param symbol IConstructor of Rascal type DocumentSymbol
      * @param om     line/column offset map
-     * @return a DocumentSymbol
+     * @return an LSP DocumentSymbol
      */
-    public static DocumentSymbol buildParametricOutline(IConstructor symbol, final LineColumnOffsetMap om) {
+    public static DocumentSymbol toLSP(IConstructor symbol, final LineColumnOffsetMap om) {
         IWithKeywordParameters<?> kwp = symbol.asWithKeywordParameters();
 
         List<DocumentSymbol> children = kwp.hasParameter("children") ?
             ((IList) kwp.getParameter("children"))
                 .stream()
-                .map(c -> buildParametricOutline((IConstructor) c, om))
+                .map(c -> toLSP((IConstructor) c, om))
                 .collect(Collectors.toList())
             : Collections.emptyList();
 


### PR DESCRIPTION
**Note:** All tests actually succeed, but SonarCloud is unhappy about "new" code duplication in `LanguageContributionsMultiplexer` and `InterpretedLanguageContributions`. This duplication was already there, but because the lines have changed due to renaming, SonarCloud is triggered.