### PR TITLE
Add token collector modes

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -430,13 +430,13 @@ public class SemanticTokenizer implements ISemanticTokens {
         public void collect(ITree tree) {
 
             // For Rascal, the default is the *strict* inner-over-outer mode
-            // (without syntax-in-syntax special case) that fixes #456.
+            // (without syntax-in-syntax special case) that fixes #456
             if (patch instanceof RascalCategoryPatch) {
                 collect(tree, Mode.INNER_OVER_OUTER_STRICT, null);
             }
 
             // For DSLs, the default is the *legacy* inner-over-outer mode (with
-            // syntax-in-syntax special case) to be backward-compatible.
+            // syntax-in-syntax special case) to be backward-compatible
             else {
                 collect(tree, Mode.INNER_OVER_OUTER_LEGACY, null);
             }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -414,7 +414,7 @@ public class SemanticTokenizer implements ISemanticTokens {
             INNER_OVER_OUTER_LEGACY; // Syntax-in-syntax special case
 
             public static Mode toMode(String s) {
-                switch (s) {
+            switch (s) {
                 case "outerOverInner":
                     return Mode.OUTER_OVER_INNER;
                 case "innerOverOuterStrict":
@@ -557,7 +557,7 @@ public class SemanticTokenizer implements ISemanticTokens {
                 }
             }
             return ifAbsent;
-	    }
+        }
     }
 
     // The idea behind the patch is to dynamically map productions in Rascal's

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -430,15 +430,13 @@ public class SemanticTokenizer implements ISemanticTokens {
         public void collect(ITree tree) {
 
             // For Rascal, the default is the *strict* inner-over-outer mode
-            // (without syntax-in-syntax special case) that fixes #456. See:
-            // https://github.com/usethesource/rascal-language-servers/issues/456
+            // (without syntax-in-syntax special case) that fixes #456.
             if (patch instanceof RascalCategoryPatch) {
                 collect(tree, Mode.INNER_OVER_OUTER_STRICT, null);
             }
 
             // For DSLs, the default is the *legacy* inner-over-outer mode (with
-            // syntax-in-syntax special case) to be backward-compatible. In the
-            // future, strictness should also become the default for DSLs.
+            // syntax-in-syntax special case) to be backward-compatible.
             else {
                 collect(tree, Mode.INNER_OVER_OUTER_LEGACY, null);
             }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SemanticTokenizer.java
@@ -414,15 +414,15 @@ public class SemanticTokenizer implements ISemanticTokens {
             INNER_OVER_OUTER_LEGACY; // Syntax-in-syntax special case
 
             public static Mode toMode(String s) {
-            switch (s) {
-                case "outerOverInner":
-                    return Mode.OUTER_OVER_INNER;
-                case "innerOverOuterStrict":
-                    return Mode.INNER_OVER_OUTER_STRICT;
-                case "innerOverOuterLegacy":
-                    return Mode.INNER_OVER_OUTER_LEGACY;
-                default:
-                    throw new IllegalArgumentException("Unexpected token collector mode: " + s);
+                switch (s) {
+                    case "outerOverInner":
+                        return Mode.OUTER_OVER_INNER;
+                    case "innerOverOuterStrict":
+                        return Mode.INNER_OVER_OUTER_STRICT;
+                    case "innerOverOuterLegacy":
+                        return Mode.INNER_OVER_OUTER_LEGACY;
+                    default:
+                        throw new IllegalArgumentException("Unexpected token collector mode: " + s);
                 }
             }
         }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/NestedCategories.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/NestedCategories.rsc
@@ -49,6 +49,9 @@ lexical Variable
 lexical Interface
     = @category="interface" "I" Class;
 
+lexical InterfaceOuterOverInner
+    = @categoryNesting="outerOverInner" Interface;
+
 lexical Class
     = @category="class" Upper Alnum*;
 
@@ -87,7 +90,16 @@ test bool testInterface() = testTokenizer(#Interface,
     // This test demonstrates that, sometimes, arguably the "natural" way to
     // write a grammar (e.g., "An interface name is just any class name, but
     // prefixed with an I") requires outer-over-inner semantic tokenization.
-    // This is currently not supported (i.e., the only "solution" right now is
-    // to rewrite the grammar). Further reading:
+    // The following test shows the effect of overriding the default from
+    // inner-over-outer to outer-over-inner. Further reading:
     // https://github.com/usethesource/rascal-language-servers/issues/456
+);
+
+test bool testInterfaceOuterOverInner() = testTokenizer(#InterfaceOuterOverInner,
+
+    "IFoo",
+
+    expectFirst("I", "interface"),
+    expectFirst("Foo", "interface"),
+    expectFirst("IFoo", "interface") // Outer over inner
 );

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -124,5 +124,5 @@ test bool testInnerOverOuterLegacy() = testTokenizer(#Declaration,
     expectFirst("3", "uncategorized"), // Instead of `number`
     expectFirst("|unknown:///|", "uncategorized"), // Instead of `string`
 
-    applyRascalCategoryPatch = false
+    applyRascalCategoryPatch = false // Use legacy mode instead of strict mode
 );

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -117,8 +117,8 @@ test bool testUnicode() = testTokenizer(#Declaration,
 test bool testInnerOverOuterLegacy() = testTokenizer(#Declaration,
 
    "void f() {
-        int  i = 3;
-        loc  l = |unknown:///|;
+        int i = 3;
+        loc l = |unknown:///|;
     }",
 
     expectFirst("3", "uncategorized"), // Instead of `number`

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/semanticTokenizer/Rascal.rsc
@@ -57,13 +57,13 @@ test bool testTypesAndValues() = testTokenizer(#Declaration,
 
     expectFirst("f", "uncategorized"),
     expectFirst("true", "keyword"),
-    expectFirst("3", "uncategorized"), // Should be `number` (https://github.com/usethesource/rascal-language-servers/issues/456)
+    expectFirst("3", "number"), // https://github.com/usethesource/rascal-language-servers/issues/456
     expectFirst("3.14", "number"),
     expectFirst("foo", "string"),
     expectFirst("\<", "string"),
     expectFirst("bar", "uncategorized"),
     expectFirst("\>", "string"),
-    expectFirst("|unknown:///|", "uncategorized"), // Should be `string` (https://github.com/usethesource/rascal-language-servers/issues/456)
+    expectFirst("|unknown:///|", "string"), // https://github.com/usethesource/rascal-language-servers/issues/456
     expectLast("\<", "uncategorized"),
     expectLast("\>", "uncategorized"),
 
@@ -112,4 +112,17 @@ test bool testUnicode() = testTokenizer(#Declaration,
     expectFirst("\"𝄞𝄞𝄞\"", "string"), // https://github.com/usethesource/rascal-language-servers/issues/19
     expectFirst(";", "uncategorized"),
     applyRascalCategoryPatch = true
+);
+
+test bool testInnerOverOuterLegacy() = testTokenizer(#Declaration,
+
+   "void f() {
+        int  i = 3;
+        loc  l = |unknown:///|;
+    }",
+
+    expectFirst("3", "uncategorized"), // Instead of `number`
+    expectFirst("|unknown:///|", "uncategorized"), // Instead of `string`
+
+    applyRascalCategoryPatch = false
 );


### PR DESCRIPTION
### This PR

This PR adds support to run the token collector in one of the following modes:

  - `INNER_OVER_OUTER_LEGACY` (default for DSLs): In this mode, the behavior of the semantic tokenizer is exactly the same as before this PR, namely inner-over-outer for nested categories, except syntax-in-syntax. No changes are needed to existing DSL grammars.

  - `INNER_OVER_OUTER_STRICT` (default for Rascal): Essentially the same as `INNER_OVER_OUTER_LEGACY` but without the syntax-in-syntax special case. This fixes #456.
  
  - `OUTER_OVER_INNER`: In this mode, outer categories take precedence over inner categories. For some grammars, this [might be more intuitive](https://github.com/usethesource/rascal-language-servers/issues/456#issuecomment-2382842966). Furthermore, this mode turns out to be already useful to tokenize ambiguities (i.e.,  if a subtree is part of an ambiguity, then ambiguity tokens should be generated, while any non-ambiguity category inside the subtree should be ignored).

Further reading about inner-over-outer vs. outer-over-inner: #456

### Usage

The defaults can be explicitly overridden in grammars by annotating a production with the following tags:

```rascal
@categoryNesting="innerOverOuterLegacy"
@categoryNesting="innerOverOuterStrict"
@categoryNesting="outerOverInner"
```

The declared mode will be used in the whole subtree starting from the annotated production. (Unless a subtree inside the subtree has its own `@categoryNesting` annotation.) In particular, users ready to migrate their DSLs to `INNER_OVER_OUTER_STRICT` only need to annotate the `start` production of the grammar with a `@categoryNesting` annotation.

### Examples

  - Migrating Pico to `INNER_OVER_OUTER_STRICT`:
   
    ```rascal
    module lang::pico::\syntax::Main

    import ParseTree;

    start syntax Program 
      = @categoryNesting="innerOverOuterStrict" program: "begin" Declarations decls {Statement  ";"}* body "end" ;

    ...
    ```

    (Pico is unaffected by the syntax-in-syntax special case, so legacy/strict mode is the same for Pico.)

  - Defining [reals in terms of ints](https://github.com/usethesource/rascal-language-servers/issues/456#issuecomment-2378861654):

    ```rascal
    lexical Ints = @category="integer" [0-9]+ !>> [0-9];
    lexical Reals = @categoryNesting="outerOverInner" @category="real" Ints "." Ints?;
    ```