### PR TITLE
Rename performance improvements

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -560,7 +560,7 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
                     ms = rascalTModelForLocs([file], ccfg, dummy_compile1);
                     for (modName <- ms.moduleLocs) {
                         <found, tm, ms> = getTModelForModule(modName, ms);
-                        if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'");
+                        if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'\n<toString(ms.messages)>");
                         tmodels += convertTModel2PhysicalLocs(tm);
                     }
                 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -230,11 +230,10 @@ set[loc] rascalGetOverloadedDefs(WorkspaceInfo ws, set[loc] defs, MayOverloadFun
     map[loc file, loc scope] moduleScopePerFile = getModuleScopePerFile(ws);
     rel[loc def, loc scope] defUseScopes = {<d, moduleScopePerFile[u.top]> | <loc u, loc d> <- ws.useDef};
     rel[loc fromScope, loc toScope] modulePaths = rascalGetTransitiveReflexiveModulePaths(ws);
-    rel[loc def, loc scope] defScopes = ws.defines<defined, scope>+;
 
     rel[loc def, loc moduleScope] defPathStep =
-        (defScopes + defUseScopes)            // 1. Look up scopes of defs and scopes of their uses
-        o (modulePaths + invert(modulePaths)) // 2. Follow import/extend relations to reachable scopes
+        (ws.defines<defined, scope>+ + defUseScopes) // 1. Look up scopes of defs and scopes of their uses
+        o (modulePaths + invert(modulePaths))        // 2. Follow import/extend relations to reachable scopes
         ;
 
     rel[loc fromDef, loc toDef] defPaths = {};
@@ -294,7 +293,7 @@ set[loc] rascalGetOverloadedDefs(WorkspaceInfo ws, set[loc] defs, MayOverloadFun
             defPaths = defPathStep o selectedFields;
         } else {
             // Find definitions in the reached scope, and definitions within those definitions (transitively)
-            defPaths = defPathStep o invert(defScopes);
+            defPaths = defPathStep o (ws.defines<idRole, scope, defined>)[role]+;
         }
 
         set[loc] overloadCandidates = defPaths[overloadedDefs.defined];

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -1,0 +1,22 @@
+module lang::rascal::tests::rename::ProjectOnDisk
+
+import lang::rascal::lsp::refactor::Rename;
+import lang::rascal::tests::rename::TestUtils;
+import util::Reflective;
+
+Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new") {
+    PathConfig pcfg;
+    if (projectDir.file == "rascal-core") {
+        pcfg = getRascalCorePathConfig(projectDir);
+    } else {
+        pcfg = pathConfig(
+            srcs = [ projectDir + "src" ],
+            bin = projectDir + "target/classes",
+            generatedSources = projectDir + "target/generated-sources/src/main/java/",
+            generatedTestSources = projectDir + "target/generated-test/sources/src/main/java/",
+            resources = projectDir + "target/generated-resources/src/main/java/",
+            libs = [ |lib://rascal| ]
+        );
+    }
+    return getEdits(projectDir + file, {projectDir}, occurrence, oldName, newName, PathConfig(_) { return pcfg; });
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -193,17 +193,13 @@ private PathConfig getTestPathConfig(loc testDir) {
     );
 }
 
-PathConfig getRascalCorePathConfig(loc rascalCoreProject, loc typepalProject) {
+PathConfig getRascalCorePathConfig(loc rascalCoreProject) {
    return pathConfig(
-        srcs = [
-                |std:///|,
-                rascalCoreProject + "src/org/rascalmpl/core/library",
-                typepalProject + "src"
-               ],
+        srcs = [rascalCoreProject + "src/org/rascalmpl/core/library"],
         bin = rascalCoreProject + "target/test-classes",
         generatedSources = rascalCoreProject + "target/generated-test-sources",
         resources = rascalCoreProject + "target/generated-test-resources",
-        libs = []
+        libs = [|lib://typepal|, |lib://rascal|]
     );
 }
 
@@ -217,27 +213,15 @@ PathConfig getPathConfig(loc project) {
     println("Getting path config for <project.file> (<project>)");
 
     if (project.file == "rascal-core") {
-        pcfg = getRascalCorePathConfig();
-        return resolveLocations(pcfg);
+        pcfg = getRascalCorePathConfig(|home:///swat/projects/Rascal/rascal-core|);
+        return pcfg;
     }
 
     pcfg = getProjectPathConfig(project);
-    return resolveLocations(pcfg);
-}
-
-Edits testRascalCore(loc rascalCoreDir, loc typepalDir) {
-    registerLocations("project", "", (
-        |project://rascal-core/target/test-classes|: rascalCoreDir + "target/test-classes",
-        |project://rascal-core/target/generated-test-sources|: rascalCoreDir + "target/generated-test-sources",
-        |project://rascal-core/target/generated-test-resources|: rascalCoreDir + "target/generated-test-resources",
-        |project://rascal-core/src/org/rascalmpl/core/library|: rascalCoreDir + "src/org/rascalmpl/core/library",
-        |project://typepal/src|: typepalDir + "src"));
-
-    return getEdits(rascalCoreDir + "src/org/rascalmpl/core/library/lang/rascalcore/check/ATypeBase.rsc", {resolveLocation(rascalCoreDir), resolveLocation(typepalDir)}, 0, "arat", "arational", getPathConfig);
+    return pcfg;
 }
 
 Edits getEdits(loc singleModule, set[loc] projectDirs, int cursorAtOldNameOccurrence, str oldName, str newName, PathConfig(loc) getPathConfig) {
-    loc f = resolveLocation(singleModule);
     Tree cursor = findCursor(singleModule, oldName, cursorAtOldNameOccurrence);
     return rascalRenameSymbol(cursor, projectDirs, newName, getPathConfig);
 }


### PR DESCRIPTION
After testing with large Rascal projects (`rascal-core`, `typepal`), some low-hanging performance improvements to the rename refactoring presented themselves. Otherwise, the rename refactoring now mainly spends time in the type checker, which has some performance improvements under development. 