### PR TITLE
Update example folder to package language servers as VS Code extensions

### DIFF
--- a/examples/pico-dsl-extension/.gitignore
+++ b/examples/pico-dsl-extension/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 dist/
 bin/
 lib/
+*.vsix

--- a/examples/pico-dsl-extension/package.json
+++ b/examples/pico-dsl-extension/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@usethesource/rascal-vscode-dsl-lsp-server": "0.5.8"
+    "@usethesource/rascal-vscode-dsl-lsp-server": "0.12.0"
   }
 }

--- a/examples/pico-dsl-extension/src/extension.ts
+++ b/examples/pico-dsl-extension/src/extension.ts
@@ -7,19 +7,19 @@ export function activate(context: vscode.ExtensionContext) {
 	const picoLSPJar = `|jar+file://${context.extensionUri.path}/assets/jars/pico-lsp.jar!|`;
 	const language = <LanguageParameter>{
 		pathConfig: `pathConfig(srcs=[${picoLSPJar}])`,
-		name: "Pico", 
-		extension: "pico", 
-		mainModule: "lang::pico::LanguageServer", 
+		name: "Pico",
+		extensions: ["pico"],
+		mainModule: "lang::pico::LanguageServer",
 		mainFunction: "picoContributions"
 	};
 	console.log(language);
 	// rascal vscode needs an instance of this class, if you register multiple languages, they can share this vfs instance
-	const vfs = new VSCodeUriResolverServer(false); 
+	const vfs = new VSCodeUriResolverServer(false);
 	// this starts the LSP server and connects it to rascal
-	const lsp = new ParameterizedLanguageServer(context, 
-		vfs, 
-		calcJarPath(context), 
-		true, 
+	const lsp = new ParameterizedLanguageServer(context,
+		vfs,
+		calcJarPath(context),
+		true,
 		"pico", // vscode language ID
 		"Pico", // vscode language Title (visible in the right bottom corner)
 		language);

--- a/examples/pico-dsl-extension/src/extension.ts
+++ b/examples/pico-dsl-extension/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ParameterizedLanguageServer, VSCodeUriResolverServer, LanguageParameter } from '@usethesource/rascal-vscode-dsl-runtime';
+import { ParameterizedLanguageServer, VSCodeUriResolverServer, LanguageParameter } from '@usethesource/rascal-vscode-dsl-lsp-server';
 import { join } from 'path';
 
 export function activate(context: vscode.ExtensionContext) {

--- a/examples/pico-dsl-extension/webpack.config.js
+++ b/examples/pico-dsl-extension/webpack.config.js
@@ -48,7 +48,7 @@ const extensionConfig = {
           // we copy the jars to an an easy to predict location
           from: path.resolve(
             __dirname,
-            "node_modules/@usethesource/rascal-vscode-dsl-runtime/assets/jars/"
+            "node_modules/@usethesource/rascal-vscode-dsl-lsp-server/assets/jars/"
           ),
           to: path.resolve(__dirname, "dist/rascal-lsp/"),
         },

--- a/examples/pico-dsl-lsp/pom.xml
+++ b/examples/pico-dsl-lsp/pom.xml
@@ -29,12 +29,12 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.28.3</version>
+      <version>0.40.17</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal-lsp</artifactId>
-      <version>2.12.1</version>
+      <version>2.21.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.rascalmpl</groupId>
@@ -96,4 +96,3 @@
     </plugins>
   </build>
 </project>
-    

--- a/examples/pico-dsl-lsp/src/main/rascal/lang/pico/LanguageServer.rsc
+++ b/examples/pico-dsl-lsp/src/main/rascal/lang/pico/LanguageServer.rsc
@@ -10,9 +10,9 @@ import IO;
 // a minimal implementation of a DSL in rascal
 // users can add support for more advanced features
 set[LanguageService] picoContributions() = {
-    parser(parser(#start[Program])), // register the parser function for the Pico language
-    outliner(picoOutliner),
-    summarizer(picoSummarizer, providesImplementations = false)
+    parsing(parser(#start[Program])), // register the parser function for the Pico language
+    documentSymbol(picoOutliner),
+    analysis(picoSummarizer, providesImplementations = false)
   };
 
 
@@ -46,7 +46,7 @@ int main() {
         language(
             pathConfig(srcs=[|project://pico-dsl-lsp/src/main/rascal|]),
             "Pico", // name of the language
-            "pico", // extension
+            {"pico"}, // extension
             "lang::pico::LanguageServer", // module to import
             "picoContributions"
         )


### PR DESCRIPTION
This PR fixes a few small things (and aligns with the current versions) in the example folder to package a language server as a VS Code extension.