### PR TITLE
Fix rename TModel load

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -549,7 +549,11 @@ list[DocumentEdit] rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, s
                                                                       [logPathConfig = false];
                 for (<file, true> <- \files) {
                     ms = rascalTModelForLocs([file], ccfg, dummy_compile1);
-                    tmodels += {convertTModel2PhysicalLocs(tm) | m <- ms.tmodels, tm := ms.tmodels[m]};
+                    for (modName <- ms.moduleLocs) {
+                        <found, tm, ms> = getTModelForModule(modName, ms);
+                        if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'");
+                        tmodels += convertTModel2PhysicalLocs(tm);
+                    }
                 }
             }
             return tmodels;


### PR DESCRIPTION
This fixes a regression with the rename code after recent changes in https://github.com/usethesource/rascal-core  (in the move from v0.12.11 to v0.12.12).