### PR TITLE
Updating to latest rascal, rascal-core, typepal, and rascal-maven-plugin

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -65,17 +65,17 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.40.11</version>
+      <version>0.40.14</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal-core</artifactId>
-      <version>0.12.9</version>
+      <version>0.12.11</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>typepal</artifactId>
-      <version>0.14.4</version>
+      <version>0.14.7</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>
@@ -164,7 +164,7 @@
       <plugin>
         <groupId>org.rascalmpl</groupId>
         <artifactId>rascal-maven-plugin</artifactId>
-        <version>0.28.6</version>
+        <version>0.28.8</version>
         <configuration>
           <errorsAsWarnings>false</errorsAsWarnings>
           <bin>${project.build.outputDirectory}</bin>

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/OldStyleLanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/OldStyleLanguageServer.rsc
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 }
 @synopsis{Demonstrating all of the LSP services for the demo language Pico.}
-@deprecated{This demo has been superseded by ((LanguageServer)) which avoids the use of deprecated API.}
+@deprecated{This demo has been superseded by ((demo::lang::pico::LanguageServer)) which avoids the use of deprecated API.}
 @description{
 This module is here to test the backward compatibility layer over the new ((util::LanguageServer)) API.
 For learning how to build a new set of lanuage services, please go [here]((util::LanguageServer)).

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -144,15 +144,15 @@ alias Documenter = set[str] (loc _origin, Tree _fullTree, Tree _lexicalAtCursor)
 alias CodeActionContributor = list[CodeAction] (Focus _focus);
 
 @synopsis{Function profile for definer contributions to a language server}
-@deprecated{Use ((FocusDefiner)) instead.}
+@deprecated{Use ((definition)) instead.}
 alias Definer = set[loc] (loc _origin, Tree _fullTree, Tree _lexicalAtCursor);
 
 @synopsis{Function profile for referrer contributions to a language server}
-@deprecated{Use ((FocusReferrer)) instead}
+@deprecated{Use ((references)) instead}
 alias Referrer = set[loc] (loc _origin, Tree _fullTree, Tree _lexicalAtCursor);
 
 @synopsis{Function profile for implementer contributions to a language server}
-@deprecated{Use ((FocusImplementer)) instead.}
+@deprecated{Use ((implementation)) instead.}
 alias Implementer = set[loc] (loc _origin, Tree _fullTree, Tree _lexicalAtCursor);
 
 @synopsis{Each kind of service contibutes the implementation of one (or several) IDE features.}
@@ -421,7 +421,7 @@ LanguageService implementer(Implementer d) {
     return implementation(focusAcceptor);
 }
 
-@deprecated{Please use ((build)) or ((analysis))}
+@deprecated{Please use ((util::LanguageServer::build)) or ((analysis))}
 @synopsis{A summarizer collects information for later use in interactive IDE features.}
 LanguageService summarizer(Summarizer summarizer
         , bool providesDocumentation = true
@@ -438,7 +438,7 @@ LanguageService summarizer(Summarizer summarizer
         , providesImplementations = providesImplementations);
 }
 
-@deprecated{Please use ((build)) or ((analysis))}
+@deprecated{Please use ((util::LanguageServer::build)) or ((analysis))}
 @synopsis{An analyzer collects information for later use in interactive IDE features.}
 LanguageService analyzer(Summarizer summarizer
         , bool providesDocumentation = true


### PR DESCRIPTION
Updating
* `rascal`: 0.40.14
* `rascal-core`: 0.12.11
* `typepal`: 0.14.7
* `rascal-maven-plugin`: 0.28.8