### PR TITLE
Both outline and codelenses support can now handle error trees

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/Outline.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/Outline.rsc
@@ -45,7 +45,7 @@ list[DocumentSymbol] outlineRascalModule(start[Module] \mod) {
     top-down-break visit (m) {
         case decl: (Declaration) `<Tags _> <Visibility _> <Type t> <{Variable ","}+ vars>;`:
             if (!hasErrors(decl)) {
-                children += [symbol(clean("<v.name>"), variable(), v@\loc, detail="variable <t> <v>") | v <- vars, !hasErrors(v)];
+                children += [symbol(clean("<v.name>"), variable(), v@\loc, detail="variable <t> <v>") | v <- vars];
             }
 
         case decl: (Declaration) `<Tags _> <Visibility _> anno <Type t> <Type ot>@<Name name>;`:


### PR DESCRIPTION
Both `locateCodeLenses` (in `RascalLanguageServices.java`) and `outlineRascalModule` (in `Outline.rsc`) would crash if they encountered trees with error nodes.

This PR fixes these problems.

In case of the outline, elements with errors are removed from the outline.

In case of the code lenses, top-level elements with errors are ignored for code lenses.
