### PR TITLE
Add semantic tokenizer tests

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizerTester.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizerTester.java
@@ -1,0 +1,31 @@
+package org.rascalmpl.vscode.lsp.util;
+
+import org.rascalmpl.values.IRascalValueFactory;
+import org.rascalmpl.values.parsetrees.ITree;
+
+import io.usethesource.vallang.IBool;
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.IValue;
+
+public class SemanticTokenizerTester {
+
+    public IValue toTokens(IConstructor tree, IBool applyRascalCategoryPatch) {
+        var tokenizer = new SemanticTokenizer(applyRascalCategoryPatch.getValue());
+        var encoded = tokenizer.semanticTokensFull((ITree) tree).getData();
+
+        var values = IRascalValueFactory.getInstance();
+        var tokens = new IValue[encoded.size() / 5];
+        var tokenTypes = tokenizer.capabilities().getTokenTypes();
+
+        for (int i = 0; i < encoded.size(); i += 5) {
+            var deltaLine     = values.integer(encoded.get(i));
+            var deltaStart    = values.integer(encoded.get(i + 1));
+            var length        = values.integer(encoded.get(i + 2));
+            var tokenType     = values.string(tokenTypes.get(encoded.get(i + 3)));
+            var tokenModifier = values.string(""); // Token modifiers aren't supported yet
+            tokens[i / 5] = values.tuple(deltaLine, deltaStart, length, tokenType, tokenModifier);
+        }
+
+        return values.list(tokens);
+    }
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizerTester.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizerTester.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.rascalmpl.vscode.lsp.util;
 
 import org.rascalmpl.values.IRascalValueFactory;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/NestedCategories.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/NestedCategories.rsc
@@ -1,0 +1,93 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::semanticTokenizer::NestedCategories
+
+import lang::rascal::tests::semanticTokenizer::Util;
+
+// -------
+// Grammar
+
+syntax Type
+    = TypeParameter
+    | @category="type" "str"
+    | @category="type" "map" "[" Type "," Type "]"
+    ;
+
+lexical TypeParameter
+    = @category="typeParameter" "&" Alnum+;
+
+lexical String
+    = @category="string" "\"" (Alnum | ("\<" Variable "\>"))* "\"";
+
+lexical Variable
+    = @category="variable" Alnum+;
+
+lexical Interface
+    = @category="interface" "I" Class;
+
+lexical Class
+    = @category="class" Upper Alnum*;
+
+lexical Alnum = [0-9 A-Z a-z];
+lexical Upper = [A-Z];
+
+// -----
+// Tests
+
+test bool testType() = testTokenizer(#Type,
+
+    "map[str,&T0]",
+
+    expectFirst("map[str,", "type"),
+    expectFirst("&T0", "typeParameter"), // Inner over outer
+    expectFirst("]", "type")
+);
+
+test bool testString() = testTokenizer(#String,
+
+    "\"foo\<bar\>\"",
+
+    expectFirst("\"foo\<", "string"),
+    expectFirst("bar", "variable"), // Inner over outer
+    expectFirst("\>\"", "string")
+);
+
+test bool testInterface() = testTokenizer(#Interface,
+
+    "IFoo",
+
+    expectFirst("I", "interface"),
+    expectFirst("Foo", "class"),
+    expectEachNot("IFoo", "interface") // *Not* outer over inner
+
+    // This test demonstrates that, sometimes, arguably the "natural" way to
+    // write a grammar (e.g., "An interface name is just any class name, but
+    // prefixed with an I") requires outer-over-inner semantic tokenization.
+    // This is currently not supported (i.e., the only "solution" right now is
+    // to rewrite the grammar). Further reading:
+    // https://github.com/usethesource/rascal-language-servers/issues/456
+);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
@@ -26,10 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module lang::rascal::tests::semanticTokenizer::Pico
 
-import IO;
-import ParseTree;
 import lang::pico::\syntax::Main;
-
 import lang::rascal::tests::semanticTokenizer::Util;
 
 // https://github.com/usethesource/rascal-language-servers/issues/90

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
@@ -26,10 +26,16 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module lang::rascal::tests::semanticTokenizer::Pico
 
-import lang::pico::\syntax::Main;
 import lang::rascal::tests::semanticTokenizer::Util;
 
-// https://github.com/usethesource/rascal-language-servers/issues/90
+// -------
+// Grammar
+
+import lang::pico::\syntax::Main;
+
+// -----
+// Tests
+
 test bool testKeywordLastLine() = testTokenizer(#Program,
 
    "begin
@@ -41,5 +47,5 @@ test bool testKeywordLastLine() = testTokenizer(#Program,
         y := x + 1
     end",
 
-    firstOccurrenceOf("end", "keyword")
+    expectFirst("end", "keyword") // Fixed: https://github.com/usethesource/rascal-language-servers/issues/90
 );

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
@@ -1,0 +1,48 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::semanticTokenizer::Pico
+
+import IO;
+import ParseTree;
+import lang::pico::\syntax::Main;
+
+import lang::rascal::tests::semanticTokenizer::Util;
+
+// https://github.com/usethesource/rascal-language-servers/issues/90
+test bool testKeywordLastLine() = testTokenizer(#Program,
+
+   "begin
+        declare
+            x: natural,
+            y: natural;
+
+        x := 5;
+        y := x + 1
+    end",
+
+    firstOccurrenceOf("end", "keyword")
+);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Pico.rsc
@@ -47,5 +47,9 @@ test bool testKeywordLastLine() = testTokenizer(#Program,
         y := x + 1
     end",
 
-    expectFirst("end", "keyword") // Fixed: https://github.com/usethesource/rascal-language-servers/issues/90
+    expectFirst("begin", "keyword"),
+    expectFirst("declare", "keyword"),
+    expectNth(0, "natural", "keyword"),
+    expectNth(1, "natural", "keyword"),
+    expectFirst("end", "keyword") // https://github.com/usethesource/rascal-language-servers/issues/90
 );

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -81,7 +81,7 @@ test bool testComments() = testTokenizer(#Declaration,
 
     expectFirst("Block comment", "comment"),
     expectFirst("Multi-line 1", "comment"),
-    expectFirst("Multi-line 2", "comment"), // Fixed: https://github.com/usethesource/rascal-language-servers/issues/20
+    expectFirst("Multi-line 2", "comment"), // https://github.com/usethesource/rascal-language-servers/issues/20
     expectFirst("Line comment", "comment"),
 
     applyRascalCategoryPatch = true
@@ -109,7 +109,7 @@ test bool testUnicode() = testTokenizer(#Declaration,
 
     expectFirst("str", "keyword"),
     expectFirst(" s = ", "uncategorized"),
-    expectFirst("\"𝄞𝄞𝄞\"", "string"), // Fixed: https://github.com/usethesource/rascal-language-servers/issues/19
+    expectFirst("\"𝄞𝄞𝄞\"", "string"), // https://github.com/usethesource/rascal-language-servers/issues/19
     expectFirst(";", "uncategorized"),
     applyRascalCategoryPatch = true
 );

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -1,0 +1,111 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::semanticTokenizer::Rascal
+
+import IO;
+import ParseTree;
+import lang::rascal::\syntax::Rascal;
+
+import lang::rascal::tests::semanticTokenizer::Util;
+
+test bool testTypesAndValues() = testTokenizer(#FunctionDeclaration,
+
+   "void f() {
+        bool b = true;
+        int  i = 3;
+        real r = 3.14;
+        str  s = \"foo\<bar\>\";
+        loc  l = |unknown:///|;
+        tuple[int, int] \\tuple = \<3, 14\>;
+    }",
+
+    // Expectation: Types
+    firstOccurrenceOf("void", "keyword"),
+    firstOccurrenceOf("bool", "keyword"),
+    firstOccurrenceOf("int", "keyword"),
+    firstOccurrenceOf("real", "keyword"),
+    firstOccurrenceOf("loc", "keyword"),
+    firstOccurrenceOf("str", "keyword"),
+    firstOccurrenceOf("tuple", "keyword"),
+
+    // Expectations: Values
+    firstOccurrenceOf("f", "uncategorized"),
+    firstOccurrenceOf("true", "keyword"),
+    //firstOccurrenceOf("3", "number"), -- https://github.com/usethesource/rascal-language-servers/issues/456
+    firstOccurrenceOf("3.14", "number"),
+    firstOccurrenceOf("foo", "string"),
+    firstOccurrenceOf("\<", "string"),
+    firstOccurrenceOf("bar", "uncategorized"),
+    firstOccurrenceOf("\>", "string"),
+    //firstOccurrenceOf("|unknown:///|", "string") -- https://github.com/usethesource/rascal-language-servers/issues/456
+    lastOccurrenceOf("\<", "uncategorized"),
+    lastOccurrenceOf("\>", "uncategorized"),
+
+    // Configuration
+    printActuals = false,
+    applyRascalCategoryPatch = true
+);
+
+test bool testComments() = testTokenizer(#FunctionDeclaration,
+
+   "void f() {
+        /* Block comment */
+        // Line comment
+    }",
+
+    // Expectation
+    firstOccurrenceOf("Block comment", "comment"),
+    firstOccurrenceOf("Line comment", "comment"),
+
+    // Configuration
+    printActuals = false,
+    applyRascalCategoryPatch = true
+);
+
+test bool testTags() = testTokenizer(#Declaration,
+
+   "@synopsis{Foo}
+    @category=\"bar\"
+    @memo
+    int i = 0;",
+
+    // Expectation
+    firstOccurrenceOf("@synopsis{Foo}", "comment"),
+    firstOccurrenceOf("@category=", "comment"),
+    firstOccurrenceOf("\"bar\"", "string"),
+    firstOccurrenceOf("@memo", "comment"),
+
+    // Configuration
+    printActuals = false,
+    applyRascalCategoryPatch = true
+);
+
+// https://github.com/usethesource/rascal-language-servers/issues/90
+test bool testTokenLastLine() = testTokenizer(#Literal,
+    "3.14",
+    firstOccurrenceOf("3.14", "number"),
+    applyRascalCategoryPatch = true);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -36,7 +36,7 @@ import lang::rascal::\syntax::Rascal;
 // -----
 // Tests
 
-test bool testTypesAndValues() = testTokenizer(#FunctionDeclaration,
+test bool testTypesAndValues() = testTokenizer(#Declaration,
 
    "void f() {
         bool b = true;
@@ -70,7 +70,7 @@ test bool testTypesAndValues() = testTokenizer(#FunctionDeclaration,
     applyRascalCategoryPatch = true
 );
 
-test bool testComments() = testTokenizer(#FunctionDeclaration,
+test bool testComments() = testTokenizer(#Declaration,
 
    "void f() {
         /* Block comment */
@@ -81,7 +81,7 @@ test bool testComments() = testTokenizer(#FunctionDeclaration,
 
     expectFirst("Block comment", "comment"),
     expectFirst("Multi-line 1", "comment"),
-    expectFirst("Multi-line 2", "comment"),
+    expectFirst("Multi-line 2", "comment"), // Fixed: https://github.com/usethesource/rascal-language-servers/issues/20
     expectFirst("Line comment", "comment"),
 
     applyRascalCategoryPatch = true
@@ -102,8 +102,14 @@ test bool testTags() = testTokenizer(#Declaration,
     applyRascalCategoryPatch = true
 );
 
-test bool testTokenLastLine() = testTokenizer(#Literal,
-    "3.14",
-    expectFirst("3.14", "number"), // Fixed: https://github.com/usethesource/rascal-language-servers/issues/90
+test bool testUnicode() = testTokenizer(#Declaration,
+   "void f() {
+        str s = \"𝄞𝄞𝄞\";
+    }",
+
+    expectFirst("str", "keyword"),
+    expectFirst(" s = ", "uncategorized"),
+    expectFirst("\"𝄞𝄞𝄞\"", "string"), // Fixed: https://github.com/usethesource/rascal-language-servers/issues/19
+    expectFirst(";", "uncategorized"),
     applyRascalCategoryPatch = true
 );

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -26,10 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module lang::rascal::tests::semanticTokenizer::Rascal
 
-import IO;
-import ParseTree;
 import lang::rascal::\syntax::Rascal;
-
 import lang::rascal::tests::semanticTokenizer::Util;
 
 test bool testTypesAndValues() = testTokenizer(#FunctionDeclaration,
@@ -74,11 +71,15 @@ test bool testComments() = testTokenizer(#FunctionDeclaration,
 
    "void f() {
         /* Block comment */
+        /* Multi-line 1
+           Multi-line 2 */
         // Line comment
     }",
 
     // Expectation
     firstOccurrenceOf("Block comment", "comment"),
+    firstOccurrenceOf("Multi-line 1", "comment"),
+    firstOccurrenceOf("Multi-line 2", "comment"),
     firstOccurrenceOf("Line comment", "comment"),
 
     // Configuration

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -26,8 +26,15 @@ POSSIBILITY OF SUCH DAMAGE.
 }
 module lang::rascal::tests::semanticTokenizer::Rascal
 
-import lang::rascal::\syntax::Rascal;
 import lang::rascal::tests::semanticTokenizer::Util;
+
+// -------
+// Grammar
+
+import lang::rascal::\syntax::Rascal;
+
+// -----
+// Tests
 
 test bool testTypesAndValues() = testTokenizer(#FunctionDeclaration,
 
@@ -40,30 +47,26 @@ test bool testTypesAndValues() = testTokenizer(#FunctionDeclaration,
         tuple[int, int] \\tuple = \<3, 14\>;
     }",
 
-    // Expectation: Types
-    firstOccurrenceOf("void", "keyword"),
-    firstOccurrenceOf("bool", "keyword"),
-    firstOccurrenceOf("int", "keyword"),
-    firstOccurrenceOf("real", "keyword"),
-    firstOccurrenceOf("loc", "keyword"),
-    firstOccurrenceOf("str", "keyword"),
-    firstOccurrenceOf("tuple", "keyword"),
+    expectFirst("void", "keyword"),
+    expectFirst("bool", "keyword"),
+    expectFirst("int", "keyword"),
+    expectFirst("real", "keyword"),
+    expectFirst("loc", "keyword"),
+    expectFirst("str", "keyword"),
+    expectFirst("tuple", "keyword"),
 
-    // Expectations: Values
-    firstOccurrenceOf("f", "uncategorized"),
-    firstOccurrenceOf("true", "keyword"),
-    //firstOccurrenceOf("3", "number"), -- https://github.com/usethesource/rascal-language-servers/issues/456
-    firstOccurrenceOf("3.14", "number"),
-    firstOccurrenceOf("foo", "string"),
-    firstOccurrenceOf("\<", "string"),
-    firstOccurrenceOf("bar", "uncategorized"),
-    firstOccurrenceOf("\>", "string"),
-    //firstOccurrenceOf("|unknown:///|", "string") -- https://github.com/usethesource/rascal-language-servers/issues/456
-    lastOccurrenceOf("\<", "uncategorized"),
-    lastOccurrenceOf("\>", "uncategorized"),
+    expectFirst("f", "uncategorized"),
+    expectFirst("true", "keyword"),
+    //expectFirst("3", "number"), // https://github.com/usethesource/rascal-language-servers/issues/456
+    expectFirst("3.14", "number"),
+    expectFirst("foo", "string"),
+    expectFirst("\<", "string"),
+    expectFirst("bar", "uncategorized"),
+    expectFirst("\>", "string"),
+    //expectFirst("|unknown:///|", "string") // https://github.com/usethesource/rascal-language-servers/issues/456
+    expectLast("\<", "uncategorized"),
+    expectLast("\>", "uncategorized"),
 
-    // Configuration
-    printActuals = false,
     applyRascalCategoryPatch = true
 );
 
@@ -76,14 +79,11 @@ test bool testComments() = testTokenizer(#FunctionDeclaration,
         // Line comment
     }",
 
-    // Expectation
-    firstOccurrenceOf("Block comment", "comment"),
-    firstOccurrenceOf("Multi-line 1", "comment"),
-    firstOccurrenceOf("Multi-line 2", "comment"),
-    firstOccurrenceOf("Line comment", "comment"),
+    expectFirst("Block comment", "comment"),
+    expectFirst("Multi-line 1", "comment"),
+    expectFirst("Multi-line 2", "comment"),
+    expectFirst("Line comment", "comment"),
 
-    // Configuration
-    printActuals = false,
     applyRascalCategoryPatch = true
 );
 
@@ -94,19 +94,16 @@ test bool testTags() = testTokenizer(#Declaration,
     @memo
     int i = 0;",
 
-    // Expectation
-    firstOccurrenceOf("@synopsis{Foo}", "comment"),
-    firstOccurrenceOf("@category=", "comment"),
-    firstOccurrenceOf("\"bar\"", "string"),
-    firstOccurrenceOf("@memo", "comment"),
+    expectFirst("@synopsis{Foo}", "comment"),
+    expectFirst("@category=", "comment"),
+    expectFirst("\"bar\"", "string"),
+    expectFirst("@memo", "comment"),
 
-    // Configuration
-    printActuals = false,
     applyRascalCategoryPatch = true
 );
 
-// https://github.com/usethesource/rascal-language-servers/issues/90
 test bool testTokenLastLine() = testTokenizer(#Literal,
     "3.14",
-    firstOccurrenceOf("3.14", "number"),
-    applyRascalCategoryPatch = true);
+    expectFirst("3.14", "number"), // Fixed: https://github.com/usethesource/rascal-language-servers/issues/90
+    applyRascalCategoryPatch = true
+);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Util.rsc
@@ -48,9 +48,7 @@ bool testTokenizer(type[&T<:Tree] begin, str input, Expect expects...,
     list[str] strings = [substring(input, l.offset, l.offset + l.length) | l <- locations];
 
     // Last, test the expectations
-    list[Actual] actuals = [];
-    actuals = zip3(tokens, locations, strings);
-    actuals = sort(actuals, less);
+    list[Actual] actuals = sort(zip3(tokens, locations, strings), less);
 
     if (printActuals) {
         iprintln(actuals);
@@ -112,15 +110,15 @@ private list[Actual] filterByString(list[Actual] actuals, str string)
 // Expects
 //
 
-data Expect
+data Expect // Represents...
 
-    // The expectation that the `n`-th/first/last occurrence of `string` is in a
-    // token of type `tokenType`
+    // ...the expectation that the `n`-th/first/last occurrence of `string` is
+    // in a token of type `tokenType`
     = expectNth(int n, str string, str tokenType)
     | expectFirst(str string, str tokenType)
     | expectLast(str string, str tokenType)
 
-    // The expectation that each occurrence of `string` is not in a token of
+    // ...the expectation that each occurrence of `string` is not in a token of
     // type `tokenType`
     | expectEachNot(str string, str tokenType);
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Util.rsc
@@ -1,0 +1,136 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::semanticTokenizer::Util
+
+import IO;
+import List;
+import ParseTree;
+import String;
+
+bool testTokenizer(type[&T<:Tree] begin, str input, Expect expects...,
+        bool printActuals = false, bool applyRascalCategoryPatch = false) {
+
+    Tree tree = parse(begin, input);
+    list[SemanticToken] tokens = toTokens(tree, applyRascalCategoryPatch);
+    list[loc] locations = toLocations(input, tokens);
+    list[str] strings = toStrings(input, locations);
+
+    bool less(Actual a1, Actual a2) = a1.l.offset < a2.l.offset;
+    list[Actual] actuals = (zip3(tokens, locations, strings));
+
+    if (printActuals) {
+        iprintln(actuals);
+    }
+
+    for (expect <- expects) {
+        compare(actuals, expect);
+    }
+
+    return true;
+}
+
+private list[loc] toLocations(str input, list[SemanticToken] tokens) {
+    list[str] lines = split("\n", input);
+
+    int line = 0;
+    int column = 0;
+
+    list[loc] locations = [];
+    locations = for (token <- tokens) {
+        line = line + token.deltaLine;
+        column = (line == 0 || token.deltaLine == 0) ? column + token.deltaStart : 0;
+
+        int offset = (0 | it + size(lines[i]) + 1 | i <- [0..line]) + column;
+        int length = token.length;
+        append |unknown:///|(offset, length);
+    };
+
+    return locations;
+}
+
+private list[str] toStrings(str input, list[loc] locations) {
+    list[str] strings = [];
+
+    strings = for (l <- locations) {
+        int begin = l.offset;
+        int end = begin + l.length;
+        append substring(input, begin, end);
+    }
+
+    return strings;
+}
+
+//
+// Semantic tokens
+//
+
+alias SemanticToken = tuple[
+    int deltaLine,
+    int deltaStart,
+    int length,
+    str tokenType,
+    str tokenModifier];
+
+@javaClass{org.rascalmpl.vscode.lsp.util.SemanticTokenizerTester}
+java list[SemanticToken] toTokens(Tree _, bool applyRascalCategoryPatch);
+
+//
+// Actuals and expects
+//
+
+alias Actual = tuple[
+    SemanticToken token,
+    loc l,
+    str s
+];
+
+data Expect
+    = firstOccurrenceOf(str string, str tokenType)
+    | lastOccurrenceOf(str string, str tokenType)
+    | eachOccurrenceOf(str string, str tokenType);
+
+void compare(list[Actual] actuals, firstOccurrenceOf(string, tokenType)) {
+    if (<SemanticToken token, _, s> <- actuals, contains(s, string)) {
+        assert token.tokenType == tokenType : "Expected token type (of \"<string>\"): <tokenType>. Actual: <token.tokenType>.";
+    } else {
+        assert false : "Unexpected string: <string>";
+    }
+}
+
+void compare(list[Actual] actuals, lastOccurrenceOf(string, tokenType)) {
+    if (<SemanticToken token, _, s> <- reverse(actuals), contains(s, string)) {
+        assert token.tokenType == tokenType : "Expected token type (of \"<string>\"): `<tokenType>`. Actual: `<token.tokenType>`.";
+    } else {
+        assert false : "Unexpected string: <string>";
+    }
+}
+
+void compare(list[Actual] actuals, eachOccurrenceOf(string, tokenType)) {
+    for (<SemanticToken token, _, s> <- actuals, contains(s, string)) {
+        assert token.tokenType == tokenType : "Expected token type (of \"<string>\"): `<tokenType>`. Actual: `<token.tokenType>`.";
+    }
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Util.rsc
@@ -40,7 +40,7 @@ bool testTokenizer(type[&T<:Tree] begin, str input, Expect expects...,
     list[str] strings = toStrings(input, locations);
 
     bool less(Actual a1, Actual a2) = a1.l.offset < a2.l.offset;
-    list[Actual] actuals = (zip3(tokens, locations, strings));
+    list[Actual] actuals = sort(zip3(tokens, locations, strings), less);
 
     if (printActuals) {
         iprintln(actuals);

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/SemanticTokenizerTests.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/SemanticTokenizerTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package engineering.swat.rascal.lsp.util;
+
+import org.junit.runner.RunWith;
+import org.rascalmpl.test.infrastructure.RascalJUnitTestPrefix;
+import org.rascalmpl.test.infrastructure.RascalJUnitTestRunner;
+
+@RunWith(RascalJUnitTestRunner.class)
+@RascalJUnitTestPrefix("lang::rascal::tests::semanticTokenizer")
+public class SemanticTokenizerTests {}


### PR DESCRIPTION
Before this PR, there were no unit(-ish) tests for the semantic tokenizer yet. In anticipation of a fix for #456, this PR adds a few basic tests so we can detect regression (including tests for issues that were fixed long ago).