### PR TITLE
Interact with type checker using module names.

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -458,11 +458,11 @@ private bool rascalContainsName(loc l, str name) {
 private set[TModel] rascalTModels(set[loc] fs, PathConfig pcfg) {
     RascalCompilerConfig ccfg = rascalCompilerConfig(pcfg)[verbose = false]
                                                           [logPathConfig = false];
-    list[str] moduleNames = [getModuleName(mloc, pcfg) | mloc <- fs];
-    ms = rascalTModelForNames(moduleNames, ccfg, dummy_compile1);
+    list[str] topModuleNames = [getModuleName(mloc, pcfg) | mloc <- fs];
+    ms = rascalTModelForNames(topModuleNames, ccfg, dummy_compile1);
 
     set[TModel] tmodels = {};
-    for (str modName <- moduleNames) {
+    for (str modName <- ms.moduleLocs) {
         <found, tm, ms> = getTModelForModule(modName, ms);
         if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'\n<toString(ms.messages)>");
         tmodels += convertTModel2PhysicalLocs(tm);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -458,10 +458,11 @@ private bool rascalContainsName(loc l, str name) {
 private set[TModel] rascalTModels(set[loc] fs, PathConfig pcfg) {
     RascalCompilerConfig ccfg = rascalCompilerConfig(pcfg)[verbose = false]
                                                           [logPathConfig = false];
-    ms = rascalTModelForLocs(toList(fs), ccfg, dummy_compile1);
+    list[str] moduleNames = [getModuleName(mloc, pcfg) | mloc <- fs];
+    ms = rascalTModelForNames(moduleNames, ccfg, dummy_compile1);
 
     set[TModel] tmodels = {};
-    for (modName <- ms.moduleLocs) {
+    for (str modName <- moduleNames) {
         <found, tm, ms> = getTModelForModule(modName, ms);
         if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'\n<toString(ms.messages)>");
         tmodels += convertTModel2PhysicalLocs(tm);


### PR DESCRIPTION
As discussed with @PaulKlint, this is a more robust way of interacting with the type checker. Internally, it uses names to represent modules, and only uses locations when TPLs are outdated.