### PR TITLE
Fixed over-eager leading backslash removal in Rascal outline

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/DocumentSymbols.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/DocumentSymbols.rsc
@@ -88,7 +88,7 @@ list[DocumentSymbol] documentRascalSymbols(start[Module] \mod) {
 }
 
 // remove leading backslash
-str clean(/\\<rest:.*>/) = clean(rest);
+str clean(/^\\<rest:.*>/) = clean(rest);
 
 str clean("false") = "\\false"; // vscode doesn't like a falsy name
 


### PR DESCRIPTION
This solves an error in the outline of Rascal source files. Fixes #89.