### PR TITLE
Renaming: Use extended TModel instead of custom ADT.

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Util.rsc
@@ -83,12 +83,11 @@ start[Module] parseModuleWithSpacesCached(loc l) {
 @synopsis{
     Try to parse string `name` as reified type `begin` and return whether this succeeded.
 }
-bool tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
+Maybe[&T <: Tree] tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
     try {
-        parse(begin, name, allowAmbiguity = allowAmbiguity);
-        return true;
+        return just(parse(begin, name, allowAmbiguity = allowAmbiguity));
     } catch ParseError(_): {
-        return false;
+        return nothing();
     }
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -83,7 +83,7 @@ set[RenameLocation] annotateLocs(set[loc] locs, Maybe[ChangeAnnotationId] annota
 
 TModel loadLocs(TModel wsTM, ProjectFiles projectFiles, set[TModel](ProjectFiles projectFiles) tmodelsForFiles) {
     for (modTM <- tmodelsForFiles(projectFiles)) {
-        wsTM = loadTModel(wsTM, modTM);
+        wsTM = appendTModel(wsTM, modTM);
     }
 
     // In addition to data from the TModel, we keep track of which projects/modules we loaded.
@@ -93,21 +93,21 @@ TModel loadLocs(TModel wsTM, ProjectFiles projectFiles, set[TModel](ProjectFiles
     return wsTM;
 }
 
-TModel loadTModel(TModel wsTM, TModel modTM) {
+TModel appendTModel(TModel to, TModel from) {
     try {
-        throwAnyErrors(modTM);
+        throwAnyErrors(from);
     } catch set[Message] errors: {
         throw unsupportedRename("Cannot rename: some files in workspace have errors.\n<toString(errors)>", issues={<(error.at ? |unknown:///|), error.msg> | error <- errors});
     }
 
-    wsTM.useDef      += modTM.useDef;
-    wsTM.defines     += modTM.defines;
-    wsTM.definitions += modTM.definitions;
-    wsTM.facts       += modTM.facts;
-    wsTM.scopes      += modTM.scopes;
-    wsTM.paths       += modTM.paths;
+    to.useDef      += from.useDef;
+    to.defines     += from.defines;
+    to.definitions += from.definitions;
+    to.facts       += from.facts;
+    to.scopes      += from.scopes;
+    to.paths       += from.paths;
 
-    return wsTM;
+    return to;
 }
 
 loc getProjectFolder(TModel ws, loc l) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/WorkspaceInfo.rsc
@@ -71,70 +71,46 @@ alias MayOverloadFun = bool(set[loc] defs, map[loc, Define] defines);
 alias FileRenamesF = rel[loc old, loc new](str newName);
 alias RenameLocation = tuple[loc l, Maybe[ChangeAnnotationId] annotation];
 alias DefsUsesRenames = tuple[set[RenameLocation] defs, set[RenameLocation] uses, FileRenamesF renames];
-alias ProjectFiles = rel[loc projectFolder, loc file, bool loadModel];
+alias ProjectFiles = rel[loc projectFolder, bool loadModel, loc file];
 
-/**
- * This is a subset of the fields from analysis::typepal::TModel, specifically tailored to refactorings.
- * WorkspaceInfo comes with a set of functions that allow (incrementally) loading information from multiple TModels, and doing (cached) queries on this data.
- */
-data WorkspaceInfo (
-    // Instance fields
-    // Read-only
-    rel[loc use, loc def] useDef = {},
-    set[Define] defines = {},
-    set[loc] sourceFiles = {},
-    map[loc, Define] definitions = (),
-    map[loc, AType] facts = (),
-    Scopes scopes = (),
-    Paths paths = {},
-    set[loc] projects = {}
-) = workspaceInfo(
-    PathConfig(loc) getPathConfig,
-    ProjectFiles() preloadFiles,
-    ProjectFiles() allFiles,
-    set[TModel](ProjectFiles) tmodelsForLocs
+// Extend the TModel to include some workspace information.
+data TModel (
+    set[loc] projects = {},
+    set[loc] sourceFiles = {}
 );
 
 set[RenameLocation] annotateLocs(set[loc] locs, Maybe[ChangeAnnotationId] annotationId = nothing()) = {<l, annotationId> | l <- locs};
 
-WorkspaceInfo loadLocs(WorkspaceInfo ws, ProjectFiles projectFiles) {
-    for (tm <- ws.tmodelsForLocs(projectFiles)) {
-        ws = loadTModel(ws, tm);
+TModel loadLocs(TModel wsTM, ProjectFiles projectFiles, set[TModel](ProjectFiles projectFiles) tmodelsForFiles) {
+    for (modTM <- tmodelsForFiles(projectFiles)) {
+        wsTM = loadTModel(wsTM, modTM);
     }
 
     // In addition to data from the TModel, we keep track of which projects/modules we loaded.
-    ws.sourceFiles += projectFiles.file;
-    ws.projects += projectFiles.projectFolder;
+    wsTM.sourceFiles += projectFiles.file;
+    wsTM.projects += projectFiles.projectFolder;
 
-    return ws;
+    return wsTM;
 }
 
-WorkspaceInfo preLoad(WorkspaceInfo ws) {
-    return loadLocs(ws, ws.preloadFiles());
-}
-
-WorkspaceInfo loadWorkspace(WorkspaceInfo ws) {
-    return loadLocs(ws, ws.allFiles());
-}
-
-WorkspaceInfo loadTModel(WorkspaceInfo ws, TModel tm) {
+TModel loadTModel(TModel wsTM, TModel modTM) {
     try {
-        throwAnyErrors(tm);
+        throwAnyErrors(modTM);
     } catch set[Message] errors: {
         throw unsupportedRename("Cannot rename: some files in workspace have errors.\n<toString(errors)>", issues={<(error.at ? |unknown:///|), error.msg> | error <- errors});
     }
 
-    ws.useDef      += tm.useDef;
-    ws.defines     += tm.defines;
-    ws.definitions += tm.definitions;
-    ws.facts       += tm.facts;
-    ws.scopes      += tm.scopes;
-    ws.paths       += tm.paths;
+    wsTM.useDef      += modTM.useDef;
+    wsTM.defines     += modTM.defines;
+    wsTM.definitions += modTM.definitions;
+    wsTM.facts       += modTM.facts;
+    wsTM.scopes      += modTM.scopes;
+    wsTM.paths       += modTM.paths;
 
-    return ws;
+    return wsTM;
 }
 
-loc getProjectFolder(WorkspaceInfo ws, loc l) {
+loc getProjectFolder(TModel ws, loc l) {
     if (project <- ws.projects, isPrefixOf(project, l)) {
         return project;
     }
@@ -143,27 +119,27 @@ loc getProjectFolder(WorkspaceInfo ws, loc l) {
 }
 
 @memo{maximumSize(1), expireAfter(minutes=5)}
-rel[loc, loc] defUse(WorkspaceInfo ws) = invert(ws.useDef);
+rel[loc, loc] defUse(TModel ws) = invert(ws.useDef);
 
 @memo{maximumSize(1), expireAfter(minutes=5)}
-map[AType, set[loc]] factsInvert(WorkspaceInfo ws) = invert(ws.facts);
+map[AType, set[loc]] factsInvert(TModel ws) = invert(ws.facts);
 
-set[loc] getUses(WorkspaceInfo ws, loc def) = defUse(ws)[def];
+set[loc] getUses(TModel ws, loc def) = defUse(ws)[def];
 
-set[loc] getUses(WorkspaceInfo ws, set[loc] defs) = defUse(ws)[defs];
+set[loc] getUses(TModel ws, set[loc] defs) = defUse(ws)[defs];
 
-set[loc] getDefs(WorkspaceInfo ws, loc use) = ws.useDef[use];
+set[loc] getDefs(TModel ws, loc use) = ws.useDef[use];
 
-Maybe[AType] getFact(WorkspaceInfo ws, loc l) = l in ws.facts ? just(ws.facts[l]) : nothing();
-
-@memo{maximumSize(1), expireAfter(minutes=5)}
-set[loc] getModuleScopes(WorkspaceInfo ws) = invert(ws.scopes)[|global-scope:///|];
+Maybe[AType] getFact(TModel ws, loc l) = l in ws.facts ? just(ws.facts[l]) : nothing();
 
 @memo{maximumSize(1), expireAfter(minutes=5)}
-map[loc, loc] getModuleScopePerFile(WorkspaceInfo ws) = (scope.top: scope | loc scope <- getModuleScopes(ws));
+set[loc] getModuleScopes(TModel ws) = invert(ws.scopes)[|global-scope:///|];
 
 @memo{maximumSize(1), expireAfter(minutes=5)}
-rel[loc from, loc to] rascalGetTransitiveReflexiveModulePaths(WorkspaceInfo ws) {
+map[loc, loc] getModuleScopePerFile(TModel ws) = (scope.top: scope | loc scope <- getModuleScopes(ws));
+
+@memo{maximumSize(1), expireAfter(minutes=5)}
+rel[loc from, loc to] rascalGetTransitiveReflexiveModulePaths(TModel ws) {
     rel[loc from, loc to] moduleI = ident(getModuleScopes(ws));
     rel[loc from, loc to] imports = (ws.paths<pathRole, from, to>)[importPath()];
     rel[loc from, loc to] extends = (ws.paths<pathRole, from, to>)[extendPath()];
@@ -174,10 +150,10 @@ rel[loc from, loc to] rascalGetTransitiveReflexiveModulePaths(WorkspaceInfo ws) 
 }
 
 @memo{maximumSize(1), expireAfter(minutes=5)}
-rel[loc from, loc to] rascalGetTransitiveReflexiveScopes(WorkspaceInfo ws) = toRel(ws.scopes)*;
+rel[loc from, loc to] rascalGetTransitiveReflexiveScopes(TModel ws) = toRel(ws.scopes)*;
 
 @memo{maximumSize(10), expireAfter(minutes=5)}
-set[loc] rascalReachableModules(WorkspaceInfo ws, set[loc] froms) {
+set[loc] rascalReachableModules(TModel ws, set[loc] froms) {
     rel[loc from, loc scope] fromScopes = {};
     for (from <- froms) {
         if (scope <- ws.scopes<1>, isContainedIn(from, scope)) {
@@ -193,9 +169,9 @@ set[loc] rascalReachableModules(WorkspaceInfo ws, set[loc] froms) {
 }
 
 @memo{maximumSize(1), expireAfter(minutes=5)}
-rel[loc, Define] definitionsRel(WorkspaceInfo ws) = toRel(ws.definitions);
+rel[loc, Define] definitionsRel(TModel ws) = toRel(ws.definitions);
 
-set[Define] rascalReachableDefs(WorkspaceInfo ws, set[loc] defs) {
+set[Define] rascalReachableDefs(TModel ws, set[loc] defs) {
     rel[loc from, loc to] modulePaths = rascalGetTransitiveReflexiveModulePaths(ws);
     rel[loc from, loc to] scopes = rascalGetTransitiveReflexiveScopes(ws);
     rel[loc from, Define define] reachableDefs =
@@ -214,7 +190,7 @@ set[Define] rascalReachableDefs(WorkspaceInfo ws, set[loc] defs) {
     return reachableDefs.define;                                // We are only interested in reached defines; not *from where* they were reached
 }
 
-set[loc] rascalGetOverloadedDefs(WorkspaceInfo ws, set[loc] defs, MayOverloadFun mayOverloadF) {
+set[loc] rascalGetOverloadedDefs(TModel ws, set[loc] defs, MayOverloadFun mayOverloadF) {
     if (defs == {}) return {};
 
     set[Define] overloadedDefs = definitionsRel(ws)[defs];
@@ -330,7 +306,7 @@ bool rascalMayOverloadSameName(set[loc] defs, map[loc, Define] definitions) {
     return false;
 }
 
-set[Define] rascalGetADTDefinitions(WorkspaceInfo ws, loc lhs) {
+set[Define] rascalGetADTDefinitions(TModel ws, loc lhs) {
     set[loc] fromDefs = (ws.definitions[lhs]? || lhs in ws.useDef<1>)
         ? {lhs}
         : getDefs(ws, lhs)
@@ -357,7 +333,7 @@ set[Define] rascalGetADTDefinitions(WorkspaceInfo ws, loc lhs) {
     return {};
 }
 
-set[RenameLocation] rascalGetKeywordFormalUses(WorkspaceInfo ws, set[loc] defs, str cursorName) {
+set[RenameLocation] rascalGetKeywordFormalUses(TModel ws, set[loc] defs, str cursorName) {
     set[RenameLocation] uses = {};
 
     for (d <- defs
@@ -394,7 +370,7 @@ set[loc] rascalGetKeywordArgs(\default(_, {KeywordArgument[Pattern] ","}+ keywor
     | kwArg <- keywordArgs
     , "<kwArg.name>" == cursorName};
 
-set[RenameLocation] rascalGetKeywordFieldUses(WorkspaceInfo ws, set[loc] defs, str cursorName) {
+set[RenameLocation] rascalGetKeywordFieldUses(TModel ws, set[loc] defs, str cursorName) {
     set[RenameLocation] uses = annotateLocs(getUses(ws, defs));
 
     set[Define] reachableDefs = rascalReachableDefs(ws, defs);
@@ -418,7 +394,7 @@ set[RenameLocation] rascalGetKeywordFieldUses(WorkspaceInfo ws, set[loc] defs, s
     return uses;
 }
 
-private set[RenameLocation] rascalGetExceptUses(WorkspaceInfo ws, set[loc] defs) {
+private set[RenameLocation] rascalGetExceptUses(TModel ws, set[loc] defs) {
     constructorDefs = {d | l <- defs, Define d: <_, _, _, constructorId(), _, _> := ws.definitions[l]};
     if (constructorDefs == {}) return {};
 
@@ -446,7 +422,7 @@ private set[RenameLocation] rascalGetExceptUses(WorkspaceInfo ws, set[loc] defs)
     return uses;
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(use(), l, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(use(), l, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) getPathConfig) {
     set[loc] defs = rascalGetOverloadedDefs(ws, getDefs(ws, l), mayOverloadF);
     set[RenameLocation] uses = annotateLocs(getUses(ws, defs));
 
@@ -454,7 +430,7 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(use(), l, cursorName)
     if (keywordFormalId() in roles) {
         uses += rascalGetKeywordFormalUses(ws, defs, cursorName);
         uses += rascalGetKeywordFieldUses(ws, defs, cursorName);
-        uses += rascalGetHasUses(ws, defs, cursorName, registerChangeAnnotation);
+        uses += rascalGetHasUses(ws, defs, cursorName, registerChangeAnnotation, getPathConfig);
     } else if (constructorId() in roles) {
         uses += rascalGetExceptUses(ws, defs);
     }
@@ -462,7 +438,7 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(use(), l, cursorName)
     return <annotateLocs(defs), uses, NO_RENAMES>;
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(def(), l, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(def(), l, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) getPathConfig) {
     set[loc] initialUses = getUses(ws, l);
     set[loc] initialDefs = {l} + {*ds | u <- initialUses, ds := getDefs(ws, u)};
     set[loc] defs = rascalGetOverloadedDefs(ws, initialDefs, mayOverloadF);
@@ -472,7 +448,7 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(def(), l, cursorName)
     if (roles & {keywordFormalId(), fieldId()} != {}) {
         uses += rascalGetKeywordFormalUses(ws, defs, cursorName);
         uses += rascalGetKeywordFieldUses(ws, defs, cursorName);
-        uses += rascalGetHasUses(ws, defs, cursorName, registerChangeAnnotation);
+        uses += rascalGetHasUses(ws, defs, cursorName, registerChangeAnnotation, getPathConfig);
     } else if (constructorId() in roles) {
         uses += rascalGetExceptUses(ws, defs);
     }
@@ -480,20 +456,20 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(def(), l, cursorName)
     return <annotateLocs(defs), uses, NO_RENAMES>;
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(exceptConstructor(), l, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(exceptConstructor(), l, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) getPathConfig) {
     if (f <- ws.facts
        , isContainedIn(l, f)
        , aprod(prod(_, [*_, conditional(AType nontermType, /\a-except(cursorName)) ,*_])) := ws.facts[f]
        , Define currentCons:<_, _, _, constructorId(), _, _> <- ws.defines
        , isContainedIn(currentCons.defined, f)
        , Define exceptCons:<_, cursorName, _, constructorId(), _, defType(acons(nontermType, _, _))> <- rascalReachableDefs(ws, {currentCons.defined})) {
-        return rascalGetDefsUses(ws, cursor(def(), exceptCons.defined, cursorName), mayOverloadF, registerChangeAnnotation);
+        return rascalGetDefsUses(ws, cursor(def(), exceptCons.defined, cursorName), mayOverloadF, registerChangeAnnotation, getPathConfig);
     }
 
     return <{}, {}, NO_RENAMES>;
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(typeParam(), cursorLoc, cursorName), MayOverloadFun _, ChangeAnnotationRegister _) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(typeParam(), cursorLoc, cursorName), MayOverloadFun _, ChangeAnnotationRegister _, PathConfig(loc) getPathConfig) {
     set[loc] getFormals(afunc(_, _, _), rel[loc, AType] facts) = {l | <l, f> <- facts, f.alabel != ""};
     set[loc] getFormals(aadt(_, _, _), rel[loc, AType] facts) {
         perName = {<name, l> | <l, f: aparameter(name, _)> <- facts, f.alabel == ""};
@@ -549,7 +525,7 @@ Maybe[tuple[loc, set[loc]]] rascalGetHasLocs(str fieldName, (Expression) `<Expre
 
 default Maybe[tuple[loc, set[loc]]] rascalGetHasLocs(str _, Tree _) = nothing();
 
-set[RenameLocation] rascalGetHasUses(WorkspaceInfo ws, set[loc] defs, str cursorName, ChangeAnnotationRegister registerChangeAnnotation) {
+set[RenameLocation] rascalGetHasUses(TModel ws, set[loc] defs, str cursorName, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) _) {
     return {
         <field, just(registerChangeAnnotation("Use of `has <cursorName>` on value of <describeFact(getFact(ws, lhs))>", "Due to the dynamic nature of these names, please review these suggested changes.", true))>
         | loc l <- rascalReachableModules(ws, defs)
@@ -558,7 +534,7 @@ set[RenameLocation] rascalGetHasUses(WorkspaceInfo ws, set[loc] defs, str cursor
     };
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(dataField(loc adtLoc, AType fieldType), cursorLoc, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(dataField(loc adtLoc, AType fieldType), cursorLoc, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) getPathConfig) {
     set[loc] initialDefs = {};
     if (cursorLoc in ws.useDef<0>) {
         initialDefs = getDefs(ws, cursorLoc);
@@ -579,14 +555,14 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(dataField(loc adtLoc,
 
     set[loc] defs = rascalGetOverloadedDefs(ws, initialDefs, mayOverloadF);
     set[RenameLocation] uses = annotateLocs(getUses(ws, defs)) + rascalGetKeywordFieldUses(ws, defs, cursorName);
-    set[RenameLocation] hasUses = rascalGetHasUses(ws, defs, cursorName, registerChangeAnnotation);
+    set[RenameLocation] hasUses = rascalGetHasUses(ws, defs, cursorName, registerChangeAnnotation, getPathConfig);
 
     return <annotateLocs(defs), uses + hasUses, NO_RENAMES>;
 }
 
 bool debug = false;
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(cursorKind, cursorLoc, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(cursorKind, cursorLoc, cursorName), MayOverloadFun mayOverloadF, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) getPathConfig) {
     if (cursorKind is dataKeywordField || cursorKind is dataCommonKeywordField) {
         set[RenameLocation] defs = {};
         set[RenameLocation] uses = {};
@@ -607,7 +583,7 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(cursorKind, cursorLoc
             uses += us;
         }
 
-        uses += rascalGetHasUses(ws, adtDefs, cursorName, registerChangeAnnotation);
+        uses += rascalGetHasUses(ws, adtDefs, cursorName, registerChangeAnnotation, getPathConfig);
 
         return <defs, uses, NO_RENAMES>;
     }
@@ -615,7 +591,7 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(cursorKind, cursorLoc
     fail;
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(collectionField(), cursorLoc, cursorName), MayOverloadFun _, ChangeAnnotationRegister _) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(collectionField(), cursorLoc, cursorName), MayOverloadFun _, ChangeAnnotationRegister _, PathConfig(loc) getPathConfig) {
     bool isTupleField(AType fieldType) = fieldType.alabel == "";
 
     lrel[loc, AType] factsBySize = sort(toRel(ws.facts), isShorterTuple);
@@ -690,7 +666,7 @@ Maybe[tuple[loc, set[loc], bool]] rascalGetKeywordLocs(str fieldName, d:(Declara
 
 default Maybe[tuple[loc, set[loc], bool]] rascalGetKeywordLocs(str _, Tree _) = nothing();
 
-private DefsUsesRenames rascalGetFieldDefsUses(WorkspaceInfo ws, set[loc] reachableModules, AType containerType, AType fieldType, str cursorName) {
+private DefsUsesRenames rascalGetFieldDefsUses(TModel ws, set[loc] reachableModules, AType containerType, AType fieldType, str cursorName) {
     set[loc] containerFacts = {f | f <- factsInvert(ws)[containerType], f.top in reachableModules};
     rel[loc file, loc u] factsByModule = groupBy(containerFacts, loc(loc l) { return l.top; });
 
@@ -717,7 +693,7 @@ private DefsUsesRenames rascalGetFieldDefsUses(WorkspaceInfo ws, set[loc] reacha
     return <annotateLocs(defs), annotateLocs(uses), NO_RENAMES>;
 }
 
-DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(moduleName(), cursorLoc, cursorName), MayOverloadFun _, ChangeAnnotationRegister registerChangeAnnotation) {
+DefsUsesRenames rascalGetDefsUses(TModel ws, cursor(moduleName(), cursorLoc, cursorName), MayOverloadFun _, ChangeAnnotationRegister registerChangeAnnotation, PathConfig(loc) getPathConfig) {
     loc moduleFile = |unknown:///|;
     if (d <- ws.useDef[cursorLoc], amodule(_) := ws.facts[d]) {
         // Cursor is at an import
@@ -734,7 +710,7 @@ DefsUsesRenames rascalGetDefsUses(WorkspaceInfo ws, cursor(moduleName(), cursorL
         }
     }
 
-    modName = getModuleName(moduleFile, ws.getPathConfig(getProjectFolder(ws, moduleFile)));
+    modName = getModuleName(moduleFile, getPathConfig(getProjectFolder(ws, moduleFile)));
 
     defs = {parseModuleWithSpacesCached(moduleFile).top.header.name.names[-1].src};
 


### PR DESCRIPTION
- Replace the `WorkspaceInfo` ADT by just a sparse, workspace-wide, `TModel`, to reduce the amount of custom code and increase maintainability.
- Some other, small changes, to increase quality/readability.