### PR TITLE
Fix configuration of Pico language server

### DIFF
--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -195,7 +195,7 @@ void main() {
             pathConfig(),
             "Pico",
             {"pico", "pico-new"},
-            "demo::lang::pico::NewLanguageServer",
+            "demo::lang::pico::LanguageServer",
             "picoLanguageServer"
         )
     );
@@ -204,7 +204,7 @@ void main() {
             pathConfig(),
             "Pico",
             {"pico", "pico-new"},
-            "demo::lang::pico::NewLanguageServer",
+            "demo::lang::pico::LanguageServer",
             "picoLanguageServerSlowSummary"
         )
     );


### PR DESCRIPTION
We missed a rename of Pico's language server module. @PieterOlivier discovered and fixed it in a commit to the error recovery branch (097d81619b6dbbf16b0d0439d2cd488e1daad74b), but it may still take some time before that branch is merged into `main` (possibly in a next release cycle).