### PR TITLE
Refine resolution of overloaded constructor & field declarations

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -48,19 +48,12 @@ import String;
 import lang::rascal::\syntax::Rascal;
 
 import lang::rascalcore::check::Checker;
-import lang::rascalcore::check::Import;
-import lang::rascalcore::check::RascalConfig;
-
-import analysis::typepal::TypePal;
-import analysis::typepal::Collector;
 
 extend lang::rascal::lsp::refactor::Exception;
 import lang::rascal::lsp::refactor::Util;
 import lang::rascal::lsp::refactor::WorkspaceInfo;
 
 import analysis::diff::edits::TextEdits;
-
-import vis::Text;
 
 import util::FileSystem;
 import util::Maybe;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -279,7 +279,7 @@ Maybe[AType] rascalConsFieldType(str fieldName, Define _:<_, _, _, constructorId
 
 private CursorKind rascalGetDataFieldCursorKind(WorkspaceInfo ws, loc container, loc cursorLoc, str cursorName) {
     for (Define dt <- rascalGetADTDefinitions(ws, container)
-        , adtType := dt.defInfo.atype) {
+        , AType adtType := dt.defInfo.atype) {
         if (just(fieldType) := rascalAdtCommonKeywordFieldType(ws, cursorName, dt)) {
             // Case 4 or 5 (or 0): common keyword field
             return dataCommonKeywordField(dt.defined, fieldType);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -193,7 +193,8 @@ set[Define] rascalReachableDefs(WorkspaceInfo ws, set[loc] defs) {
     rel[loc from, loc to] modulePaths = rascalGetTransitiveReflexiveModulePaths(ws);
     rel[loc from, loc to] scopes = rascalGetTransitiveReflexiveScopes(ws);
     rel[loc from, Define define] reachableDefs =
-        (ws.defines<defined, defined, scope>)[defs]             // <definition, scope> pairs
+        ((ws.defines<defined, defined, scope>)[defs]             // <definition, scope> pairs
+        + (ws.defines<scope, defined, scope>)[defs])
       o (
          (scopes                                                // All scopes surrounding defs
         o modulePaths                                           // Transitive-reflexive paths from scope to reachable modules

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -248,13 +248,13 @@ set[loc] rascalGetOverloadedDefs(WorkspaceInfo ws, set[loc] defs, MayOverloadFun
         defPaths = defPaths o allDefs;
     }
 
-    solve(overloadedDefs) {
-        rel[loc from, loc to] reachableDefs = ident(overloadedDefs) o defPaths;
-
+    set[loc] reachableDefs = defPaths[overloadedDefs];
+    solve(overloadedDefs, reachableDefs) {
         overloadedDefs += {d
-            | loc d <- reachableDefs<1>
+            | loc d <- reachableDefs
             , mayOverloadF(overloadedDefs + d, ws.definitions)
         };
+        reachableDefs = defPaths[overloadedDefs];
     }
 
     return overloadedDefs;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -453,9 +453,9 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(typeParam(), cursorLo
         });
     }
 
-    bool definesTypeParam(Define _: <_, _, _, functionId(), _, defType(dT)>, AType paramType) =
+    bool definesTypeParam(Define _: <_, _, _, functionId(), _, defType(AType dT)>, AType paramType) =
         afunc(_, /paramType, _) := dT;
-    bool definesTypeParam(Define _: <_, _, _, nonterminalId(), _, defType(dT)>, AType paramType) =
+    bool definesTypeParam(Define _: <_, _, _, nonterminalId(), _, defType(AType dT)>, AType paramType) =
         aadt(_, /paramType, _) := dT;
     default bool definesTypeParam(Define _, AType _) = false;
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -237,12 +237,20 @@ set[loc] rascalGetOverloadedDefs(WorkspaceInfo ws, set[loc] defs, MayOverloadFun
       o scopeDefs                  // 3. Find definitions in the reached scope, and definitions within those definitions (transitively)
       ;
 
-    rel[loc from, loc to] defPaths = {};
+    rel[loc from, loc to] defPaths = fromDefPaths;
     if (constructorId() := role) {
         // We are just looking for constructors for the same ADT/nonterminal type
         rel[loc, loc] selectedConstructors = (ws.defines<defInfo, defined, defined>)[originalDefs.defInfo];
         defPaths = (defPaths o selectedConstructors)
                  + (invert(defPaths) o selectedConstructors);
+    } else if (fieldId() := role) {
+        // We are looking for fields for the same ADT type (but not necessarily same constructor type)
+        set[DefInfo] selectedADTTypes = (ws.defines<defined, defInfo>)[originalDefs.scope];
+        rel[loc, loc] selectedADTs = (ws.defines<defInfo, defined, defined>)[selectedADTTypes];
+        rel[loc, loc] selectedFields = selectedADTs o ws.defines<scope, defined>;
+
+        defPaths = (defPaths o selectedFields)
+                 + invert(defPaths) o selectedFields;
     } else {
         defPaths = fromDefPaths + invert(fromDefPaths);
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
@@ -59,6 +59,27 @@ test bool constructorNameUsedAsVar() = testRenameOccurrences({
            'int foo = 8;", {})
 });
 
+test bool constructorInPattern() = testRenameOccurrences({0, 1, 2, 3}, "
+    'Foo f = foo(8);
+    'if (foo(_) := f) {
+    '   int x = match(f);
+    '}
+", decls = "
+    'data Foo = foo(int i);
+    'int match(foo(int i)) = i;
+");
+
+test bool constructorIsCheck() = testRenameOccurrences({0, 1, 2, 3}, "
+    'Foo f = foo(8);
+    'isFoo(f);
+", decls = "
+    'data Foo
+    '   = foo(int i)
+    '   | foo(int i, int j)
+    '   | baz();
+    bool isFoo(Foo f) = f is foo;
+");
+
 test bool constructorsAndTypesInVModuleStructure() = testRenameOccurrences({
     byText("Left", "data Foo = foo();", {0}), byText("Right", "data Foo = foo(int i);", {0})
                     , byText("Merger",

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
@@ -1,0 +1,247 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::rename::Constructors
+
+import lang::rascal::tests::rename::TestUtils;
+
+test bool extendedConstructor() = testRenameOccurrences({
+    byText("Definer", "data Foo = foo(int i);", {0})
+  , byText("Extender",
+           "extend Definer;
+           'data Foo = foo(int i, int j);
+           'void main() {
+           '   Foo f = foo(8);
+           '}", {0, 1})
+});
+
+test bool disjunctConstructor() = testRenameOccurrences({
+    byText("Definer", "data Foo = foo(int i);", {0})
+  , byText("Unrelated",
+           "data Foo = foo();", {})
+});
+
+test bool differentADTsDuplicateConstructorNames() = testRenameOccurrences({
+    byText("A", "data Bar = foo();", {0})
+  , byText("B",
+           "extend A;
+           'data Foo = foo(int i);
+           'Bar f = foo();", {1})
+});
+
+test bool constructorNameUsedAsVar() = testRenameOccurrences({
+    byText("Constructor", "data Foo = foo();", {0})
+  , byText("OtherType",
+           "import Constructor;
+           'int foo = 8;", {})
+});
+
+test bool constructorsAndTypesInVModuleStructure() = testRenameOccurrences({
+    byText("Left", "data Foo = foo();", {0}), byText("Right", "data Foo = foo(int i);", {0})
+                    , byText("Merger",
+                        "import Left;
+                        'import Right;
+                        'bool f(Foo f) = (f == foo() || f == foo(1));
+                        ", {0, 1})
+});
+
+test bool constructorsVModuleStructure() = testRenameOccurrences({
+    byText("Left", "data Foo = foo();", {0}), byText("Right", "data Foo = foo(int i);", {0})
+                    , byText("Merger",
+                        "import Left;
+                        'import Right;
+                        'bool f(foo()) = true;
+                        ", {0})
+});
+
+@synopsis{
+    (defs)
+    /    \
+    A  B  C
+     \/ \/
+      D E
+     /   \
+     (uses)
+}
+test bool constructorsAndTypesInWModuleStructureWithoutMerge() = testRenameOccurrences({
+    byText("A", "data Foo = foo();", {0}), byText("B", "", {}), byText("C", "data Foo = foo(int i, int j);", {})
+                    , byText("D",
+                        "import A;
+                        'import B;
+                        'bool func(Foo f) = f == foo();
+                        ", {0}),    byText("E",
+                                        "import B;
+                                        'import C;
+                                        'bool func(Foo f) = f == foo(8, 54);", {})
+});
+
+@synopsis{
+    (defs)
+    /    \
+    A  B  C
+     \/ \/
+      D E
+     /   \
+     (uses)
+}
+test bool constructorsInWModuleStructureWithoutMerge() = testRenameOccurrences({
+    byText("A", "data Foo = foo();", {0}), byText("B", "", {}), byText("C", "data Foo = foo(int i, int j);", {})
+                    , byText("D",
+                        "import A;
+                        'import B;
+                        'bool func(foo()) = true;
+                        ", {0}),    byText("E",
+                                        "import B;
+                                        'import C;
+                                        'bool func(foo(8, 54)) = true;", {})
+});
+
+@synopsis{
+    (defs)
+    /  | \
+    v  v  v
+    A  B  C
+     \/ \/
+      D E
+      ^ ^
+     /   \
+     (uses)
+}
+test bool constructorsAndTypesInWModuleStructureWithMerge() = testRenameOccurrences({
+    byText("A", "data Foo = foo();", {0}), byText("B", "data Foo = foo(int i);", {0}), byText("C", "data Foo = foo(int i, int j);", {0})
+                    , byText("D",
+                        "import A;
+                        'import B;
+                        'bool func(Foo f) = f == foo();
+                        ", {0}),    byText("E",
+                                        "import B;
+                                        'import C;
+                                        'bool func(Foo f) = f == foo(8, 54);", {0})
+});
+
+@synopsis{
+    (defs)
+    /  | \
+    v  v  v
+    A  B  C
+     \/ \/
+      D E
+      ^ ^
+     /   \
+     (uses)
+}
+test bool constructorsInWModuleStructureWithMerge() = testRenameOccurrences({
+    byText("A", "data Foo = foo();", {0}), byText("B", "data Foo = foo(int i);", {0}), byText("C", "data Foo = foo(int i, int j);", {0})
+                    , byText("D",
+                        "import A;
+                        'import B;
+                        'bool func(foo()) = true;
+                        ", {0}),    byText("E",
+                                        "import B;
+                                        'import C;
+                                        'bool func(foo(8, 54)) = true;", {0})
+});
+
+test bool constructorsAndTypesInYModuleStructure() = testRenameOccurrences({
+    byText("Left", "data Foo = foo();", {0}), byText("Right", "data Foo = foo(int i);", {0})
+                    , byText("Merger",
+                        "extend Left;
+                        'extend Right;
+                        ", {})
+                    , byText("User",
+                        "import Merger;
+                        'bool f(Foo f) = (f == foo() || f == foo(1));
+                        ", {0, 1})
+});
+
+test bool constructorsInYModuleStructure() = testRenameOccurrences({
+    byText("Left", "data Foo = foo();", {0}), byText("Right", "data Foo = foo(int i);", {0})
+                    , byText("Merger",
+                        "extend Left;
+                        'extend Right;
+                        ", {})
+                    , byText("User",
+                        "import Merger;
+                        'bool f(foo()) = true;
+                        'bool f(foo(1)) = true;
+                        ", {0, 1})
+});
+
+test bool constructorsAndTypesInInvertedVModuleStructure() = testRenameOccurrences({
+            byText("Definer", "data Foo = foo() | foo(int i);", {0, 1}),
+    byText("Left", "import Definer;
+                   'bool isF(Foo f) = f == foo();", {0}), byText("Right", "import Definer;
+                                                                          'bool isG(Foo f) = f == foo(1);", {0})
+});
+
+test bool constructorsInInvertedVModuleStructure() = testRenameOccurrences({
+            byText("Definer", "data Foo = foo() | foo(int i);", {0, 1}),
+    byText("Left", "import Definer;
+                   'bool isF(foo()) = true;", {0}), byText("Right", "import Definer;
+                                                                    'bool isG(foo(1)) = true;", {0})
+});
+
+test bool constructorsAndTypesInDiamondModuleStructure() = testRenameOccurrences({
+            byText("Definer", "data Foo = foo() | foo(int i);", {0, 1}),
+    byText("Left", "extend Definer;", {}), byText("Right", "extend Definer;", {}),
+            byText("User", "import Left;
+                           'import Right;
+                           'bool isF(Foo f) = f == foo();
+                           'bool isG(Foo f) = f == foo(8);", {0, 1})
+});
+
+test bool constructorsInDiamondModuleStructure() = testRenameOccurrences({
+            byText("Definer", "data Foo = foo() | foo(int i);", {0, 1}),
+    byText("Left", "extend Definer;", {}), byText("Right", "extend Definer;", {}),
+            byText("User", "import Left;
+                           'import Right;
+                           'bool isF(foo()) = true;
+                           'bool isG(foo(8)) = true;", {0, 1})
+});
+
+@synopsis{
+    Two disjunct module trees. Both trees define `data Foo`. Since the trees are disjunct,
+    we expect a renaming triggered from the left side leaves the right side untouched.
+}
+test bool constructorsAndTypesInIIModuleStructure() = testRenameOccurrences({
+    byText("LeftDefiner", "data Foo = foo();", {0}),              byText("RightDefiner", "data Foo = foo(int i);", {}),
+    byText("LeftExtender", "extend LeftDefiner;", {}),            byText("RightExtender", "extend RightDefiner;", {}),
+    byText("LeftUser", "import LeftExtender;
+                       'bool func(Foo f) = f == foo();", {0}),       byText("RightUser", "import RightExtender;
+                                                                            'bool func(Foo f) = f == foo(8);", {})
+});
+
+@synopsis{
+    Two disjunct module trees. Both trees define `data Foo`. Since the trees are disjunct,
+    we expect a renaming triggered from the left side leaves the right side untouched.
+}
+test bool constructorsInIIModuleStructure() = testRenameOccurrences({
+    byText("LeftDefiner", "data Foo = foo();", {0}),              byText("RightDefiner", "data Foo = foo(int i);", {}),
+    byText("LeftExtender", "extend LeftDefiner;", {}),            byText("RightExtender", "extend RightDefiner;", {}),
+    byText("LeftUser", "import LeftExtender;
+                       'bool func(foo()) = true;", {0}),       byText("RightUser", "import RightExtender;
+                                                                      'bool func(foo(8)) = true;", {})
+});

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -81,6 +81,19 @@ test bool commonKeywordFieldsSameType() = testRenameOccurrences({0, 1},
     decls = "data D (set[loc] foo = {}, set[loc] baz = {})= d();"
 );
 
+test bool sameNameFields() = testRenameOccurrences({0, 2}, "
+    'D x = d(8);
+    'int i = x.foo;
+", decls = "
+    'data D = d(int foo);
+    'data E = e(int foo);
+");
+
+test bool sameNameFieldsDisconnectedModules() = testRename({
+    byText("A", "data D = d(int foo);", {0})
+  , byText("B", "data E = e(int foo);")
+});
+
 test bool complexDataType() = testRenameOccurrences({0, 1},
     "WorkspaceInfo ws = workspaceInfo(
     '   ProjectFiles() { return {}; },

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -47,8 +47,6 @@ test bool commonKeywordField() = testRenameOccurrences({0, 1, 2}, "
     ", decls = "data D(int foo = 0, int baz = 0) = d();"
 );
 
-// Flaky. Fix for non-determinism in typepal, upcoming in future release of Rascal (Core)
-// https://github.com/usethesource/typepal/commit/55456edcc52653e42d7f534a5412147b01b68c29
 test bool multipleConstructorField() = testRenameOccurrences({0, 1, 2}, "
     'x = d(1, 2);
     'y = x.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -87,6 +87,11 @@ test bool sameNameFields() = testRenameOccurrences({0, 2}, "
     'data E = e(int foo);
 ");
 
+test bool sameNameADTFields() = testRenameOccurrences({
+    byText("Definer", "data D = d(int foo);", {0})
+  , byText("Unrelated", "data D = d(int foo);", {})
+});
+
 test bool sameNameFieldsDisconnectedModules() = testRenameOccurrences({
     byText("A", "data D = d(int foo);", {0})
   , byText("B", "data E = e(int foo);", {})

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -87,9 +87,9 @@ test bool sameNameFields() = testRenameOccurrences({0, 2}, "
     'data E = e(int foo);
 ");
 
-test bool sameNameFieldsDisconnectedModules() = testRename({
+test bool sameNameFieldsDisconnectedModules() = testRenameOccurrences({
     byText("A", "data D = d(int foo);", {0})
-  , byText("B", "data E = e(int foo);")
+  , byText("B", "data E = e(int foo);", {})
 });
 
 test bool complexDataType() = testRenameOccurrences({0, 1},

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -145,7 +145,7 @@ bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str new
             success = false;
         }
 
-        for (src <- pcfg.srcs) {
+        for (success, src <- pcfg.srcs) {
             verifyTypeCorrectRenaming(src, edits, pcfg);
         }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -101,6 +101,15 @@ bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str new
 
         pcfg = getTestPathConfig(testDir);
         modulesByLocation = {mByLoc | m <- modules, mByLoc := (m is byLoc ? m : byLoc(storeTestModule(testDir, m.name, m.body), m.nameOccs, newName = m.newName, skipCursors = m.skipCursors))};
+
+        for (byLoc(loc ml, _) <- modulesByLocation) {
+            try {
+                parseModuleWithSpaces(ml);
+            } catch _: {
+                throw "Parse error in test module <ml>";
+            }
+        }
+
         cursorT = findCursor([m.file | m <- modulesByLocation, getModuleName(m.file, pcfg) == mm.name][0], oldName, cursorOcc);
 
         println("Renaming \'<oldName>\' from <cursorT.src>");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -89,7 +89,7 @@ bool expectEq(&T expected, &T actual, str epilogue = "") {
 bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str newName = "bar") {
     bool success = true;
     for (mm <- modules, cursorOcc <- (mm.nameOccs - mm.skipCursors)) {
-        str testName = "Test<abs(arbInt(10))>";
+        str testName = "Test_<mm.name>_<cursorOcc>";
         loc testDir = |memory://tests/rename/<testName>|;
 
         if(any(m <- modules, m is byLoc)) {
@@ -248,7 +248,7 @@ list[DocumentEdit] getEdits(str stmtsStr, int cursorAtOldNameOccurrence, str old
     return edits;
 }
 
-private tuple[list[DocumentEdit], set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports, str moduleName = "TestModule<abs(arbInt(10))>") {
+private tuple[list[DocumentEdit], set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNameOccurrence, str oldName, str newName, str decls, str imports, str moduleName = "TestModule") {
     str moduleStr =
     "module <moduleName>
     '<trim(imports)>


### PR DESCRIPTION
1. Field with identical name/type signatures from distinct ADTs would incorrectly be classified as mutual overloads.
2. Constructor overloads where not detected correctly, and no constructor tests existed at all.

This PR refines the overload detection to solve both issues, and adds many tests.