### PR TITLE
Simplify class `TokenCollector` to avoid two versions of maximal token logic

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -423,20 +423,27 @@ public class SemanticTokenizer implements ISemanticTokens {
         }
 
         private void collectAppl(ITree tree, @Nullable String parentCategory) {
-            var param = tree.asWithKeywordParameters().getParameter("category");
-            var prod = tree.getProduction();
 
             // Compute the category
-            var category = TokenTypes.AMBIGUITY.equals(parentCategory) ? TokenTypes.AMBIGUITY : null;
-            if (category == null && param != null) {
-                category = ((IString) param).getValue();
+            String category = null;
+            if (TokenTypes.AMBIGUITY.equals(parentCategory)) {
+                category = TokenTypes.AMBIGUITY;
             }
+
+            IValue catParameter = tree.asWithKeywordParameters().getParameter("category");
+            if (category == null && catParameter != null) {
+                category = ((IString) catParameter).getValue();
+            }
+
+            IConstructor prod = tree.getProduction();
             if (category == null && ProductionAdapter.isDefault(prod)) {
                 category = ProductionAdapter.getCategory(prod);
             }
+
             if (category == null && parentCategory == null && isKeyword(tree)) {
                 category = SemanticTokenTypes.Keyword;
             }
+
             if (category == null) {
                 category = parentCategory;
             }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -423,8 +423,6 @@ public class SemanticTokenizer implements ISemanticTokens {
         }
 
         private void collectAppl(ITree tree, @Nullable String parentCategory) {
-
-            // Compute the category
             String category = null;
             if (TokenTypes.AMBIGUITY.equals(parentCategory)) {
                 category = TokenTypes.AMBIGUITY;
@@ -435,7 +433,7 @@ public class SemanticTokenizer implements ISemanticTokens {
                 category = ((IString) catParameter).getValue();
             }
 
-            IConstructor prod = tree.getProduction();
+            IConstructor prod = TreeAdapter.getProduction(tree);
             if (category == null && ProductionAdapter.isDefault(prod)) {
                 category = ProductionAdapter.getCategory(prod);
             }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -57,13 +57,13 @@ test bool testTypesAndValues() = testTokenizer(#Declaration,
 
     expectFirst("f", "uncategorized"),
     expectFirst("true", "keyword"),
-    //expectFirst("3", "number"), // https://github.com/usethesource/rascal-language-servers/issues/456
+    expectFirst("3", "uncategorized"), // Should be `number` (https://github.com/usethesource/rascal-language-servers/issues/456)
     expectFirst("3.14", "number"),
     expectFirst("foo", "string"),
     expectFirst("\<", "string"),
     expectFirst("bar", "uncategorized"),
     expectFirst("\>", "string"),
-    //expectFirst("|unknown:///|", "string") // https://github.com/usethesource/rascal-language-servers/issues/456
+    expectFirst("|unknown:///|", "uncategorized"), // Should be `string` (https://github.com/usethesource/rascal-language-servers/issues/456)
     expectLast("\<", "uncategorized"),
     expectLast("\>", "uncategorized"),
 


### PR DESCRIPTION
(The description of this PR is somewhat lengthy -- a bit in the style of a small ADR -- to be able to remember why this PR was needed and how we got here.)

### Background

The implementation of the semantic tokenizer consists of three parts:
  - class `TokenCollector`: conversion from parse trees to lists of semantic tokens
  - class `TokenList`: data structure that encodes lists of semantic tokens as integer arrays (required by LSP);
  - class `TokenTypes`: mapping from Rascal *categories* (= Rascal's legacy semantic token types, TextMate scopes, and LSP semantic token types) to LSP semantic token types;

To compute the semantic tokens for a parse tree, an instance of `TokenCollector` recursively traverses the parse tree. Each time when a semantic token is identified during the traversal, an instance of `TokenList` is updated.

### Scope

This PR touches only the token collector. Tests were recently added in #494 to gain confidence this PR doesn't break anything.

### Motivation

The semantic tokenizer should compute maximal tokens. For instance, if `foobar` is a string, then the semantic tokenizer should return `foobar` as semantic token instead of separately `foo` and `bar`.

As of 2495f20, logic to compute maximal tokens is actually implemented twice. Roughly:
 1. Token collector: It adds a new token to the token list only when the current character in the parse tree has a different Rascal category than the previous character. **This results in maximal tokens in terms of Rascal categories.**
 2. Token list: It merges each new token-to-be-added with the previous token when they have the same LSP semantic token type. **This results in maximal tokens in terms of LSP semantic token types.**

This PR removes point 1 from the token collector, because:
  - It is subsumed by point 2, but not the other way around (maximality in terms of Rascal categories vs. maximality in terms of LSP semantic token types).
  - The token collector has organically grown quite complex as new features were added over the years. Code comprehension/extensibility is starting to become problematic. In anticipation of a fix for #456, now seems to be a good opportunity to re-simplify the design and implementation of the token collector.

### Plan

#### Before this PR

The token collector has a number of fields that are used for bookkeeping. The fields are used throughout the recursive traversal. These are the relevant commits in which fields were added to support new features:

  - Initial implementation:
    https://github.com/usethesource/rascal-language-servers/blob/6a73d54695b819e2c389a8b9336b313410e38702/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java#L130-L131

  - After adding support for subtrees without categories:
    https://github.com/usethesource/rascal-language-servers/blob/cb733e16e1d0c18f6fe912a4707d80933b74b93b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java#L155-L158
  
  - After adding support for multiline subtrees:
    https://github.com/usethesource/rascal-language-servers/blob/9bef2839c6f6ac9a657ff945971d4bca79d58c37/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java#L363-L367
    
  - After adding support for subtrees with nested categories
    https://github.com/usethesource/rascal-language-servers/blob/ee708382c49ed2485e95c103d44d3996fbfe5b67/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java#L391-L396 

#### After this PR

By removing the logic to compute maximal tokens from the token collector (keep it only in the token list), the state of the token collector is simplified to:

https://github.com/usethesource/rascal-language-servers/blob/6c2ed04836b005d0f77cd3f8e2cecb6dc105929d/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java#L394-L396

The recursive traversal is much simplified as well.
