### PR TITLE
Improve rename refactoring name check

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Exception.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Exception.rsc
@@ -40,7 +40,7 @@ data IllegalRenameReason
     | definitionsOutsideWorkspace(set[loc] defs)
     ;
 
-data RuntimeException
+data RenameException
     = illegalRename(str message, set[IllegalRenameReason] reason)
     | unsupportedRename(str message, rel[loc location, str message] issues = {})
     | unexpectedFailure(str message)

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -90,9 +90,10 @@ private set[IllegalRenameReason] rascalCheckLegalName(str name, set[IdRole] role
 }
 
 private void rascalCheckLegalName(str name, Symbol sym) {
+    escName = rascalEscapeName(name);
     g = grammar(#start[Module]);
-    if (!tryParseAs(type(sym, g.rules), name)) {
-        throw illegalRename("\'<name>\' is not a valid name at this position", {invalidName(name, "<sym>")});
+    if (!tryParseAs(type(sym, g.rules), escName)) {
+        throw illegalRename("\'<escName>\' is not a valid name at this position", {invalidName(escName, "<sym>")});
     }
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
@@ -30,6 +30,7 @@ import IO;
 import List;
 import Location;
 import Message;
+import ParseTree;
 import String;
 
 import util::Maybe;
@@ -77,6 +78,18 @@ bool isPrefixOf(loc prefix, loc l) = l.scheme == prefix.scheme
 start[Module] parseModuleWithSpacesCached(loc l) {
     @memo{expireAfter(minutes=5)} start[Module] parseModuleWithSpacesCached(loc l, datetime _) = parseModuleWithSpaces(l);
     return parseModuleWithSpacesCached(l, lastModified(l));
+}
+
+@synopsis{
+    Try to parse string `name` as reified type `begin` and return whether this succeeded.
+}
+bool tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
+    try {
+        parse(begin, name, allowAmbiguity = allowAmbiguity);
+        return true;
+    } catch ParseError(_): {
+        return false;
+    }
 }
 
 Maybe[&B] flatMap(nothing(), Maybe[&B](&A) _) = nothing();

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ValidNames.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ValidNames.rsc
@@ -57,3 +57,6 @@ test bool newNameHasNumericPrefix() = testRename("int foo = 8;", newName = "8abc
 
 @expected{illegalRename}
 test bool newNameIsEscapedInvalid() = testRename("int foo = 8;", newName = "\\8int");
+
+@expected{illegalRename}
+test bool qualifiedNameWhereNameExpected() = testRename("int foo = 8;", newName = "Foo::foo");


### PR DESCRIPTION
This PR improves the user experience when trying to rename to an invalid name.
- Before checking the validity of the new name based on the type of declarations, perform a quick check based on only the location in the parse tree. Since this does not require any type information, this can be performed early and efficiently, informing the user as soon as possible when the renaming will not succeed.
- Fix the type of exceptions thrown by the rename refactoring, so VS Code shows it once (instead of twice).

Closes #517.