### PR TITLE
Enable bracket matching in strings and comments (i.e., restore old be…

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -133,12 +133,20 @@
       {
         "language": "rascalmpl",
         "scopeName": "source.rascalmpl",
-        "path": "./syntaxes/rascal.tmGrammar.json"
+        "path": "./syntaxes/rascal.tmGrammar.json",
+        "tokenTypes": {
+          "string": "other",
+          "comment": "other"
+        }
       },
       {
         "language": "parametric-rascalmpl",
         "scopeName": "source.parametric-rascalmpl",
-        "path": "./syntaxes/parametric.tmGrammar.json"
+        "path": "./syntaxes/parametric.tmGrammar.json",
+        "tokenTypes": {
+          "string": "other",
+          "comment": "other"
+        }
       }
     ],
     "semanticTokenScopes": [


### PR DESCRIPTION
### Abstract

This PR restores the past behavior (pre-TextMate integration) of bracket matching.

Note: This PR changes only a few lines in `package.json`. The long description below serves to explain what/why these changes do.

### Background on bracket matching in VS Code

  - VS Code assigns one of four [*standard token types*](https://github.com/microsoft/vscode/blob/89d6652d8f895f097de8c6ebb06981f92e59a130/src/vs/editor/common/encodedTokenAttributes.ts#L38-L43) to each token: `Other`, `Comment`, `String`, or `RegEx`. Standard token types are also [referred to](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#tokenization) as "content mode".
  - Standard token types are different from semantic token types and TextMate scopes. The standard token type of each token is derived from its TextMate scope (not from its semantic token type; this might be a [bug](https://github.com/microsoft/vscode/issues/229530)).
  - Only brackets that occur in `Other` tokens seem to be [taken into account](https://github.com/microsoft/vscode/blob/89d6652d8f895f097de8c6ebb06981f92e59a130/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts#L199-L204) for matching and colorization. The algorithm is [non-trivial](https://code.visualstudio.com/blogs/2021/09/29/bracket-pair-colorization), though, so I might have missed something in the implementation, but it's consistent with empirical observations.

### Past behavior (pre-TextMate integration; `v11.x.y` and earlier)

In the past, without TextMate tokenization, each token is assigned standard token type `Other`. As a result, all brackets (including those that occur in comments and strings) are taken into account for matching and highlighting. This is demonstrated in the following screenshot:

![image](https://github.com/user-attachments/assets/c190099a-7d47-4f89-bf26-3da02879e7ab)

Note:
  - The TextMate scope is `source.rascalmpl`
  - The semantic token type is `string`
  - The standard token type (derived from the TextMate scope) is `Other`

See also: #214

### Present behavior (post-TextMate integration; [d1097f1](https://github.com/usethesource/rascal-language-servers/commit/d1097f165b1230ff66081598cd06e6c06ec48763))

In the present, with TextMate tokenization, comments and strings are assigned standard token types `Comment` and `String`. However, because the TextMate grammar is sometimes imprecise, non-comments/strings are sometimes mistakenly assigned standard token types `Comment`/`String`. The semantic tokenizer corrects this, but as semantic token types do not affect standard token types, the standard token types remain `Comment`/`String`. As a result, some brackets are mistakenly *not* taken into account for matching and highlighting. This is demonstrated in the following screenshot (i.e., the closing bracket on line 4 is colorized as not-matched):

![image](https://github.com/user-attachments/assets/4a1e77b3-9297-4c63-9ec3-d2806ff8a8aa)

Note:
  - The TextMate scope of the opening bracket is `string.quoted.double` (misclassification)
  - The semantic token type is `uncategorized` (correction)
  - The standard token type remains `String`, so the bracket is not taken into account

### Future behavior (after this PR)

The past behavior is restored by explicitly configuring that TextMate scopes for comments and strings should be mapped to standard token type `Other`. Screenshot:

![image](https://github.com/user-attachments/assets/7532b5c0-92c3-45b3-a1c1-5c4d9b0dc985)
