### PR TITLE
Fix duplicate locations in rename edits.

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -65,6 +65,8 @@ private DocumentEdit sortChanges(changed(loc l, list[TextEdit] edits)) = changed
 private default DocumentEdit sortChanges(DocumentEdit e) = e;
 
 private void verifyTypeCorrectRenaming(loc root, Edits edits, PathConfig pcfg) {
+    list[loc] editLocs = [l | /replace(l, _) := edits<0>];
+    assert size(editLocs) == size(toSet(editLocs)) : "Duplicate locations in suggested edits - VS Code cannot handle this";
     executeDocumentEdits(sortEdits(edits<0>));
     remove(pcfg.resources);
     RascalCompilerConfig ccfg = rascalCompilerConfig(pcfg)[forceCompilationTopModule = true][verbose = false][logPathConfig = false];


### PR DESCRIPTION
In some cases, names of definitions also appear as use locations in the TModel. In those cases, the rename logic would mark that location as both a definition and use.
Since the addition of annotated edits, locations are not deduplicated, so VS Code would receive multiple edits for the same location, and fail to apply all of them. Many renames would fail due to this, depending on what kind of name the cursor was on.

This PR fixes this behaviour; it postpones attaching annotations to most rename locations, simplifying location deduplication (and, as a side-effect, de-duplicates the annotations as well). It also adds assertions against duplicate edit locations to the test framework.