### PR TITLE
Improve handling of qualified names when renaming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [buildjet-4vcpu-ubuntu-2204, windows-latest, macos-latest]
-      fail-fast: true
+      fail-fast: false
     env:
       CODE_VERSION: "1.82.3"
     runs-on:  ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
         env:
           DELAY_FACTOR: 10
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
 
       - name: "UI test (mac)"
         shell: bash
@@ -103,7 +103,7 @@ jobs:
         env:
           DELAY_FACTOR: 15
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
 
       - name: "UI test (ubuntu)"
         shell: bash
@@ -112,7 +112,7 @@ jobs:
         env:
           DELAY_FACTOR: 8
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
-        run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [buildjet-4vcpu-ubuntu-2204, windows-latest, macos-latest]
-      fail-fast: false
+      fail-fast: true
     env:
       CODE_VERSION: "1.82.3"
     runs-on:  ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
         env:
           DELAY_FACTOR: 10
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (mac)"
         shell: bash
@@ -103,7 +103,7 @@ jobs:
         env:
           DELAY_FACTOR: 15
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"
         shell: bash
@@ -112,7 +112,7 @@ jobs:
         env:
           DELAY_FACTOR: 8
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
-        run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v4

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
@@ -155,17 +155,19 @@ public abstract class BaseLanguageServer {
     public static void startLanguageServer(ExecutorService threadPool, Function<ExecutorService, IBaseTextDocumentService> docServiceProvider, BiFunction<ExecutorService, IBaseTextDocumentService, BaseWorkspaceService> workspaceServiceProvider, int portNumber) {
         logger.info("Starting Rascal Language Server: {}", getVersion());
 
-        var docService = docServiceProvider.apply(threadPool);
-        var wsService = workspaceServiceProvider.apply(threadPool, docService);
-        docService.pair(wsService);
-
         if (DEPLOY_MODE) {
+            var docService = docServiceProvider.apply(threadPool);
+            var wsService = workspaceServiceProvider.apply(threadPool, docService);
+            docService.pair(wsService);
             startLSP(constructLSPClient(capturedIn, capturedOut, new ActualLanguageServer(() -> System.exit(0), docService, wsService)));
         }
         else {
             try (ServerSocket serverSocket = new ServerSocket(portNumber, 0, InetAddress.getByName("127.0.0.1"))) {
                 logger.info("Rascal LSP server listens on port number: {}", portNumber);
                 while (true) {
+                    var docService = docServiceProvider.apply(threadPool);
+                    var wsService = workspaceServiceProvider.apply(threadPool, docService);
+                    docService.pair(wsService);
                     startLSP(constructLSPClient(serverSocket.accept(), new ActualLanguageServer(() -> {}, docService, wsService)));
                 }
             } catch (IOException e) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.apache.logging.log4j.LogManager;
@@ -151,11 +152,11 @@ public abstract class BaseLanguageServer {
     }
 
     @SuppressWarnings({"java:S2189", "java:S106"})
-    public static void startLanguageServer(ExecutorService threadPool, Function<ExecutorService, IBaseTextDocumentService> docServiceProvider, Function<IBaseTextDocumentService, BaseWorkspaceService> workspaceServiceProvider, int portNumber) {
+    public static void startLanguageServer(ExecutorService threadPool, Function<ExecutorService, IBaseTextDocumentService> docServiceProvider, BiFunction<ExecutorService, IBaseTextDocumentService, BaseWorkspaceService> workspaceServiceProvider, int portNumber) {
         logger.info("Starting Rascal Language Server: {}", getVersion());
 
         var docService = docServiceProvider.apply(threadPool);
-        var wsService = workspaceServiceProvider.apply(docService);
+        var wsService = workspaceServiceProvider.apply(threadPool, docService);
         docService.pair(wsService);
 
         if (DEPLOY_MODE) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -30,6 +30,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+
 import com.google.gson.JsonPrimitive;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -51,12 +53,15 @@ public class BaseWorkspaceService implements WorkspaceService, LanguageClientAwa
     public static final String RASCAL_META_COMMAND = "rascal-meta-command";
     public static final String RASCAL_COMMAND = "rascal-command";
 
+    private final ExecutorService ownExecuter;
+
     private final IBaseTextDocumentService documentService;
     private final CopyOnWriteArrayList<WorkspaceFolder> workspaceFolders = new CopyOnWriteArrayList<>();
 
 
-    protected BaseWorkspaceService(IBaseTextDocumentService documentService) {
+    protected BaseWorkspaceService(ExecutorService exec, IBaseTextDocumentService documentService) {
         this.documentService = documentService;
+        this.ownExecuter = exec;
     }
 
 
@@ -122,6 +127,9 @@ public class BaseWorkspaceService implements WorkspaceService, LanguageClientAwa
     }
 
 
+    protected final ExecutorService getExecuter() {
+        return ownExecuter;
+    }
 
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -57,7 +57,6 @@ public class BaseWorkspaceService implements WorkspaceService, LanguageClientAwa
 
     protected BaseWorkspaceService(IBaseTextDocumentService documentService) {
         this.documentService = documentService;
-        documentService.pair(this);
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
@@ -54,7 +55,7 @@ public class BaseWorkspaceService implements WorkspaceService, LanguageClientAwa
     private final CopyOnWriteArrayList<WorkspaceFolder> workspaceFolders = new CopyOnWriteArrayList<>();
 
 
-    BaseWorkspaceService(IBaseTextDocumentService documentService) {
+    protected BaseWorkspaceService(IBaseTextDocumentService documentService) {
         this.documentService = documentService;
         documentService.pair(this);
     }
@@ -69,10 +70,12 @@ public class BaseWorkspaceService implements WorkspaceService, LanguageClientAwa
         var clientWorkspaceCap = clientCap.getWorkspace();
 
         if (clientWorkspaceCap != null && Boolean.TRUE.equals(clientWorkspaceCap.getWorkspaceFolders())) {
-            var workspaceCap = new WorkspaceFoldersOptions();
-            workspaceCap.setSupported(true);
-            workspaceCap.setChangeNotifications(true);
-            capabilities.setWorkspace(new WorkspaceServerCapabilities(workspaceCap));
+            var workspaceOpts = new WorkspaceFoldersOptions();
+            workspaceOpts.setSupported(true);
+            workspaceOpts.setChangeNotifications(true);
+            var workspaceCap = new WorkspaceServerCapabilities(workspaceOpts);
+            workspaceCap.setFileOperations(new FileOperationsServerCapabilities());
+            capabilities.setWorkspace(workspaceCap);
         }
 
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
-import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
@@ -74,12 +73,10 @@ public class BaseWorkspaceService implements WorkspaceService, LanguageClientAwa
         var clientWorkspaceCap = clientCap.getWorkspace();
 
         if (clientWorkspaceCap != null && Boolean.TRUE.equals(clientWorkspaceCap.getWorkspaceFolders())) {
-            var workspaceOpts = new WorkspaceFoldersOptions();
-            workspaceOpts.setSupported(true);
-            workspaceOpts.setChangeNotifications(true);
-            var workspaceCap = new WorkspaceServerCapabilities(workspaceOpts);
-            workspaceCap.setFileOperations(new FileOperationsServerCapabilities());
-            capabilities.setWorkspace(workspaceCap);
+            var workspaceCap = new WorkspaceFoldersOptions();
+            workspaceCap.setSupported(true);
+            workspaceCap.setChangeNotifications(true);
+            capabilities.setWorkspace(new WorkspaceServerCapabilities(workspaceCap));
         }
 
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -35,6 +35,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.util.locations.LineColumnOffsetMap;
+
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValue;
 
@@ -47,7 +48,6 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     void unregisterLanguage(LanguageParameter lang);
     CompletableFuture<IValue> executeCommand(String languageName, String command);
     LineColumnOffsetMap getColumnMap(ISourceLocation file);
-    String getContents(ISourceLocation file);
 
     default void didRenameFiles(RenameFilesParams params, Set<ISourceLocation> workspaceFolders) {}
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -44,5 +44,5 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     void unregisterLanguage(LanguageParameter lang);
     CompletableFuture<IValue> executeCommand(String languageName, String command);
     LineColumnOffsetMap getColumnMap(ISourceLocation file);
-
+    String getContents(ISourceLocation file);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -26,7 +26,10 @@
  */
 package org.rascalmpl.vscode.lsp;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -45,4 +48,6 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     CompletableFuture<IValue> executeCommand(String languageName, String command);
     LineColumnOffsetMap getColumnMap(ISourceLocation file);
     String getContents(ISourceLocation file);
+
+    default void didRenameFiles(RenameFilesParams params, Set<ISourceLocation> workspaceFolders) {}
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricLanguageServer.java
@@ -26,10 +26,8 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.rascalmpl.vscode.lsp.BaseLanguageServer;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 
@@ -45,10 +43,10 @@ public class ParametricLanguageServer extends BaseLanguageServer {
             dedicatedLanguage = null;
         }
 
-        startLanguageServer(() -> {
-            ExecutorService threadPool = Executors.newCachedThreadPool();
-            var docService = new ParametricTextDocumentService(threadPool, dedicatedLanguage);
-            return Pair.of(docService, new ParametricWorkspaceService(docService));
-        }, 9999);
+        startLanguageServer(Executors.newCachedThreadPool()
+            , threadPool -> new ParametricTextDocumentService(threadPool, dedicatedLanguage)
+            , ParametricWorkspaceService::new
+            , 9999
+        );
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricLanguageServer.java
@@ -29,8 +29,10 @@ package org.rascalmpl.vscode.lsp.parametric;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.rascalmpl.vscode.lsp.BaseLanguageServer;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
+
 import com.google.gson.GsonBuilder;
 
 public class ParametricLanguageServer extends BaseLanguageServer {
@@ -45,7 +47,8 @@ public class ParametricLanguageServer extends BaseLanguageServer {
 
         startLanguageServer(() -> {
             ExecutorService threadPool = Executors.newCachedThreadPool();
-            return new ParametricTextDocumentService(threadPool, dedicatedLanguage);
+            var docService = new ParametricTextDocumentService(threadPool, dedicatedLanguage);
+            return Pair.of(docService, new ParametricWorkspaceService(docService));
         }, 9999);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -167,7 +167,8 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         return columns.get(file);
     }
 
-    private String getContents(ISourceLocation file) {
+    @Override
+    public String getContents(ISourceLocation file) {
         file = file.top();
         TextDocumentState ideState = files.get(file);
         if (ideState != null) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -167,7 +167,6 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         return columns.get(file);
     }
 
-    @Override
     public String getContents(ISourceLocation file) {
         file = file.top();
         TextDocumentState ideState = files.get(file);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricWorkspaceService.java
@@ -26,11 +26,13 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
+import java.util.concurrent.ExecutorService;
+
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 
 public class ParametricWorkspaceService extends BaseWorkspaceService {
-    ParametricWorkspaceService(IBaseTextDocumentService docService) {
-        super(docService);
+    ParametricWorkspaceService(ExecutorService exec, IBaseTextDocumentService docService) {
+        super(exec, docService);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricWorkspaceService.java
@@ -24,30 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package org.rascalmpl.vscode.lsp.rascal;
+package org.rascalmpl.vscode.lsp.parametric;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.rascalmpl.vscode.lsp.BaseLanguageServer;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 
-public class RascalLanguageServer extends BaseLanguageServer {
-    public static void main(String[] args) {
-        try {
-            startLanguageServer(() -> {
-                ExecutorService threadPool = Executors.newCachedThreadPool();
-                IBaseTextDocumentService docService = new RascalTextDocumentService(threadPool);
-                return Pair.of(docService, new RascalWorkspaceService(docService));
-            }, 8888);
-        }
-        catch (Throwable e) {
-            final Logger logger = LogManager.getLogger(RascalLanguageServer.class);
-            logger.fatal(e.getMessage(), e);
-        }
+public class ParametricWorkspaceService extends BaseWorkspaceService {
+    ParametricWorkspaceService(IBaseTextDocumentService docService) {
+        super(docService);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
@@ -36,7 +36,7 @@ public class RascalLanguageServer extends BaseLanguageServer {
     public static void main(String[] args) {
         try {
             var threadPool = Executors.newCachedThreadPool();
-            startLanguageServer(threadPool, RascalTextDocumentService::new, (docService) -> new RascalWorkspaceService(threadPool, docService), 8888);
+            startLanguageServer(threadPool, RascalTextDocumentService::new, RascalWorkspaceService::new, 8888);
         }
         catch (Throwable e) {
             final Logger logger = LogManager.getLogger(RascalLanguageServer.class);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
@@ -35,8 +35,7 @@ import org.rascalmpl.vscode.lsp.BaseLanguageServer;
 public class RascalLanguageServer extends BaseLanguageServer {
     public static void main(String[] args) {
         try {
-            var threadPool = Executors.newCachedThreadPool();
-            startLanguageServer(threadPool, RascalTextDocumentService::new, RascalWorkspaceService::new, 8888);
+            startLanguageServer(Executors.newCachedThreadPool(), RascalTextDocumentService::new, RascalWorkspaceService::new, 8888);
         }
         catch (Throwable e) {
             final Logger logger = LogManager.getLogger(RascalLanguageServer.class);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
@@ -39,11 +39,7 @@ import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 public class RascalLanguageServer extends BaseLanguageServer {
     public static void main(String[] args) {
         try {
-            startLanguageServer(() -> {
-                ExecutorService threadPool = Executors.newCachedThreadPool();
-                IBaseTextDocumentService docService = new RascalTextDocumentService(threadPool);
-                return Pair.of(docService, new RascalWorkspaceService(docService));
-            }, 8888);
+            startLanguageServer(Executors.newCachedThreadPool(), RascalTextDocumentService::new, RascalWorkspaceService::new, 8888);
         }
         catch (Throwable e) {
             final Logger logger = LogManager.getLogger(RascalLanguageServer.class);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServer.java
@@ -26,20 +26,17 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.rascalmpl.vscode.lsp.BaseLanguageServer;
-import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
-import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 
 public class RascalLanguageServer extends BaseLanguageServer {
     public static void main(String[] args) {
         try {
-            startLanguageServer(Executors.newCachedThreadPool(), RascalTextDocumentService::new, RascalWorkspaceService::new, 8888);
+            var threadPool = Executors.newCachedThreadPool();
+            startLanguageServer(threadPool, RascalTextDocumentService::new, (docService) -> new RascalWorkspaceService(threadPool, docService), 8888);
         }
         catch (Throwable e) {
             final Logger logger = LogManager.getLogger(RascalLanguageServer.class);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -244,7 +244,7 @@ public class RascalLanguageServices {
         try {
             return URIUtil.createFromURI(uri);
         } catch (URISyntaxException e) {
-            throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed, e.getMessage(), null));
+            throw new RuntimeException(e);
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -300,7 +300,9 @@ public class RascalLanguageServices {
     }
 
     public InterruptibleFuture<ITuple> getModuleRenames(List<FileRename> fileRenames, Set<ISourceLocation> workspaceFolders, Function<ISourceLocation, PathConfig> getPathConfig) {
-        if (fileRenames.isEmpty()) return InterruptibleFuture.completedFuture(null);
+        if (fileRenames.isEmpty()) {
+            return InterruptibleFuture.completedFuture(null);
+        }
 
         final ISet qualifiedNameChanges = qualfiedNameChangesFromRenames(fileRenames, workspaceFolders, getPathConfig);
         return runEvaluator("Rascal module rename", semanticEvaluator, eval -> {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -310,7 +310,7 @@ public class RascalLanguageServices {
                         throw new RuntimeException(e.getMessage());
                     }
                 }, emptyResult, exec, false, client).get();
-        });
+            });
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -271,20 +271,17 @@ public class RascalLanguageServices {
             ISourceLocation newLoc = sourceLocationFromUri(rename.getNewUri());
 
             ISourceLocation currentWsFolder = findContainingWorkspaceFolder(currentLoc, sortedWorkspaceFolders)
-                .orElseThrow(() -> new ResponseErrorException(new ResponseError(ResponseErrorCode.InvalidParams,
-                    String.format("Cannot automatically change uses of %s, since it is outside the current workspace.", currentLoc), null)));
+                .orElseThrow(() -> new RuntimeException(String.format("Cannot automatically change uses of %s, since it is outside the current workspace.", currentLoc)));
 
             ISourceLocation newWsFolder = findContainingWorkspaceFolder(newLoc, sortedWorkspaceFolders)
-                .orElseThrow(() -> new ResponseErrorException(new ResponseError(ResponseErrorCode.InvalidParams,
-                    String.format("Cannot automatically change uses of %s, since that it is outside the current workspace.", newLoc), null)));
+                .orElseThrow(() -> new RuntimeException(String.format("Cannot automatically change uses of %s, since that it is outside the current workspace.", newLoc)));
 
             if (!currentWsFolder.equals(newWsFolder)) {
                 String commonProjPrefix = StringUtils.getCommonPrefix(currentWsFolder.toString(), newWsFolder.toString());
                 String currentProject = StringUtils.removeStart(currentWsFolder.toString(), commonProjPrefix);
                 String newProject = StringUtils.removeStart(newWsFolder.toString(), commonProjPrefix);
 
-                throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed,
-                    String.format("Cannot automatically change uses of %s, since moving files between projects (from %s to %s) is not supported", currentLoc, currentProject, newProject), null));
+                throw new RuntimeException(String.format("Cannot automatically change uses of %s, since moving files between projects (from %s to %s) is not supported", currentLoc, currentProject, newProject));
             }
 
             PathConfig pcfg = getPathConfig.apply(currentWsFolder);
@@ -294,7 +291,7 @@ public class RascalLanguageServices {
 
                 writer.insert(VF.tuple(currentName, newName, addResources(pcfg)));
             } catch (IOException e) {
-                throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed, e.getMessage(), null));
+                throw new RuntimeException(e);
             }
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -300,8 +300,9 @@ public class RascalLanguageServices {
     }
 
     public InterruptibleFuture<ITuple> getModuleRenames(List<FileRename> fileRenames, Set<ISourceLocation> workspaceFolders, Function<ISourceLocation, PathConfig> getPathConfig) {
+        var emptyResult = VF.tuple(VF.list(), VF.map());
         if (fileRenames.isEmpty()) {
-            return InterruptibleFuture.completedFuture(null);
+            return InterruptibleFuture.completedFuture(emptyResult);
         }
 
         final ISet qualifiedNameChanges = qualfiedNameChangesFromRenames(fileRenames, workspaceFolders, getPathConfig);
@@ -312,7 +313,7 @@ public class RascalLanguageServices {
             } catch (Throw e) {
                 throw new RuntimeException(e.getMessage());
             }
-        }, VF.tuple(VF.list(), VF.map()), exec, false, client);
+        }, emptyResult, exec, false, client);
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -250,7 +250,7 @@ public class RascalLanguageServices {
         return CompletableFuture.supplyAsync(() -> fileRenames.stream()
                 .map(r -> VF.tuple(sourceLocationFromUri(r.getOldUri()), sourceLocationFromUri(r.getNewUri())))
                 .collect(VF.listWriter())
-            )
+            , exec)
             .thenCompose(renames -> {
                 return runEvaluator("Rascal module rename", semanticEvaluator, eval -> {
                     IFunction rascalGetPathConfig = eval.getFunctionValueFactory().function(getPathConfigType, (t, u) -> addResources(getPathConfig.apply((ISourceLocation) t[0])));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -339,8 +339,11 @@ public class RascalLanguageServices {
                 var loc = (ISourceLocation) args[0];
                 try {
                     return getEditorTreeOrParse(loc, documents).get();
-                } catch (ExecutionException | InterruptedException | IOException e) {
+                } catch (ExecutionException | IOException e) {
                     throw new RuntimeException(e);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(String.format("Thread %d was interrupted", Thread.currentThread().getId()));
                 }
             });
             try {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -298,16 +299,12 @@ public class RascalLanguageServices {
         return writer.done();
     }
 
-    private static String readFile(ISourceLocation loc, String charset) throws IOException {
+    private static String readFile(ISourceLocation loc) {
         URIResolverRegistry reg = URIResolverRegistry.getInstance();
-        try (Reader reader = reg.getCharacterReader(loc, charset)) {
-            StringBuilder res = new StringBuilder();
-            char[] chunk = new char[8192]; // from Prelude.java
-            int read;
-            while ((read = reader.read(chunk, 0, chunk.length)) != -1) {
-                res.append(chunk, 0, read);
-            }
-            return res.toString();
+        try (Reader reader = reg.getCharacterReader(loc)) {
+            return IOUtils.toString(reader);
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Error reading file %s", loc));
         }
     }
 
@@ -320,7 +317,7 @@ public class RascalLanguageServices {
                 ;
         }
 
-        var input = readFile(loc, "UTF-8");
+        var input = readFile(loc);
         return parseSourceFile(loc, input);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -49,7 +49,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.FileRename;
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
@@ -69,8 +68,6 @@ import org.rascalmpl.vscode.lsp.TextDocumentState;
 import org.rascalmpl.vscode.lsp.util.EvaluatorUtil;
 import org.rascalmpl.vscode.lsp.util.RascalServices;
 import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
-import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
-import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
@@ -210,11 +207,7 @@ public class RascalLanguageServices {
     }
 
 
-    public InterruptibleFuture<ITuple> getRename(ITree module, Position cursor, Set<ISourceLocation> workspaceFolders, Function<ISourceLocation, PathConfig> getPathConfig, String newName, ColumnMaps columns) {
-        var moduleLocation = TreeAdapter.getLocation(module);
-        Position pos = Locations.toRascalPosition(moduleLocation, cursor, columns);
-        var cursorTree = TreeAdapter.locateLexical(module, pos.getLine(), pos.getCharacter());
-
+    public InterruptibleFuture<ITuple> getRename(ITree cursorTree, Set<ISourceLocation> workspaceFolders, Function<ISourceLocation, PathConfig> getPathConfig, String newName) {
         return runEvaluator("Rascal rename", semanticEvaluator, eval -> {
             try {
                 IFunction rascalGetPathConfig = eval.getFunctionValueFactory().function(getPathConfigType, (t, u) -> addResources(getPathConfig.apply((ISourceLocation) t[0])));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -316,7 +316,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
                 // Find all trees containing the cursor, in ascending order of size
                 IList focusList = TreeSearch.computeFocusList(tr, rascalCursorPos.getLine(), rascalCursorPos.getCharacter());
-                List<String> sortNames = focusList.stream().map(tree -> ProductionAdapter.getSortName(TreeAdapter.getProduction((ITree) tree))).collect(Collectors.toList());
+                List<String> sortNames = focusList.stream()
+                    .map(tree -> ProductionAdapter.getSortName(TreeAdapter.getProduction((ITree) tree)))
+                    .collect(Collectors.toList());
 
                 int qNameIdx = sortNames.indexOf("QualifiedName");
                 if (qNameIdx != -1) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -401,7 +401,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .thenCompose(docChanges -> client.applyEdit(new ApplyWorkspaceEditParams(docChanges)))
             .thenAccept(editResponse -> {
                 if (!editResponse.isApplied()) {
-                    throw new RuntimeException("Applying module rename failed: " + editResponse.getFailureReason());
+                    throw new RuntimeException("Applying module rename failed" + (editResponse.getFailureReason() != null ? (": " + editResponse.getFailureReason()) : ""));
                 }
             })
             .exceptionally(e -> {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -391,7 +391,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public void didRenameFiles(RenameFilesParams params, Set<ISourceLocation> workspaceFolders) {
         logger.debug("workspace/willRenameFiles: {}", params.getFiles());
 
-        rascalServices.getModuleRenames(params.getFiles(), workspaceFolders, facts::getPathConfig).get()
+        rascalServices.getModuleRenames(params.getFiles(), workspaceFolders, facts::getPathConfig, documents).get()
             .thenApply(edits -> DocumentChanges.translateDocumentChanges(this, edits))
             .thenCompose(docChanges -> client.applyEdit(new ApplyWorkspaceEditParams(docChanges)))
             .thenAccept(editResponse -> {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -312,8 +312,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                     // Cursor is at a qualified name
                     ITree qualifiedName = (ITree) focusList.get(qNameIdx);
 
-                    // If the qualified name in in a header, it is a module path
-                    if (sortNames.contains("Header")) return Either3.forLeft3(DocumentChanges.locationToRange(this, TreeAdapter.getLocation(qualifiedName)));
+                    // If the qualified name is in a header, but not in module parameters or a syntax defintion, it is a full module path
+                    if (sortNames.contains("Header") && !(sortNames.contains("ModuleParameters") || sortNames.contains("SyntaxDefinition")))
+                        return Either3.forLeft3(DocumentChanges.locationToRange(this, TreeAdapter.getLocation(qualifiedName)));
 
                     // Since the cursor is not in a header, the qualified name consists of a declaration name on the right, and an optional module path prefix.
                     IList names = TreeAdapter.getListASTArgs(TreeAdapter.getArg(qualifiedName, "names"));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -153,7 +153,6 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return columns.get(file);
     }
 
-    @Override
     public String getContents(ISourceLocation file) {
         file = file.top();
         TextDocumentState ideState = documents.get(file);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -302,7 +302,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         // Find all trees containing the cursor, in ascending order of size
         IList focusList = TreeSearch.computeFocusList(moduleTree, rascalCursorPos.getLine(), rascalCursorPos.getCharacter());
         List<String> sortNames = focusList.stream()
-            .map(tree -> ProductionAdapter.getSortName(TreeAdapter.getProduction((ITree) tree)))
+            .map(ITree.class::cast)
+            .map(TreeAdapter::getProduction)
+            .map(ProductionAdapter::getSortName)
             .collect(Collectors.toList());
 
         int qNameIdx = sortNames.indexOf("QualifiedName");

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -296,7 +296,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             ;
     }
 
-    private ITree getCursorFromPosition(ISourceLocation file, ITree moduleTree, Position p) {
+    private ITree findQualifiedNameUnderCursor(ISourceLocation file, ITree moduleTree, Position p) {
         Position rascalCursorPos = Locations.toRascalPosition(file, p, columns);
 
         // Find all trees containing the cursor, in ascending order of size
@@ -343,7 +343,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return file.getCurrentTreeAsync()
             .thenApply(Versioned::get)
             .handle((t, r) -> (t == null ? file.getMostRecentTree().get() : t))
-            .thenApply(tr -> getCursorFromPosition(file.getLocation(), tr, params.getPosition()))
+            .thenApply(tr -> findQualifiedNameUnderCursor(file.getLocation(), tr, params.getPosition()))
             .thenApply(cur -> DocumentChanges.locationToRange(this, TreeAdapter.getLocation(cur)))
             .thenApply(Either3::forFirst);
     }
@@ -361,7 +361,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return file.getCurrentTreeAsync()
             .thenApply(Versioned::get)
             .handle((t, r) -> (t == null ? (file.getMostRecentTree().get()) : t))
-            .thenApply(tr -> getCursorFromPosition(file.getLocation(), tr, params.getPosition()))
+            .thenApply(tr -> findQualifiedNameUnderCursor(file.getLocation(), tr, params.getPosition()))
             .thenCompose(cursor -> rascalServices.getRename(cursor, workspaceFolders, facts::getPathConfig, params.getNewName()).get())
             .thenApply(t -> DocumentChanges.translateDocumentChanges(this, t));
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -389,7 +389,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     @Override
     public void didRenameFiles(RenameFilesParams params, Set<ISourceLocation> workspaceFolders) {
-        logger.debug("workspace/willRenameFiles: {}", params.getFiles());
+        logger.debug("workspace/didRenameFiles: {}", params.getFiles());
 
         rascalServices.getModuleRenames(params.getFiles(), workspaceFolders, facts::getPathConfig, documents).get()
             .thenApply(edits -> DocumentChanges.translateDocumentChanges(this, edits))

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -169,13 +169,6 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         }
     }
 
-    Set<ISourceLocation> getFolderContents(ISourceLocation folder) {
-        return documents.keySet()
-            .stream()
-            .filter(file -> URIUtil.isParentOf(folder, file))
-            .collect(Collectors.toSet());
-    }
-
     public void initializeServerCapabilities(ServerCapabilities result) {
         result.setDefinitionProvider(true);
         result.setTextDocumentSync(TextDocumentSyncKind.Full);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -390,7 +390,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public void didRenameFiles(RenameFilesParams params, Set<ISourceLocation> workspaceFolders) {
         logger.debug("workspace/didRenameFiles: {}", params.getFiles());
 
-        rascalServices.getModuleRenames(params.getFiles(), workspaceFolders, facts::getPathConfig, documents).get()
+        rascalServices.getModuleRenames(params.getFiles(), workspaceFolders, facts::getPathConfig, documents)
             .thenApply(edits -> DocumentChanges.translateDocumentChanges(this, edits))
             .thenCompose(docChanges -> client.applyEdit(new ApplyWorkspaceEditParams(docChanges)))
             .thenAccept(editResponse -> {
@@ -399,8 +399,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 }
             })
             .exceptionally(e -> {
+                logger.catching(Level.ERROR, e.getCause());
                 client.showMessage(new MessageParams(MessageType.Error, e.getCause().getMessage()));
-                return null;
+                return null; // Return of type `Void` is unused, but required
             });
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -321,8 +321,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                     ITree qualifiedName = (ITree) focusList.get(qNameIdx);
 
                     // If the qualified name is in a header, but not in module parameters or a syntax defintion, it is a full module path
-                    if (sortNames.contains("Header") && !(sortNames.contains("ModuleParameters") || sortNames.contains("SyntaxDefinition")))
+                    if (sortNames.contains("Header") && !(sortNames.contains("ModuleParameters") || sortNames.contains("SyntaxDefinition"))) {
                         return Either3.forLeft3(DocumentChanges.locationToRange(this, TreeAdapter.getLocation(qualifiedName)));
+                    }
 
                     // Since the cursor is not in a header, the qualified name consists of a declaration name on the right, and an optional module path prefix.
                     IList names = TreeAdapter.getListASTArgs(TreeAdapter.getArg(qualifiedName, "names"));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -101,7 +101,6 @@ import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.parser.gtd.exception.ParseError;
 import org.rascalmpl.uri.URIResolverRegistry;
-import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
@@ -400,7 +399,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 }
             })
             .exceptionally(e -> {
-                client.showMessage(new MessageParams(MessageType.Error, e.getMessage()));
+                client.showMessage(new MessageParams(MessageType.Error, e.getCause().getMessage()));
                 return null;
             });
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -41,6 +41,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -82,7 +82,7 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
 
     @Override
     public void didRenameFiles(RenameFilesParams params) {
-        logger.debug("workspace/willRenameFiles: {}", params.getFiles());
+        logger.debug("workspace/didRenameFiles: {}", params.getFiles());
 
         Set<ISourceLocation> workspaceFolders = workspaceFolders()
             .stream()

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -40,6 +40,7 @@ import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.FileOperationFilter;
 import org.eclipse.lsp4j.FileOperationOptions;
 import org.eclipse.lsp4j.FileOperationPattern;
+import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.RenameFilesParams;
@@ -75,7 +76,12 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
             ServerCapabilities capabilities) {
         super.initialize(clientCap, currentWorkspaceFolders, capabilities);
 
-        capabilities.getWorkspace().getFileOperations().setDidRename(new FileOperationOptions(List.of(new FileOperationFilter(new FileOperationPattern("**/*.rsc")))));
+        var fileCap = new FileOperationsServerCapabilities();
+        fileCap.setDidRename(new FileOperationOptions(
+            List.of(new FileOperationFilter(new FileOperationPattern("**/*.rsc")))
+        ));
+
+        capabilities.getWorkspace().setFileOperations(fileCap);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -26,16 +26,206 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.FileOperationFilter;
+import org.eclipse.lsp4j.FileOperationOptions;
+import org.eclipse.lsp4j.FileOperationPattern;
+import org.eclipse.lsp4j.FileRename;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.RenameFilesParams;
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.rascalmpl.library.util.PathConfig;
+import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.values.parsetrees.ITree;
+import org.rascalmpl.values.parsetrees.ProductionAdapter;
+import org.rascalmpl.values.parsetrees.TreeAdapter;
+import org.rascalmpl.values.parsetrees.visitors.IdentityTreeVisitor;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
+import org.rascalmpl.vscode.lsp.TextDocumentState;
+import org.rascalmpl.vscode.lsp.util.Versioned;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
+
+import io.usethesource.vallang.ISourceLocation;
+import io.usethesource.vallang.IValue;
 
 public class RascalWorkspaceService extends BaseWorkspaceService {
     private static final Logger logger = LogManager.getLogger(RascalWorkspaceService.class);
 
+    private final RascalTextDocumentService rascalDocService;
+
     RascalWorkspaceService(IBaseTextDocumentService documentService) {
         super(documentService);
+        rascalDocService = (RascalTextDocumentService) documentService;
     }
 
+    @Override
+    public void initialize(ClientCapabilities clientCap, @Nullable List<WorkspaceFolder> currentWorkspaceFolders,
+            ServerCapabilities capabilities) {
+        super.initialize(clientCap, currentWorkspaceFolders, capabilities);
+
+        capabilities.getWorkspace().getFileOperations().setWillRename(new FileOperationOptions(List.of(new FileOperationFilter(new FileOperationPattern("**/*.rsc")))));
+    }
+
+    private Pair<String, Range> processQNamePrefix(ITree qn) {
+        ISourceLocation fileLoc = TreeAdapter.getLocation(qn).top();
+        List<ITree> nameSegments = TreeAdapter.getListASTArgs(TreeAdapter.getArg(qn, "names")).stream().map(ITree.class::cast).collect(Collectors.toList());
+        String fullName = TreeAdapter.yield(qn);
+
+        // Check if prefix is present
+        if (nameSegments.size() <= 1) return Pair.of("", null);
+
+        ITree firstPrefName = nameSegments.get(0);
+        ITree lastPrefname = nameSegments.get(nameSegments.size() - 2);
+        Position start = Locations.toPosition(TreeAdapter.getLocation(firstPrefName), rascalDocService.getColumnMap(fileLoc)    , false);
+        Position end = Locations.toPosition(TreeAdapter.getLocation(lastPrefname), rascalDocService.getColumnMap(fileLoc), true);
+
+        int prefixEndIdx = fullName.lastIndexOf("::");
+        String prefix = fullName.substring(0, prefixEndIdx);
+
+        return Pair.of(prefix, new Range(start, end));
+    }
+
+    private Pair<String, Range> processQName(ITree qn) {
+        ISourceLocation fileLoc = TreeAdapter.getLocation(qn).top();
+        return Pair.of(TreeAdapter.yield(qn), Locations.toRange(TreeAdapter.getLocation(qn), rascalDocService.getColumnMap(fileLoc)));
+    }
+
+    private ISourceLocation sourceLocationFromUri(String uri) {
+        try {
+            return URIUtil.createFromURI(uri);
+        } catch (URISyntaxException e) {
+            throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed, e.getMessage(), null));
+        }
+    }
+
+    private Map<String, String> qualfiedNameChangesFromRenames(List<FileRename> renames, List<ISourceLocation> wsFolders) {
+        return renames.stream()
+            .map(rename -> {
+                ISourceLocation currentLoc = sourceLocationFromUri(rename.getOldUri());
+                ISourceLocation newLoc = sourceLocationFromUri(rename.getNewUri());
+
+                ISourceLocation currentWsFolder = wsFolders.stream()
+                    .filter(folderLoc -> URIUtil.isParentOf(folderLoc, currentLoc))
+                    .findFirst()
+                    .orElseThrow(() -> new ResponseErrorException(new ResponseError(ResponseErrorCode.InvalidParams,
+                        String.format("Cannot move %s, since that location is outside the current workspace", currentLoc), null)));;
+
+                ISourceLocation newWsFolder = wsFolders.stream()
+                    .filter(folderLoc -> URIUtil.isParentOf(folderLoc, newLoc))
+                    .findFirst()
+                    .orElseThrow(() -> new ResponseErrorException(new ResponseError(ResponseErrorCode.InvalidParams,
+                        String.format("Cannot move file to %s, since that location is outside the current workspace", newLoc), null)));
+
+                if (!currentWsFolder.equals(newWsFolder)) {
+                    String commonProjPrefix = StringUtils.getCommonPrefix(currentWsFolder.toString(), newWsFolder.toString());
+                    String currentProject = StringUtils.removeStart(currentWsFolder.toString(), commonProjPrefix);
+                    String newProject = StringUtils.removeStart(newWsFolder.toString(), commonProjPrefix);
+
+                    throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed,
+                        String.format("Moving files between projects (from %s to %s) is not supported", currentProject, newProject), null));
+                }
+
+                PathConfig pcfg = rascalDocService.facts.getPathConfig(currentWsFolder);
+                try {
+                    String currentName = pcfg.getModuleName(currentLoc);
+                    String newName = pcfg.getModuleName(newLoc);
+
+                    return Pair.of(currentName, newName);
+                } catch (IOException e) {
+                    throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed, e.getMessage(), null));
+                }
+            })
+            .collect(Collectors.toConcurrentMap(Pair::getLeft, Pair::getRight));
+    }
+
+    private boolean checkAndAddCandidate(final Map<String, String> nameChanges, Pair<String, Range> info, Map<Range, String> changeLocations) {
+        if (nameChanges.containsKey(info.getKey())) {
+            changeLocations.put(info.getValue(), nameChanges.get(info.getKey()));
+            return true;
+        }
+        return false;
+    }
+
+    private TextDocumentEdit collectChanges(final Map<String, String> nameChanges, ITree tree) {
+        Map<Range, String> changeLocations = new HashMap<>();
+        tree.accept(new IdentityTreeVisitor<RuntimeException>() {
+            @Override
+            public ITree visitTreeAppl(ITree arg) throws RuntimeException  {
+                if ("QualifiedName".equals(ProductionAdapter.getSortName(TreeAdapter.getProduction(arg)))
+                    && !checkAndAddCandidate(nameChanges, processQName(arg), changeLocations)) {
+                    checkAndAddCandidate(nameChanges, processQNamePrefix(arg), changeLocations);
+                }
+
+                for (IValue child : TreeAdapter.getArgs(arg)) {
+                    child.accept(this);
+                }
+                return null;
+            }
+        });
+
+        List<TextEdit> edits = changeLocations.entrySet().stream()
+            .map(entry -> new TextEdit(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList());
+
+        return new TextDocumentEdit(new VersionedTextDocumentIdentifier(TreeAdapter.getLocation(tree).top().getURI().toString(), null), edits);
+    }
+
+    @Override
+    public CompletableFuture<WorkspaceEdit> willRenameFiles(RenameFilesParams params) {
+        logger.debug("workspace/willRenameFiles: {}", params.getFiles());
+
+        return CompletableFuture.supplyAsync(() -> {
+            List<ISourceLocation> wsFolders = workspaceFolders().stream()
+                .sorted(Comparator.comparing(WorkspaceFolder::getUri))
+                .map(wsFolder -> sourceLocationFromUri(wsFolder.getUri()))
+                .collect(Collectors.toList());
+
+            final Map<String, String> qualifiedNameChanges = qualfiedNameChangesFromRenames(params.getFiles(), wsFolders);
+
+            List<TextDocumentEdit> docChanges = wsFolders.stream()
+                .flatMap(folder -> rascalDocService.getFolderContents(folder).stream())
+                .parallel()
+                .map(fileLoc -> {
+                    TextDocumentState file = rascalDocService.getFile(fileLoc);
+                    return file.getCurrentTreeAsync()
+                        .thenApply(Versioned::get)
+                        .handle((t, r) -> (t == null ? file.getMostRecentTree().get() : t))
+                        .thenApply(tree -> collectChanges(qualifiedNameChanges, tree));
+                })
+                .map(CompletableFuture::join)
+                .collect(Collectors.toList());
+
+            List<Either<TextDocumentEdit, ResourceOperation>> eithers = new ArrayList<>();
+            docChanges.forEach(change -> eithers.add(Either.forLeft(change)));
+
+            return new WorkspaceEdit(eithers);
+        });
+    }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -52,7 +52,6 @@ import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.rascal.model.FileFacts;
 import org.rascalmpl.vscode.lsp.util.DocumentChanges;
-import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
@@ -68,7 +67,6 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     RascalWorkspaceService(ExecutorService exec, IBaseTextDocumentService documentService) {
         super(exec, documentService);
         this.docService = documentService;
-        new ColumnMaps(docService::getContents);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -82,10 +82,12 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     public void didRenameFiles(RenameFilesParams params) {
         logger.debug("workspace/didRenameFiles: {}", params.getFiles());
 
-        CompletableFuture.supplyAsync(() -> workspaceFolders()
-            .stream()
-            .map(f -> Locations.toLoc(f.getUri()))
-            .collect(Collectors.toSet()), getExecuter())
-                .thenAccept(folders -> ((RascalTextDocumentService) docService).didRenameFiles(params, folders));
+        CompletableFuture.supplyAsync(() ->
+            workspaceFolders()
+                .stream()
+                .map(f -> Locations.toLoc(f.getUri()))
+                .collect(Collectors.toSet())
+            , getExecuter()
+        ).thenAccept(folders -> ((RascalTextDocumentService) docService).didRenameFiles(params, folders));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -66,7 +66,7 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
 
         var fileCap = new FileOperationsServerCapabilities();
         fileCap.setDidRename(new FileOperationOptions(
-            List.of(new FileOperationFilter(new FileOperationPattern("**/*.rsc")))
+            List.of(new FileOperationFilter(new FileOperationPattern("**")))
         ));
 
         capabilities.getWorkspace().setFileOperations(fileCap);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -86,6 +86,6 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
             .stream()
             .map(f -> Locations.toLoc(f.getUri()))
             .collect(Collectors.toSet()), getExecuter())
-        .thenAccept(folders -> ((RascalTextDocumentService) docService).didRenameFiles(params, folders));
+                .thenAccept(folders -> ((RascalTextDocumentService) docService).didRenameFiles(params, folders));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -88,6 +88,6 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
                 .map(f -> Locations.toLoc(f.getUri()))
                 .collect(Collectors.toSet())
             , getExecuter()
-        ).thenAccept(folders -> ((RascalTextDocumentService) docService).didRenameFiles(params, folders));
+        ).thenAccept(folders -> docService.didRenameFiles(params, folders));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -26,28 +26,16 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.rascalmpl.vscode.lsp.BaseLanguageServer;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 
-public class RascalLanguageServer extends BaseLanguageServer {
-    public static void main(String[] args) {
-        try {
-            startLanguageServer(() -> {
-                ExecutorService threadPool = Executors.newCachedThreadPool();
-                IBaseTextDocumentService docService = new RascalTextDocumentService(threadPool);
-                return Pair.of(docService, new RascalWorkspaceService(docService));
-            }, 8888);
-        }
-        catch (Throwable e) {
-            final Logger logger = LogManager.getLogger(RascalLanguageServer.class);
-            logger.fatal(e.getMessage(), e);
-        }
+public class RascalWorkspaceService extends BaseWorkspaceService {
+    private static final Logger logger = LogManager.getLogger(RascalWorkspaceService.class);
+
+    RascalWorkspaceService(IBaseTextDocumentService documentService) {
+        super(documentService);
     }
+
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -26,20 +26,12 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -48,40 +40,20 @@ import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.FileOperationFilter;
 import org.eclipse.lsp4j.FileOperationOptions;
 import org.eclipse.lsp4j.FileOperationPattern;
-import org.eclipse.lsp4j.FileRename;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.RenameFilesParams;
-import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentEdit;
-import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceFolder;
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
-import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.rascalmpl.library.util.PathConfig;
-import org.rascalmpl.uri.URIUtil;
-import org.rascalmpl.values.parsetrees.ITree;
-import org.rascalmpl.values.parsetrees.ProductionAdapter;
-import org.rascalmpl.values.parsetrees.TreeAdapter;
-import org.rascalmpl.values.parsetrees.visitors.IdentityTreeVisitor;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
-import org.rascalmpl.vscode.lsp.TextDocumentState;
 import org.rascalmpl.vscode.lsp.rascal.model.FileFacts;
 import org.rascalmpl.vscode.lsp.util.DocumentChanges;
-import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IValue;
 
 public class RascalWorkspaceService extends BaseWorkspaceService {
     private static final Logger logger = LogManager.getLogger(RascalWorkspaceService.class);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -27,7 +27,7 @@
 package org.rascalmpl.vscode.lsp.rascal;
 
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -47,8 +47,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
-
-import io.usethesource.vallang.ISourceLocation;
 
 public class RascalWorkspaceService extends BaseWorkspaceService {
     private static final Logger logger = LogManager.getLogger(RascalWorkspaceService.class);
@@ -84,11 +82,10 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     public void didRenameFiles(RenameFilesParams params) {
         logger.debug("workspace/didRenameFiles: {}", params.getFiles());
 
-        Set<ISourceLocation> workspaceFolders = workspaceFolders()
+        CompletableFuture.supplyAsync(() -> workspaceFolders()
             .stream()
             .map(f -> Locations.toLoc(f.getUri()))
-            .collect(Collectors.toSet());
-
-        ((RascalTextDocumentService) docService).didRenameFiles(params, workspaceFolders);
+            .collect(Collectors.toSet()), getExecuter())
+        .thenAccept(folders -> ((RascalTextDocumentService) docService).didRenameFiles(params, folders));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -60,14 +60,12 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     private static final Logger logger = LogManager.getLogger(RascalWorkspaceService.class);
 
     private final IBaseTextDocumentService docService;
-    private final ExecutorService ownExecuter;
     private @MonotonicNonNull RascalLanguageServices rascalServices;
     private @MonotonicNonNull FileFacts facts;
     private @MonotonicNonNull LanguageClient client;
 
     RascalWorkspaceService(ExecutorService exec, IBaseTextDocumentService documentService) {
-        super(documentService);
-        this.ownExecuter = exec;
+        super(exec, documentService);
         this.docService = documentService;
         new ColumnMaps(docService::getContents);
     }
@@ -84,7 +82,7 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     public void connect(LanguageClient client) {
         super.connect(client);
         this.client = client;
-        this.rascalServices = new RascalLanguageServices((RascalTextDocumentService) docService, this, (IBaseLanguageClient) client, ownExecuter);
+        this.rascalServices = new RascalLanguageServices((RascalTextDocumentService) docService, this, (IBaseLanguageClient) client, getExecuter());
         this.facts = ((RascalTextDocumentService) docService).getFileFacts();
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentChanges.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentChanges.java
@@ -105,7 +105,7 @@ public class DocumentChanges {
             .collect(Collectors.toList());
     }
 
-    private static Range locationToRange(final IBaseTextDocumentService docService, ISourceLocation loc) {
+    public static Range locationToRange(final IBaseTextDocumentService docService, ISourceLocation loc) {
         LineColumnOffsetMap columnMap = docService.getColumnMap(loc);
         return Locations.toRange(loc, columnMap);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentChanges.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentChanges.java
@@ -41,6 +41,7 @@ import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.util.locations.LineColumnOffsetMap;
@@ -63,6 +64,13 @@ import io.usethesource.vallang.IValue;
  */
 public class DocumentChanges {
     private DocumentChanges() { }
+
+    public static WorkspaceEdit translateDocumentChanges(final IBaseTextDocumentService docService, ITuple edits) {
+        WorkspaceEdit wsEdit = new WorkspaceEdit();
+        wsEdit.setDocumentChanges(DocumentChanges.translateDocumentChanges(docService, (IList) edits.get(0)));
+        wsEdit.setChangeAnnotations(DocumentChanges.translateChangeAnnotations((IMap) edits.get(1)));
+        return wsEdit;
+    }
 
     public static List<Either<TextDocumentEdit, ResourceOperation>> translateDocumentChanges(final IBaseTextDocumentService docService, IList list) {
         List<Either<TextDocumentEdit, ResourceOperation>> result = new ArrayList<>(list.size());
@@ -114,7 +122,7 @@ public class DocumentChanges {
         return ((ISourceLocation) edit.get(label)).getURI().toString();
     }
 
-    public static Map<String, ChangeAnnotation> translateChangeAnnotations(IMap annos) {
+    private static Map<String, ChangeAnnotation> translateChangeAnnotations(IMap annos) {
         return annos.stream()
             .map(ITuple.class::cast)
             .map(entry -> {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -125,6 +125,10 @@ public class Locations {
         return new Location(sloc.getURI().toString(), toRange(sloc, cm));
     }
 
+    public static Location toLSPLocation(ISourceLocation sloc, LineColumnOffsetMap map) {
+        return new Location(sloc.getURI().toString(), toRange(sloc, map));
+    }
+
     public static Range toRange(ISourceLocation sloc, ColumnMaps cm) {
         return toRange(sloc, cm.get(sloc));
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -50,6 +50,8 @@ import lang::rascal::\syntax::Rascal;
 
 import lang::rascalcore::check::Checker;
 
+import lang::rascal::lsp::refactor::rename::Modules;
+
 extend lang::rascal::lsp::refactor::Exception;
 import lang::rascal::lsp::refactor::Util;
 import lang::rascal::lsp::refactor::WorkspaceInfo;
@@ -61,8 +63,6 @@ import util::LanguageServer;
 import util::Maybe;
 import util::Monitor;
 import util::Reflective;
-
-alias Edits = tuple[list[DocumentEdit], map[ChangeAnnotationId, ChangeAnnotation]];
 
 private str MANDATORY_CHANGE_DESCRIPTION = "These changes are required for a correct renaming. They can be previewed here, but it is not advised to disable them.";
 
@@ -650,6 +650,9 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
 
     return <changes + renames, changeAnnotations>;
 }, totalWork = 7);
+
+Edits rascalRenameModule(map[str, str] qualifiedNameChanges, set[loc] workspaceFolders) =
+    propagateModuleRenames(qualifiedNameChanges, workspaceFolders);
 
 //// WORKAROUNDS
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -653,8 +653,8 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
     return <changes + renames, changeAnnotations>;
 }, totalWork = 7);
 
-Edits rascalRenameModule(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
-    propagateModuleRenames(qualifiedNameChanges, workspaceFolders, getPathConfig);
+Edits rascalRenameModule(list[tuple[loc old, loc new]] renames, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
+    propagateModuleRenames(renames, workspaceFolders, getPathConfig);
 
 //// WORKAROUNDS
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -653,8 +653,8 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
     return <changes + renames, changeAnnotations>;
 }, totalWork = 7);
 
-Edits rascalRenameModule(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig, Tree(loc) getModuleTree) =
-    propagateModuleRenames(qualifiedNameChanges, workspaceFolders, getPathConfig, getModuleTree);
+Edits rascalRenameModule(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
+    propagateModuleRenames(qualifiedNameChanges, workspaceFolders, getPathConfig);
 
 //// WORKAROUNDS
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -128,13 +128,14 @@ private set[IllegalRenameReason] rascalCheckCausesDoubleDeclarations(TModel ws, 
     return {doubleDeclaration(old, doubleDeclarations[old]) | old <- (doubleDeclarations + doubleFieldDeclarations + doubleTypeParamDeclarations).old};
 }
 
-private set[IllegalRenameReason] rascalCheckCausesCaptures(TModel ws, start[Module] m, set[loc] currentDefs, set[loc] currentUses, set[Define] newDefs) {
+private set[IllegalRenameReason] rascalCheckCausesCaptures(TModel ws, loc moduleLoc, set[loc] currentDefs, set[loc] currentUses, set[Define] newDefs) {
     set[Define] rascalFindImplicitDefinitions(TModel ws, start[Module] m, set[Define] newDefs) {
         set[loc] maybeImplicitDefs = {l | /QualifiedName n := m, just(l) := rascalLocationOfName(n)};
         return {def | Define def <- newDefs, (def.idRole is variableId && def.defined in ws.useDef<0>)
                                         || (def.idRole is patternVariableId && def.defined in maybeImplicitDefs)};
     }
 
+    start[Module] m = parseModuleWithSpacesCached(moduleLoc);
     set[Define] newNameImplicitDefs = rascalFindImplicitDefinitions(ws, m, newDefs);
 
     // Will this rename turn an implicit declaration of `newName` into a use of a current declaration?
@@ -170,15 +171,18 @@ private set[IllegalRenameReason] rascalCheckCausesCaptures(TModel ws, start[Modu
     return allCaptures == {} ? {} : {captureChange(allCaptures)};
 }
 
-private set[IllegalRenameReason] rascalCollectIllegalRenames(TModel ws, start[Module] m, set[loc] currentDefs, set[loc] currentUses, str newName) {
+private set[IllegalRenameReason] rascalCollectIllegalRenames(TModel ws, rel[loc file, RenameLocation rename] defsPerFile, rel[loc file, RenameLocation rename] usesPerFile, str newName) {
     set[Define] newNameDefs = {def | Define def:<_, newName, _, _, _, _> <- ws.defines};
+    set[loc] editFiles = defsPerFile.file + usesPerFile.file;
 
-    return
-        rascalCheckLegalName(newName, definitionsRel(ws)[currentDefs].idRole)
-      + rascalCheckDefinitionsOutsideWorkspace(ws, currentDefs)
-      + rascalCheckCausesDoubleDeclarations(ws, currentDefs, newNameDefs, newName)
-      + rascalCheckCausesCaptures(ws, m, currentDefs, currentUses, newNameDefs)
-    ;
+    set[IllegalRenameReason] reasons = {};
+    reasons += rascalCheckLegalName(newName, definitionsRel(ws)[defsPerFile.rename.l].idRole);
+    reasons += rascalCheckDefinitionsOutsideWorkspace(ws, defsPerFile.rename.l);
+    reasons += rascalCheckCausesDoubleDeclarations(ws, defsPerFile.rename.l, newNameDefs, newName);
+    for (file <- editFiles) {
+        reasons += rascalCheckCausesCaptures(ws, file, defsPerFile[file].l, usesPerFile[file].l, newNameDefs);
+    }
+    return reasons;
 }
 
 private str rascalEscapeName(str name) = name in getRascalReservedIdentifiers() ? "\\<name>" : name;
@@ -221,13 +225,7 @@ Maybe[loc] rascalLocationOfName(Nonterminal nt) = just(nt.src);
 Maybe[loc] rascalLocationOfName(NonterminalLabel l) = just(l.src);
 default Maybe[loc] rascalLocationOfName(Tree t) = nothing();
 
-private tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits] computeTextEdits(TModel ws, start[Module] m, set[RenameLocation] defs, set[RenameLocation] uses, str name, ChangeAnnotationRegister registerChangeAnnotation) {
-    if (reasons := rascalCollectIllegalRenames(ws, m, defs.l, uses.l, name), reasons != {}) {
-        return <reasons, []>;
-    }
-
-    replaceName = rascalEscapeName(name);
-
+private list[TextEdit] computeTextEdits(TModel ws, start[Module] m, set[RenameLocation] defs, set[RenameLocation] uses, cursor(cursorKind, _, _), str newName, ChangeAnnotationRegister registerChangeAnnotation) {
     rel[loc l, Maybe[ChangeAnnotationId] ann, bool isDef] renames =
         {<l, a, true>  | <l, a> <- defs}
       + {<l, a, false> | <l, a> <- uses};
@@ -238,15 +236,17 @@ private tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits] computeTex
 
     // Note: if the implementer of the rename logic has attached annotations to multiple rename suggestions that have the same
     // name location, one will be arbitrarily chosen here. This could mean that a `needsConfirmation` annotation is thrown away.
-    return <{}, [{just(annotation), *_} := renameOpts.ann
-                 ? replace(l, replaceName, annotation = annotation)
-                 : replace(l, replaceName, annotation = any(b <- renameOpts.isDef) ? defAnno : useAnno)
-                 | l <- nameOfUseDef.name
-                 , rel[Maybe[ChangeAnnotationId] ann, bool isDef] renameOpts := renames[nameOfUseDef[l]]]>;
+    return [
+        {just(annotation), *_} := renameOpts.ann
+        ? replace(l, rascalEscapeName(newName), annotation = annotation)
+        : replace(l, rascalEscapeName(newName), annotation = any(b <- renameOpts.isDef) ? defAnno : useAnno)
+        | l <- nameOfUseDef.name
+        , rel[Maybe[ChangeAnnotationId] ann, bool isDef] renameOpts := renames[nameOfUseDef[l]]
+    ];
 }
 
-private tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits] computeTextEdits(TModel ws, loc moduleLoc, set[RenameLocation] defs, set[RenameLocation] uses, str name, ChangeAnnotationRegister registerChangeAnnotation) =
-    computeTextEdits(ws, parseModuleWithSpacesCached(moduleLoc), defs, uses, name, registerChangeAnnotation);
+private list[TextEdit] computeTextEdits(TModel ws, loc moduleLoc, set[RenameLocation] defs, set[RenameLocation] uses, Cursor cur, str newName, ChangeAnnotationRegister registerChangeAnnotation) =
+    computeTextEdits(ws, parseModuleWithSpacesCached(moduleLoc), defs, uses, cur, newName, registerChangeAnnotation);
 
 private bool rascalIsFunctionLocalDefs(TModel ws, set[loc] defs) {
     for (d <- defs) {
@@ -607,20 +607,20 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
     set[loc] \files = defsPerFile.file + usesPerFile.file;
 
     step("checking rename validity", 1);
-
-    map[loc, tuple[set[IllegalRenameReason] reasons, list[TextEdit] edits]] moduleResults =
-        (file: <reasons, edits> | file <- \files, <reasons, edits> := computeTextEdits(ws, file, defsPerFile[file], usesPerFile[file], newName, registerChangeAnnotation));
-
-    if (reasons := union({moduleResults[file].reasons | file <- moduleResults}), reasons != {}) {
-        list[str] reasonDescs = toList({describe(r) | r <- reasons});
-        throw illegalRename("Rename is not valid, because:\n - <intercalate("\n - ", reasonDescs)>", reasons);
+    if (reasons := rascalCollectIllegalRenames(ws, defsPerFile, usesPerFile, newName)
+      , reasons != {}) {
+        throw illegalRename("Rename is not valid, because:\n - <intercalate("\n - ", toList({describe(r) | r <- reasons}))>", reasons);
     }
 
-    list[DocumentEdit] changes = [changed(file, moduleResults[file].edits) | file <- moduleResults];
+    step("building list of edits", 1);
+    map[loc, list[TextEdit]] moduleResults =
+        (file: edits | file <- \files, edits := computeTextEdits(ws, file, defsPerFile[file], usesPerFile[file], cur, newName, registerChangeAnnotation));
+
+    list[DocumentEdit] changes = [changed(file, moduleResults[file]) | file <- moduleResults];
     list[DocumentEdit] renames = [renamed(from, to) | <from, to> <- getRenames(newName)];
 
     return <changes + renames, changeAnnotations>;
-}, totalWork = 6);
+}, totalWork = 7);
 
 //// WORKAROUNDS
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -187,7 +187,9 @@ private set[IllegalRenameReason] rascalCollectIllegalRenames(TModel ws, rel[loc 
 }
 
 @memo{maximumSize(1000), expireAfter(minutes=5)}
-private str rascalEscapeName(str name) = name in getRascalReservedIdentifiers() ? "\\<name>" : name;
+private str rascalEscapeName(str name) = intercalate("::", [n in getRascalReservedIdentifiers() ? "\\<n>" : n | n <- split("::", name)]);
+
+private str rascalUnescapeName(str name) = replaceAll(name, "\\", "");
 
 // Find the smallest trees of defined non-terminal type with a source location in `useDefs`
 private rel[loc name, loc useDef] rascalFindNamesInUseDefs(start[Module] m, set[loc] useDefs, CursorKind cursorKind) {
@@ -646,7 +648,7 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
         (file: edits | file <- \files, edits := computeTextEdits(ws, file, defsPerFile[file], usesPerFile[file], cur, newName, registerChangeAnnotation));
 
     list[DocumentEdit] changes = [changed(file, moduleResults[file]) | file <- moduleResults];
-    list[DocumentEdit] renames = [renamed(from, to) | <from, to> <- getRenames(newName)];
+    list[DocumentEdit] renames = [renamed(from, to) | <from, to> <- getRenames(rascalUnescapeName(newName))];
 
     return <changes + renames, changeAnnotations>;
 }, totalWork = 7);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -653,8 +653,8 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
     return <changes + renames, changeAnnotations>;
 }, totalWork = 7);
 
-Edits rascalRenameModule(map[str, str] qualifiedNameChanges, set[loc] workspaceFolders) =
-    propagateModuleRenames(qualifiedNameChanges, workspaceFolders);
+Edits rascalRenameModule(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
+    propagateModuleRenames(qualifiedNameChanges, workspaceFolders, getPathConfig);
 
 //// WORKAROUNDS
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -653,8 +653,8 @@ Edits rascalRenameSymbol(Tree cursorT, set[loc] workspaceFolders, str newName, P
     return <changes + renames, changeAnnotations>;
 }, totalWork = 7);
 
-Edits rascalRenameModule(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
-    propagateModuleRenames(qualifiedNameChanges, workspaceFolders, getPathConfig);
+Edits rascalRenameModule(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig, Tree(loc) getModuleTree) =
+    propagateModuleRenames(qualifiedNameChanges, workspaceFolders, getPathConfig, getModuleTree);
 
 //// WORKAROUNDS
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
@@ -38,6 +38,10 @@ import util::Reflective;
 
 import lang::rascal::\syntax::Rascal;
 
+import lang::rascal::lsp::refactor::TextEdits;
+
+alias Edits = tuple[list[DocumentEdit], map[ChangeAnnotationId, ChangeAnnotation]];
+
 @synopsis{
     Finds the smallest location in `wrappers` than contains `l`. If none contains `l`, returns `nothing().`
     Accepts a predicate deciding containment as an optional argument.
@@ -125,3 +129,9 @@ bool(&T, &T) desc(bool(&T, &T) f) {
         return f(t2, t1);
     };
 }
+
+set[&T] flatMap(set[&S] ss, set[&T](&S) f) =
+    {*ts | &S s <- ss, set[&T] ts := f(s)};
+
+list[&T] flatMap(list[&S] ss, list[&T](&S) f) =
+    [*ts | &S s <- ss, list[&T] ts := f(s)];

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
@@ -130,8 +130,5 @@ bool(&T, &T) desc(bool(&T, &T) f) {
     };
 }
 
-set[&T] flatMap(set[&S] ss, set[&T](&S) f) =
-    {*ts | &S s <- ss, set[&T] ts := f(s)};
-
-list[&T] flatMap(list[&S] ss, list[&T](&S) f) =
-    [*ts | &S s <- ss, list[&T] ts := f(s)];
+set[&T] flatMap(set[&S] ss, set[&T](&S) f) = ({} | it + f(s) | s <- ss);
+list[&T] flatMap(list[&S] ss, list[&T](&S) f) = ([] | it + f(s) | s <- ss);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
@@ -91,9 +91,6 @@ Maybe[&T <: Tree] tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbigui
     }
 }
 
-Maybe[&B] flatMap(nothing(), Maybe[&B](&A) _) = nothing();
-Maybe[&B] flatMap(just(&A a), Maybe[&B](&A) f) = f(a);
-
 str toString(error(msg, l)) = "[error] \'<msg>\' at <l>";
 str toString(error(msg)) = "[error] \'<msg>\'";
 str toString(warning(msg, l)) = "[warning] \'<msg>\' at <l>";

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -714,7 +714,7 @@ DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(moduleName(), cursorLoc, cur
 
     rel[loc fromFile, loc toFile] modulePaths = toRel(getModuleScopePerFile(ws)) o rascalGetTransitiveReflexiveModulePaths(ws);
     set[loc] importUses = {u
-        | <loc u, Define _: <_, _, _, moduleId(), d, _>> <- ws.useDef o definitionsRel(ws)
+        | <loc u, Define _: <_, cursorName, _, moduleId(), d, _>> <- ws.useDef o definitionsRel(ws)
         , <u.top, d> in modulePaths
     };
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -43,6 +43,7 @@ import lang::rascal::lsp::refactor::Exception;
 import lang::rascal::lsp::refactor::TextEdits;
 import lang::rascal::lsp::refactor::Util;
 
+import IO;
 import List;
 import Location;
 import Map;
@@ -710,27 +711,25 @@ DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(moduleName(), cursorLoc, cur
         }
     }
 
-    modName = getModuleName(moduleFile, getPathConfig(getProjectFolder(ws, moduleFile)));
+    defs = {ms | ms <- getModuleScopes(ws), ms.top == moduleFile};
 
-    defs = {parseModuleWithSpacesCached(moduleFile).top.header.name.names[-1].src};
-
-    imports = {u | u <- ws.useDef<0>, amodule(modName) := ws.facts[u]};
+    imports = {u | u <- ws.useDef<0>, amodule(cursorName) := ws.facts[u]};
     qualifiedUses = {
         // We compute the location of the module name in the qualified name at `u`
         // some::qualified::path::to::Foo::SomeVar
         // \____________________________/\/\_____/
-        // moduleNameSize ^  qualSepSize ^   ^ idSize
-        trim(u, removePrefix = moduleNameSize - size(cursorName)
-              , removeSuffix = idSize + qualSepSize)
+        // size(cursorName) ^ qualSepSize ^   ^ idSize
+        u
         | <loc u, Define d> <- ws.useDef o definitionsRel(ws)
         , idSize := size(d.id)
         , u.length > idSize // There might be a qualified prefix
-        , moduleNameSize := size(modName)
-        , u.length == moduleNameSize + qualSepSize + idSize
+        , u.length == size(cursorName) + qualSepSize + idSize
     };
     uses = imports + qualifiedUses;
 
-    rel[loc, loc] getRenames(str newName) = {<file, file[file = "<newName>.rsc"]> | d <- defs, file := d.top};
+    pcfg = getPathConfig(getProjectFolder(ws, moduleFile));
+    loc srcFolder = [srcFolder | relModulePath := relativize(pcfg.srcs, moduleFile), srcFolder <- pcfg.srcs, exists(srcFolder + relModulePath.path)][0];
+    rel[loc, loc] getRenames(str newName) = {<file, srcFolder + makeFileName(newName)> | d <- defs, file := d.top};
 
     return <annotateLocs(defs), annotateLocs(uses), getRenames>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -285,7 +285,6 @@ set[loc] rascalGetOverloadedDefs(TModel ws, set[loc] defs, MayOverloadFun mayOve
 }
 
 private rel[loc, loc] NO_RENAMES(str _) = {};
-private int qualSepSize = size("::");
 
 bool rascalIsCollectionType(AType at) = at is arel || at is alrel || at is atuple;
 bool rascalIsConstructorType(AType at) = at is acons;
@@ -711,21 +710,30 @@ DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(moduleName(), cursorLoc, cur
         }
     }
 
-    defs = {ms | ms <- getModuleScopes(ws), ms.top == moduleFile};
+    set[loc] defs = {ms | ms <- getModuleScopes(ws), ms.top == moduleFile};
 
-    imports = {u | u <- ws.useDef<0>, amodule(cursorName) := ws.facts[u]};
-    qualifiedUses = {
-        // We compute the location of the module name in the qualified name at `u`
-        // some::qualified::path::to::Foo::SomeVar
-        // \____________________________/\/\_____/
-        // size(cursorName) ^ qualSepSize ^   ^ idSize
-        u
-        | <loc u, Define d> <- ws.useDef o definitionsRel(ws)
-        , idSize := size(d.id)
-        , u.length > idSize // There might be a qualified prefix
-        , u.length == size(cursorName) + qualSepSize + idSize
+    rel[loc fromFile, loc toFile] modulePaths = toRel(getModuleScopePerFile(ws)) o rascalGetTransitiveReflexiveModulePaths(ws);
+    set[loc] importUses = {u
+        | <loc u, Define _: <_, _, _, moduleId(), d, _>> <- ws.useDef o definitionsRel(ws)
+        , <u.top, d> in modulePaths
     };
-    uses = imports + qualifiedUses;
+
+    rel[loc file, loc use] qualifiedUseCandidates = {
+        <u.top, u>
+        | <loc u, Define d> <- ws.useDef o definitionsRel(ws)
+        , u.length > size(d.id) // use name > declaration name, i.e. there is a qualified prefix
+    };
+    set[loc] qualifiedUses = {
+        qn.src
+        | loc file <- qualifiedUseCandidates.file
+        , start[Module] m := parseModuleWithSpacesCached(file)
+        , set[loc] localUses := qualifiedUseCandidates[file]
+        , /QualifiedName qn := m
+        , qn.src in localUses
+        , cursorName == intercalate("::", prefix(["<n>" | n <- qn.names]))
+    };
+
+    set[loc] uses = importUses + qualifiedUses;
 
     pcfg = getPathConfig(getProjectFolder(ws, moduleFile));
     loc srcFolder = [srcFolder | relModulePath := relativize(pcfg.srcs, moduleFile), srcFolder <- pcfg.srcs, exists(srcFolder + relModulePath.path)][0];

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -57,10 +57,10 @@ private bool isReachable(PathConfig toProject, PathConfig fromProject) =
     toProject == fromProject           // Both configs belong to the same project
  || toProject.bin in fromProject.libs; // The using project can import the declaring project
 
-list[TextEdit] getChanges(loc f, PathConfig wsProject, rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges) {
+list[TextEdit] getChanges(loc f, PathConfig wsProject, rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, Tree(loc) getModuleTree) {
     list[TextEdit] changes = [];
 
-    start[Module] m = parseModuleWithSpacesCached(f);
+    Tree m = getModuleTree(f);
     for (/QualifiedName qn := m) {
         for (<oldName, l> <- {fullQualifiedName(qn), qualifiedPrefix(qn)}
            , {<newName, projWithRenamedMod>} := qualifiedNameChanges[oldName]
@@ -73,7 +73,7 @@ list[TextEdit] getChanges(loc f, PathConfig wsProject, rel[str oldName, str newN
     return changes;
 }
 
-Edits propagateModuleRenames(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) {
+Edits propagateModuleRenames(rel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, set[loc] workspaceFolders, PathConfig(loc) getPathConfig, Tree(loc) getModuleTree) {
     set[PathConfig] projectWithRenamedModule = qualifiedNameChanges.pcfg;
     set[DocumentEdit] edits = flatMap(workspaceFolders, set[DocumentEdit](loc wsFolder) {
         PathConfig wsFolderPcfg = getPathConfig(wsFolder);
@@ -83,7 +83,7 @@ Edits propagateModuleRenames(rel[str oldName, str newName, PathConfig pcfg] qual
 
         return {changed(file, changes)
             | loc file <- find(wsFolder, "rsc")
-            , changes := getChanges(file, wsFolderPcfg, qualifiedNameChanges)
+            , changes := getChanges(file, wsFolderPcfg, qualifiedNameChanges, getModuleTree)
             , changes != []
         };
     });

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -1,3 +1,29 @@
+@license{
+Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
 module lang::rascal::lsp::refactor::rename::Modules
 
 import lang::rascal::lsp::refactor::TextEdits;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -1,0 +1,58 @@
+module lang::rascal::lsp::refactor::rename::Modules
+
+import lang::rascal::lsp::refactor::TextEdits;
+import lang::rascal::lsp::refactor::Util;
+
+import lang::rascal::\syntax::Rascal;
+
+import IO;
+import List;
+import Location;
+import ParseTree;
+import Set;
+import String;
+
+import util::FileSystem;
+
+data PathConfig;
+
+private tuple[str, loc] fullQualifiedName(QualifiedName qn) = <"<qn>", qn.src>;
+private tuple[str, loc] qualifiedPrefix(QualifiedName qn) {
+    list[Name] names = [n | n <- qn.names];
+    if (size(names) <= 1) return <"", |unknown:///|>;
+
+    str fullName = "<qn>";
+    str namePrefix = substring(fullName, 0, findLast(fullName, "::"));
+    loc prefixLoc = cover([n.src | Name n <- prefix(names)]);
+
+    return <namePrefix, prefixLoc>;
+}
+
+list[TextEdit] getChanges(loc f, map[str, str] qualifiedNameChanges) {
+    list[TextEdit] changes = [];
+
+    start[Module] m = parseModuleWithSpacesCached(f);
+    for (/QualifiedName qn := m) {
+        if (<fullName, fullLoc> := fullQualifiedName(qn), fullName in qualifiedNameChanges) {
+            changes += replace(fullLoc, qualifiedNameChanges[fullName]);
+        } else if (<namePrefix, prefixLoc> := qualifiedPrefix(qn), namePrefix in qualifiedNameChanges) {
+            changes += replace(prefixLoc, qualifiedNameChanges[namePrefix]);
+        }
+    }
+
+    return changes;
+}
+
+Edits propagateModuleRenames(map[str, str] qualifiedNameChanges, set[loc] workspaceFolders) {
+    set[loc] wsFiles = flatMap(workspaceFolders, set[loc](loc wsFolder) {
+        return find(wsFolder, "rsc");
+    });
+
+    set[DocumentEdit] edits = {changed(file, changes)
+        | loc file <- wsFiles
+        , changes := getChanges(file, qualifiedNameChanges)
+        , changes != []
+    };
+
+    return <toList(edits), ()>;
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -47,7 +47,7 @@ private tuple[str, loc] qualifiedPrefix(QualifiedName qn) {
     if (size(names) <= 1) return <"", |unknown:///|>;
 
     str fullName = "<qn>";
-    str namePrefix = substring(fullName, 0, findLast(fullName, "::"));
+    str namePrefix = fullName[..findLast(fullName, "::")];
     loc prefixLoc = cover([n.src | Name n <- prefix(names)]);
 
     return <namePrefix, prefixLoc>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -81,29 +81,7 @@ test bool singleModule() = testRenameOccurrences({
     ", {0, 1}, skipCursors = {1})
 }, oldName = "util::Foo", newName = "util::Bar");
 
-test bool m1() = testRenameOccurrences({
-    byText("foo::Foo", "import BarOld;", {0}),
-    byText("BarOld", "import Baz;", {0}, newName = "BarNew"),
-    byText("Baz", "
-        'void f() {}
-        'void g() {
-        '   Baz::f();
-        '}
-    ", {})
-}, oldName = "BarOld", newName = "BarNew");
-
-test bool m2() = testRenameOccurrences({
-    byText("Foo", "import BarOld;", {0}),
-    byText("BarOld", "import Baz;", {0}, newName = "BarNew"),
-    byText("Baz", "
-        'void f() {}
-        'void g() {
-        '   Baz::f();
-        '}
-    ", {})
-}, oldName = "BarOld", newName = "BarNew");
-
-test bool m3() = testRenameOccurrences({
+test bool moduleBarIsNotBaz() = testRenameOccurrences({
     byText("foo::Foo", "import Foo;", {1}),
     byText("Foo", "import Baz;", {0}, newName = "Bar"),
     byText("Baz", "

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -38,8 +38,8 @@ test bool deepModule() = testRenameOccurrences({
         'void main() {
         '   some::path::to::Foo::Bool b = and(t(), f());
         '}
-    ", {0, 1})
-}, oldName = "Foo", newName = "Bar");
+    ", {0, 1}, skipCursors = {1})
+}, oldName = "some::path::to::Foo", newName = "some::path::to::Bar");
 
 test bool shadowedModuleWithVar() = testRenameOccurrences({
     byText("Foo", "
@@ -52,7 +52,7 @@ test bool shadowedModuleWithVar() = testRenameOccurrences({
         'void main() {
         '   Foo::Bool b = and(t(), f());
         '}
-    ", {0, 1})
+    ", {0, 1}, skipCursors = {1})
 }, oldName = "Foo", newName = "Bar");
 
 test bool shadowedModuleWithFunc() = testRenameOccurrences({
@@ -65,7 +65,7 @@ test bool shadowedModuleWithFunc() = testRenameOccurrences({
         'void main() {
         '   Foo::f();
         '}
-    ", {0, 1})
+    ", {0, 1}, skipCursors = {1})
 }, oldName = "Foo", newName = "Bar");
 
 test bool singleModule() = testRenameOccurrences({
@@ -78,5 +78,45 @@ test bool singleModule() = testRenameOccurrences({
         'void main() {
         '   util::Foo::Bool b = and(t(), f());
         '}
-    ", {0, 1})
+    ", {0, 1}, skipCursors = {1})
+}, oldName = "util::Foo", newName = "util::Bar");
+
+test bool m1() = testRenameOccurrences({
+    byText("foo::Foo", "import BarOld;", {0}),
+    byText("BarOld", "import Baz;", {0}, newName = "BarNew"),
+    byText("Baz", "
+        'void f() {}
+        'void g() {
+        '   Baz::f();
+        '}
+    ", {})
+}, oldName = "BarOld", newName = "BarNew");
+
+test bool m2() = testRenameOccurrences({
+    byText("Foo", "import BarOld;", {0}),
+    byText("BarOld", "import Baz;", {0}, newName = "BarNew"),
+    byText("Baz", "
+        'void f() {}
+        'void g() {
+        '   Baz::f();
+        '}
+    ", {})
+}, oldName = "BarOld", newName = "BarNew");
+
+test bool m3() = testRenameOccurrences({
+    byText("foo::Foo", "import Foo;", {1}),
+    byText("Foo", "import Baz;", {0}, newName = "Bar"),
+    byText("Baz", "
+        'void f() {}
+        'void g() {
+        '   Baz::f();
+        '}
+    ", {})
 }, oldName = "Foo", newName = "Bar");
+
+test bool moveModule() = testRenameOccurrences({
+    byText("Foo", "int foo() = 8;", {0}, newName = "path::to::Foo"),
+    byText("Main", "
+        'import Foo;
+        'int f = Foo::foo();", {0, 1}, skipCursors = {1})
+}, oldName = "Foo", newName = "path::to::Foo");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -107,3 +107,10 @@ test bool qualifiedSelf() = testRenameOccurrences({
         '}
     ", {0, 1}, skipCursors = {1}, newName = "Bar")
 }, oldName = "Foo", newName = "Bar");
+
+@expected{unsupportedRename}
+test bool externalImport() = testRenameOccurrences({
+    byText("Main", "
+        'import Foo = |memory:///Foo.rsc|;
+    ", {0})
+}, oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -98,3 +98,12 @@ test bool moveModule() = testRenameOccurrences({
         'import Foo;
         'int f = Foo::foo();", {0, 1}, skipCursors = {1})
 }, oldName = "Foo", newName = "path::to::Foo");
+
+test bool qualifiedSelf() = testRenameOccurrences({
+    byText("Foo", "
+        'void f() {}
+        'void g() {
+        '   Foo::f();
+        '}
+    ", {0, 1}, skipCursors = {1}, newName = "Bar")
+}, oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -50,6 +50,7 @@ import lang::rascal::lsp::refactor::TextEdits;
 
 import util::FileSystem;
 import util::Math;
+import util::Maybe;
 import util::Reflective;
 
 
@@ -263,25 +264,39 @@ private tuple[Edits, set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNa
     return <edits, occs>;
 }
 
-private list[Tree] collectNameTrees(start[Module] m, str name) {
-    list[Tree] names = [];
-        visit (m) {
+private lrel[int, loc, Maybe[Tree]] collectNameTrees(start[Module] m, str name) {
+    lrel[loc, Maybe[Tree]] names = [];
+        top-down-break visit (m) {
+        case QualifiedName qn: {
+            if ("<qn>" == name) {
+                names += <qn.src, just(qn)>;
+            }
+            else {
+                modPrefix = prefix([n | n <- qn.names]);
+                if (intercalate("::", ["<n>" | n <- modPrefix]) == name) {
+                    names += <cover([n.src | n <- modPrefix]), nothing()>;
+                } else {
+                    fail;
+                }
+            }
+        }
         // 'Normal' names
         case Name n:
-            if ("<n>" == name) names += n;
+            if ("<n>" == name) names += <n.src, just(n)>;
         // Nonterminals (grammars)
         case Nonterminal s:
-            if ("<s>" == name) names += s;
+            if ("<s>" == name) names += <s.src, just(s)>;
         // Labels for nonterminals (grammars)
         case NonterminalLabel label:
-            if ("<label>" == name) names += label;
+            if ("<label>" == name) names += <label.src, just(label)>;
     }
-    return names;
+
+    return [<i, l, mt> | <i, <l, mt>> <- zip2(index(names), names)];
 }
 
 private set[int] extractRenameOccurrences(loc moduleFileName, Edits edits, str name) {
     start[Module] m = parseModuleWithSpaces(moduleFileName);
-    list[loc] oldNameOccurrences = [n.src | n <- collectNameTrees(m, name)];
+    list[loc] oldNameOccurrences = [l | <_, l, _> <- collectNameTrees(m, name)];
 
     if ([changed(_, replaces)] := edits<0>) {
         set[int] occs = {};
@@ -313,7 +328,13 @@ private Tree findCursor(loc f, str id, int occ) {
     m = parseModuleWithSpaces(f);
     names = collectNameTrees(m, id);
     if (occ >= size(names) || occ < 0) throw "Found <size(names)> occurrences of \'<id>\'; cannot use occurrence at position <occ> as cursor";
-    return names[occ];
+    maybeCursor = names[occ];
+
+    if (<i, l, nothing()> := maybeCursor) {
+        throw "Cannot use <i>th occurrence of \'<id>\' at <l> as cursor";
+    } else {
+        return (maybeCursor<2>).val;
+    }
 }
 
 private loc storeTestModule(loc dir, str name, str body) {
@@ -328,6 +349,5 @@ private loc storeTestModule(loc dir, str name, str body) {
     return moduleFile;
 }
 
-private set[Tree] occsToTrees(start[Module] m, str name, set[int] occs) = {n | i <- occs, n := collectNameTrees(m, name)[i]};
-private set[loc] occsToLocs(start[Module] m, str name, set[int] occs) = {t.src | t <- occsToTrees(m, name, occs)};
-private set[int] locsToOccs(start[Module] m, str name, set[loc] occs) = {indexOf(names, occ) | names := [n.src | n <- collectNameTrees(m, name)], occ <- occs};
+private set[int] locsToOccs(start[Module] m, str name, set[loc] occs) =
+    toSet((collectNameTrees(m, name)<1, 0>)[occs]);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ValidNames.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ValidNames.rsc
@@ -40,6 +40,28 @@ test bool renameToReservedName() {
     return newNames == {"\\int"};
 }
 
+test bool renameToUnescapedQualifiedName() = testRenameOccurrences({
+    byText("FooSyntax", "syntax S = \"s\";", {0}, newName = "syntax::Foo"),
+    byText("Main", "
+        'import FooSyntax;
+        'import ParseTree;
+        'void main() {
+        '   s = parse(#FooSyntax::S, \"s\");
+        '}
+    ", {0, 1}, skipCursors = {1})
+}, oldName = "FooSyntax", newName = "syntax::Foo");
+
+test bool renameToEscapedQualifiedName() = testRenameOccurrences({
+    byText("FooSyntax", "syntax S = \"s\";", {0}, newName = "syntax::Foo"),
+    byText("Main", "
+        'import FooSyntax;
+        'import ParseTree;
+        'void main() {
+        '   s = parse(#FooSyntax::S, \"s\");
+        '}
+    ", {0, 1}, skipCursors = {1})
+}, oldName = "FooSyntax", newName = "\\syntax::Foo");
+
 @expected{illegalRename}
 test bool renameToUsedReservedName() = testRename("
     'int \\int = 0;

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -196,21 +196,28 @@ describe('IDE', function () {
         const workspace = await explorer.getContent().getSection("test (Workspace)");
         await workspace.expand();
         await ide.openModule(TestWorkspace.libFile);
+        await ide.screenshot("IDE-find-files-in-explorer");
         const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.extremelySlow, "Cannot find Lib.rsc");
         const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.extremelySlow, "Cannot find lib folder");
 
         // Open the lib file before moving it, so we have the editor ready to inspect afterwards
         const libFile = await ide.openModule(TestWorkspace.libFile);
+        await ide.screenshot("IDE-rename-modules-before-move");
         await driver.actions().dragAndDrop(libFileInTree!, libFolderInTree).perform();
+        await ide.screenshot("IDE-rename-modules-after-move");
 
+        let tries = 1;
         await driver.wait(async() => {
             const text = await libFile.getText();
+            await ide.screenshot(`${tries++}-IDE-lib-text`);
             return text.indexOf("module lib::Lib") !== -1;
         }, Delays.extremelySlow, "Module name should have changed to `lib::Lib`");
 
         const callFile = await ide.openModule(TestWorkspace.libCallFile);
+        tries = 1;
         await driver.wait(async() => {
             const text = await callFile.getText();
+            await ide.screenshot(`${tries++}-IDE-lib-call-text`);
             return text.indexOf("import lib::Lib") !== -1;
         }, Delays.extremelySlow, "Import should have changed to `lib::Lib`");
     });

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -240,8 +240,8 @@ describe('IDE', function () {
             // Context menus are supported for Windows and Linux
             const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.normal, "Cannot find Lib.rsc");
             const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.normal, "Cannot find lib folder");
-            await driver.wait(ignoreFails((await libFileInTree!.openContextMenu()).select("Cut")), Delays.slow);
-            await driver.wait(ignoreFails((await libFolderInTree!.openContextMenu()).select("Paste")), Delays.slow);
+            await (await libFileInTree!.openContextMenu()).select("Cut");
+            await (await libFolderInTree!.openContextMenu()).select("Paste");
         }
 
         await driver.wait(async() => {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -159,7 +159,7 @@ describe('IDE', function () {
         }, Delays.normal, "Cursor should have moved to line that contains the println function");
     });
 
-    it("rename works", async() => {
+    it ("rename works", async() => {
         const editor = await ide.openModule(TestWorkspace.libFile);
         await editor.moveCursor(7, 15);
 
@@ -193,7 +193,7 @@ describe('IDE', function () {
         expect(editorText).to.contain("i -2");
     });
 
-    it.only("renaming files works", async() => {
+    it("renaming files works", async() => {
         const newDir = path.join(TestWorkspace.libProject, "src", "main", "rascal", "lib");
         await fs.mkdir(newDir, {recursive: true});
 

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -30,7 +30,6 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { By, Key, TextEditor, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
 import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
-import { fail } from 'assert';
 import * as os from 'os';
 
 

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -212,8 +212,11 @@ describe('IDE', function () {
         await driver.wait(checkRascalStatus(), Delays.extremelySlow, "Rascal evaluators have not finished loading");
 
         // Move the file
+        await ide.screenshot("1IDE-rename-before-move");
         await (await libFileInTree!.openContextMenu()).select("Cut");
+        await ide.screenshot("2IDE-rename-before-paste");
         await (await libFolderInTree!.openContextMenu()).select("Paste");
+        await ide.screenshot("3IDE-rename-after-paste");
 
         await driver.wait(async() => {
             const text = await libFile.getText();

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -196,11 +196,13 @@ describe('IDE', function () {
         const workspace = await explorer.getContent().getSection("test (Workspace)");
         await workspace.expand();
         await ide.openModule(TestWorkspace.libFile);
-        const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.normal, "Cannot find Lib.rsc");
-        const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.normal, "Cannot find lib folder");
+        const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.extremelySlow, "Cannot find Lib.rsc");
+        const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.extremelySlow, "Cannot find lib folder");
+
+        // Open the lib file before moving it, so we have the editor ready to inspect afterwards
+        const libFile = await ide.openModule(TestWorkspace.libFile);
         await driver.actions().dragAndDrop(libFileInTree!, libFolderInTree).perform();
 
-        const libFile = await ide.openModule(path.join(newDir, "Lib.rsc"));
         await driver.wait(async() => {
             const text = await libFile.getText();
             return text.indexOf("module lib::Lib") !== -1;

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -30,6 +30,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { By, Key, TextEditor, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
 import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
+import { fail } from 'assert';
 
 
 const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile];
@@ -211,12 +212,17 @@ describe('IDE', function () {
         const checkRascalStatus = ide.statusContains("Loading Rascal");
         await driver.wait(checkRascalStatus(), Delays.extremelySlow, "Rascal evaluators have not finished loading");
 
+        if (!libFileInTree) {fail("Could not find Lib.rsc");}
+        if (!libFolderInTree) {fail("Could not find lib folder");}
+
         // Move the file
         await ide.screenshot("1IDE-rename-before-move");
-        await (await libFileInTree!.openContextMenu()).select("Cut");
-        await ide.screenshot("2IDE-rename-before-paste");
-        await (await libFolderInTree!.openContextMenu()).select("Paste");
-        await ide.screenshot("3IDE-rename-after-paste");
+        const fileContextMenu = await libFileInTree.openContextMenu();
+        await ide.screenshot("2IDE-rename-after-contextclick");
+        await fileContextMenu.select("Cut");
+        await ide.screenshot("3IDE-rename-before-paste");
+        await (await libFolderInTree.openContextMenu()).select("Paste");
+        await ide.screenshot("5IDE-rename-after-paste");
 
         await driver.wait(async() => {
             const text = await libFile.getText();

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -193,15 +193,16 @@ describe('IDE', function () {
         await fs.mkdir(newDir, {recursive: true});
 
         const explorer = await (await bench.getActivityBar().getViewControl("Explorer"))!.openView();
+        await bench.executeCommand("workbench.files.action.refreshFilesExplorer")
         const workspace = await explorer.getContent().getSection("test (Workspace)");
         await workspace.expand();
         await ide.openModule(TestWorkspace.libFile);
+        // Open the lib file before moving it, so we have the editor ready to inspect afterwards
+        const libFile = await ide.openModule(TestWorkspace.libFile);
         await ide.screenshot("IDE-find-files-in-explorer");
         const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.extremelySlow, "Cannot find Lib.rsc");
         const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.extremelySlow, "Cannot find lib folder");
 
-        // Open the lib file before moving it, so we have the editor ready to inspect afterwards
-        const libFile = await ide.openModule(TestWorkspace.libFile);
         await ide.screenshot("IDE-rename-modules-before-move");
         await driver.actions().dragAndDrop(libFileInTree!, libFolderInTree).perform();
         await ide.screenshot("IDE-rename-modules-after-move");

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -203,11 +203,13 @@ describe('IDE', function () {
         const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.normal, "Cannot find Lib.rsc");
         const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.normal, "Cannot find lib folder");
 
-        await ide.screenshot("IDE-rename-modules-before-move");
-        console.log("Lib file: " + libFileInTree);
-        console.log("Lib folder: " + libFolderInTree);
-        await driver.actions().dragAndDrop(libFileInTree!, libFolderInTree).perform();
-        await ide.screenshot("IDE-rename-modules-after-move");
+        // Before moving, check that Rascal is really loaded
+        const checkRascalStatus = ide.statusContains("Loading Rascal");
+        await driver.wait(checkRascalStatus(), Delays.extremelySlow, "Rascal evaluators have not finished loading");
+
+        // Move the file
+        await (await libFileInTree!.openContextMenu()).select("Cut");
+        await (await libFolderInTree!.openContextMenu()).select("Paste");
 
         let tries = 1;
         await driver.wait(async() => {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -162,6 +162,10 @@ describe('IDE', function () {
         const editor = await ide.openModule(TestWorkspace.libFile);
         await editor.moveCursor(7, 15);
 
+        // Before moving, check that Rascal is really loaded
+        const checkRascalStatus = ide.statusContains("Loading Rascal");
+        await driver.wait(checkRascalStatus(), Delays.normal, "Rascal evaluators have not finished loading");
+
         let renameSuccess = false;
         let tries = 0;
         while (!renameSuccess && tries < 5) {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -200,8 +200,8 @@ describe('IDE', function () {
         // Open the lib file before moving it, so we have the editor ready to inspect afterwards
         const libFile = await ide.openModule(TestWorkspace.libFile);
         await ide.screenshot("IDE-find-files-in-explorer");
-        const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.extremelySlow, "Cannot find Lib.rsc");
-        const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.extremelySlow, "Cannot find lib folder");
+        const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.normal, "Cannot find Lib.rsc");
+        const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.normal, "Cannot find lib folder");
 
         await ide.screenshot("IDE-rename-modules-before-move");
         await driver.actions().dragAndDrop(libFileInTree!, libFolderInTree).perform();

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -198,7 +198,7 @@ describe('IDE', function () {
         await fs.mkdir(newDir, {recursive: true});
 
         const explorer = await (await bench.getActivityBar().getViewControl("Explorer"))!.openView();
-        await bench.executeCommand("workbench.files.action.refreshFilesExplorer")
+        await bench.executeCommand("workbench.files.action.refreshFilesExplorer");
         const workspace = await explorer.getContent().getSection("test (Workspace)");
         await workspace.expand();
 

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -25,11 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { By, DefaultTreeSection, Key, TextEditor, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
-import { Delays, IDEOperations, TestWorkspace, ignoreFails, printRascalOutputOnFailure, sleep } from './utils';
-import { expect } from 'chai';
+import { By, Key, TextEditor, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
 
 
 const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile];
@@ -193,7 +193,7 @@ describe('IDE', function () {
         await fs.mkdir(newDir, {recursive: true});
 
         const explorer = await (await bench.getActivityBar().getViewControl("Explorer"))!.openView();
-        const workspace = await explorer.getContent().getSection("test (Workspace)") as DefaultTreeSection;
+        const workspace = await explorer.getContent().getSection("test (Workspace)");
         await workspace.expand();
         await ide.openModule(TestWorkspace.libFile);
         const libFileInTree = await driver.wait(async() => workspace.findItem("Lib.rsc"), Delays.normal, "Cannot find Lib.rsc");

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -158,7 +158,7 @@ describe('IDE', function () {
         }, Delays.normal, "Cursor should have moved to line that contains the println function");
     });
 
-    it ("rename works", async() => {
+    it("rename works", async() => {
         const editor = await ide.openModule(TestWorkspace.libFile);
         await editor.moveCursor(7, 15);
 
@@ -188,7 +188,7 @@ describe('IDE', function () {
         expect(editorText).to.contain("i -2");
     });
 
-    it("renaming files works", async() => {
+    it.only("renaming files works", async() => {
         const newDir = path.join(TestWorkspace.libProject, "src", "main", "rascal", "lib");
         await fs.mkdir(newDir, {recursive: true});
 

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -211,20 +211,18 @@ describe('IDE', function () {
         await (await libFileInTree!.openContextMenu()).select("Cut");
         await (await libFolderInTree!.openContextMenu()).select("Paste");
 
-        let tries = 1;
         await driver.wait(async() => {
             const text = await libFile.getText();
-            await ide.screenshot(`${tries++}-IDE-lib-text`);
             return text.indexOf("module lib::Lib") !== -1;
-        }, Delays.extremelySlow, "Module name should have changed to `lib::Lib`");
+        }, Delays.extremelySlow, "Module name should have changed to `lib::Lib`", Delays.normal);
 
         const callFile = await ide.openModule(TestWorkspace.libCallFile);
-        tries = 1;
         await driver.wait(async() => {
             const text = await callFile.getText();
-            await ide.screenshot(`${tries++}-IDE-lib-call-text`);
             return text.indexOf("import lib::Lib") !== -1;
-        }, Delays.extremelySlow, "Import should have changed to `lib::Lib`");
+        }, Delays.extremelySlow, "Import should have changed to `lib::Lib`", Delays.normal);
+
+        await fs.rm(newDir, {recursive: true, force: true});
     });
 
     it("code actions work", async() => {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -204,6 +204,8 @@ describe('IDE', function () {
         const libFolderInTree = await driver.wait(async() => workspace.findItem("lib"), Delays.normal, "Cannot find lib folder");
 
         await ide.screenshot("IDE-rename-modules-before-move");
+        console.log("Lib file: " + libFileInTree);
+        console.log("Lib folder: " + libFolderInTree);
         await driver.actions().dragAndDrop(libFileInTree!, libFolderInTree).perform();
         await ide.screenshot("IDE-rename-modules-after-move");
 

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -217,11 +217,8 @@ describe('IDE', function () {
 
         // Move the file
         await ide.screenshot("1IDE-rename-before-move");
-        const fileContextMenu = await libFileInTree.openContextMenu();
-        await ide.screenshot("2IDE-rename-after-contextclick");
-        await fileContextMenu.select("Cut");
-        await ide.screenshot("3IDE-rename-before-paste");
-        await (await libFolderInTree.openContextMenu()).select("Paste");
+        await driver.wait(ignoreFails((await libFileInTree.openContextMenu()).select("Cut")), Delays.slow);
+        await driver.wait(ignoreFails((await libFolderInTree.openContextMenu()).select("Paste")), Delays.slow);
         await ide.screenshot("5IDE-rename-after-paste");
 
         await driver.wait(async() => {

--- a/rascal-vscode-extension/test-workspace/test.code-workspace
+++ b/rascal-vscode-extension/test-workspace/test.code-workspace
@@ -8,6 +8,9 @@
     },
 
 
-  ]
+  ],
+  "settings": {
+    "explorer.confirmDragAndDrop": false
+  }
 
 }


### PR DESCRIPTION
- [x] Support renaming fully qualified modules names (instead of last name segment only)
- [x] Reject renaming of modules from qualified declaration names.
- [x] Explicitly do not support external imports
- [x] Support module renames from explorer view.
- [x] Escape name segments (`\syntax`) and v.v.
- [x] Resolve module names via dependencies
- [x] Use 'did rename' instead of 'will rename' callback, to prevent problems in case the evaluator is locked
- [x] Add UI test for module move
- [x] Change qualified names on folder rename