### PR TITLE
Avoid registering the same scheme multiple times

### DIFF
--- a/rascal-vscode-extension/src/fs/RascalFileSystemProviders.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemProviders.ts
@@ -63,11 +63,17 @@ export class RascalFileSystemProvider implements vscode.FileSystemProvider {
             .map(s => {
                 try {
                     vscode.workspace.registerFileSystemProvider(s, this);
-                    this.client.info(`Scheme registered: ${s}`);
+                    this.client.debug(`Rascal VFS registered scheme: ${s}`);
                     return true;
                 } catch (error) {
-                    this.client.error(`Unable to register scheme: ${s}\n${error}`);
-                    return false;
+                    if (isUnknownFileSystem(s)) {
+                        this.client.error(`Unable to register scheme: ${s}\n${error}`);
+                        return false;
+                    }
+                    else {
+                        this.client.debug(`Rascal VFS lost the race to register scheme: ${s}, which in most cases is fine`);
+                        return true;
+                    }
                 }
             })
             .every(b => b);

--- a/rascal-vscode-extension/src/fs/RascalFileSystemProviders.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemProviders.ts
@@ -50,33 +50,28 @@ export class RascalFileSystemProvider implements vscode.FileSystemProvider {
     /**
      * Attemptes to register all schemes.
      * @param schemes The list of schemes to register for this provider
-     * @returns `true` if all schemes were registered successfully; `false` if any schemes failed to register.
      */
-    tryRegisterSchemes(schemes: string[]): boolean {
-        return schemes
+    tryRegisterSchemes(schemes: string[]) {
+        schemes
             .filter(s => !this.protectedSchemes.includes(s))
             // we add support for schemes that look inside a jar
             .concat(schemes
                 .filter(s => s !== "jar" && s !== "zip" && s !== "compressed")
                 .map(s => "jar+" + s))
             .filter(isUnknownFileSystem)
-            .map(s => {
+            .forEach(s => {
                 try {
                     vscode.workspace.registerFileSystemProvider(s, this);
                     this.client.debug(`Rascal VFS registered scheme: ${s}`);
-                    return true;
                 } catch (error) {
                     if (isUnknownFileSystem(s)) {
                         this.client.error(`Unable to register scheme: ${s}\n${error}`);
-                        return false;
                     }
                     else {
                         this.client.debug(`Rascal VFS lost the race to register scheme: ${s}, which in most cases is fine`);
-                        return true;
                     }
                 }
-            })
-            .every(b => b);
+            });
     }
 
     watch(uri: vscode.Uri, options: { recursive: boolean; excludes: string[]; }): vscode.Disposable {

--- a/rascal-vscode-extension/src/fs/VSCodeURIResolver.ts
+++ b/rascal-vscode-extension/src/fs/VSCodeURIResolver.ts
@@ -220,6 +220,10 @@ export class VSCodeUriResolverServer implements Disposable {
         toIgnore.forEach(v => this.rascalNativeSchemes.add(v));
     }
 
+    getIgnoredSchemes(): string[] {
+        return Array.from(this.rascalNativeSchemes.values());
+    }
+
     dispose() {
         this.server.close();
         this.activeClients.forEach(c => c.dispose());

--- a/rascal-vscode-extension/src/fs/VSCodeURIResolver.ts
+++ b/rascal-vscode-extension/src/fs/VSCodeURIResolver.ts
@@ -220,10 +220,6 @@ export class VSCodeUriResolverServer implements Disposable {
         toIgnore.forEach(v => this.rascalNativeSchemes.add(v));
     }
 
-    getIgnoredSchemes(): string[] {
-        return Array.from(this.rascalNativeSchemes.values());
-    }
-
     dispose() {
         this.server.close();
         this.activeClients.forEach(c => c.dispose());

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -63,10 +63,7 @@ export async function activateLanguageClient(
 
     schemesReply.then( schemes => {
         vfsServer.ignoreSchemes(schemes);
-        const allRegistered = new RascalFileSystemProvider(client).tryRegisterSchemes(schemes);
-        if (!allRegistered) {
-            client.warn(`At least one of the expected schemes failed to register.\nExpected schemes: ${schemes}`);
-        }
+        new RascalFileSystemProvider(client).tryRegisterSchemes(schemes);
     });
 
     return client;

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -62,8 +62,12 @@ export async function activateLanguageClient(
     const schemesReply = client.sendRequest<string[]>("rascal/filesystem/schemes");
 
     schemesReply.then( schemes => {
-        vfsServer.ignoreSchemes(schemes);
-        new RascalFileSystemProvider(client).registerSchemes(schemes);
+        // avoid registering the same schemes multiple times
+        const knownRascalNativeSchemes = vfsServer.getIgnoredSchemes();
+        const remainingSchemes = schemes.filter(s => !knownRascalNativeSchemes.includes(s));
+        if (remainingSchemes.length) {
+            new RascalFileSystemProvider(client).registerSchemes(schemes);
+        }
     });
 
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -65,7 +65,7 @@ export async function activateLanguageClient(
         vfsServer.ignoreSchemes(schemes);
         const allRegistered = new RascalFileSystemProvider(client).tryRegisterSchemes(schemes);
         if (!allRegistered) {
-            client.warn("At least one of the expected schemes failed to register.", { expectedSchemes: schemes });
+            client.warn(`At least one of the expected schemes failed to register.\nExpected schemes: ${schemes}`);
         }
     });
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -66,6 +66,7 @@ export async function activateLanguageClient(
         const knownRascalNativeSchemes = vfsServer.getIgnoredSchemes();
         const remainingSchemes = schemes.filter(s => !knownRascalNativeSchemes.includes(s));
         if (remainingSchemes.length) {
+            vfsServer.ignoreSchemes(remainingSchemes);
             new RascalFileSystemProvider(client).registerSchemes(schemes);
         }
     });

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -62,15 +62,12 @@ export async function activateLanguageClient(
     const schemesReply = client.sendRequest<string[]>("rascal/filesystem/schemes");
 
     schemesReply.then( schemes => {
-        // avoid registering the same schemes multiple times
-        const knownRascalNativeSchemes = vfsServer.getIgnoredSchemes();
-        const remainingSchemes = schemes.filter(s => !knownRascalNativeSchemes.includes(s));
-        if (remainingSchemes.length) {
-            vfsServer.ignoreSchemes(remainingSchemes);
-            new RascalFileSystemProvider(client).registerSchemes(schemes);
+        vfsServer.ignoreSchemes(schemes);
+        const allRegistered = new RascalFileSystemProvider(client).tryRegisterSchemes(schemes);
+        if (!allRegistered) {
+            client.warn("At least one of the expected schemes failed to register.", { expectedSchemes: schemes });
         }
     });
-
 
     return client;
 }


### PR DESCRIPTION
When multiple `ParameterizedLanguageServer` instances are created in the same extension, the same schemes are registered multiple times - failing.

This PR avoids registering a scheme multiple times by filtering the previously registered schemes.

```
rejected promise not handled within 1 second: Error: a provider for the scheme 'zip' is already registered
extensionHostProcess.js:155
stack trace: Error: a provider for the scheme 'zip' is already registered
    at o.registerFileSystemProvider (...\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:161:94201)
    at Object.registerFileSystemProvider (...\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:171:48861)
    at ...\node_modules\@usethesource\rascal-vscode-dsl-lsp-server\lib\fs\RascalFileSystemProviders.js:51:1
    at Array.forEach (<anonymous>)
    at RascalFileSystemProvider.registerSchemes (...\node_modules\@usethesource\rascal-vscode-dsl-lsp-server\lib\fs\RascalFileSystemProviders.js:51:1)
    at ...\node_modules\@usethesource\rascal-vscode-dsl-lsp-server\lib\lsp\RascalLSPConnection.js:56:1
    at runNextTicks (node:internal/process/task_queues:60:5)
    at processImmediate (node:internal/timers:449:9)
    at process.callbackTrampoline (node:internal/async_hooks:130:17)
```

[VS Code API docs](https://code.visualstudio.com/api/references/vscode-api#workspace) say:

> There can only be one provider per scheme and an error is being thrown when a scheme has been claimed by another provider or when it is reserved.

