### PR TITLE
Add custom view for easy access to the Rascal debugger

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -55,26 +55,13 @@
           "light": "./assets/images/rascal-logo-v2.1.svg",
           "dark": "./assets/images/rascal-logo-v2.1.svg"
         }
-      },
-      {
-        "command": "rascalmpl.stopDebuggerForRepl",
-        "title": "Stop Rascal debugger for REPL",
-        "icon": {
-          "light": "./assets/images/rascal-logo-v2.1.svg",
-          "dark": "./assets/images/rascal-logo-v2.1.svg"
-        }
       }
     ],
     "menus": {
       "view/item/context": [
         {
           "command": "rascalmpl.startDebuggerForRepl",
-          "when": "view == rascalmpl-debugger-view && viewItem == 'isNotDebugging'",
-          "group": "inline"
-        },
-        {
-          "command": "rascalmpl.stopDebuggerForRepl",
-          "when": "view == rascalmpl-debugger-view && viewItem == 'isDebugging'",
+          "when": "view == rascalmpl-debugger-view && viewItem == 'canStartDebugging'",
           "group": "inline"
         }
       ]

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -47,8 +47,28 @@
       {
         "command": "rascalmpl.importModule",
         "title": "Start Rascal Terminal and Import this module"
+      },
+      {
+        "command": "rascalmpl.startDebuggerForRepl",
+        "title": "Start Rascal debugger for REPL",
+        "icon": "$(debug)"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "rascalmpl.startDebuggerForRepl",
+          "when": "false"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "rascalmpl.startDebuggerForRepl",
+          "when": "view == rascalmpl-debugger-view && viewItem == 'canStartDebugging'",
+          "group": "inline"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "rascalmpl",

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -55,6 +55,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "rascalmpl.startDebuggerForRepl",
+          "when": "false"
+        }
+      ],
       "view/item/context": [
         {
           "command": "rascalmpl.startDebuggerForRepl",

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -47,8 +47,38 @@
       {
         "command": "rascalmpl.importModule",
         "title": "Start Rascal Terminal and Import this module"
+      },
+      {
+        "command": "rascalmpl.startDebuggerForRepl",
+        "title": "Start Rascal debugger for REPL",
+        "icon": {
+          "light": "./assets/images/rascal-logo-v2.1.svg",
+          "dark": "./assets/images/rascal-logo-v2.1.svg"
+        }
+      },
+      {
+        "command": "rascalmpl.stopDebuggerForRepl",
+        "title": "Stop Rascal debugger for REPL",
+        "icon": {
+          "light": "./assets/images/rascal-logo-v2.1.svg",
+          "dark": "./assets/images/rascal-logo-v2.1.svg"
+        }
       }
     ],
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "rascalmpl.startDebuggerForRepl",
+          "when": "view == rascalmpl-debugger-view && viewItem == 'isNotDebugging'",
+          "group": "inline"
+        },
+        {
+          "command": "rascalmpl.stopDebuggerForRepl",
+          "when": "view == rascalmpl-debugger-view && viewItem == 'isDebugging'",
+          "group": "inline"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "rascalmpl",
@@ -89,12 +119,24 @@
           "icon": "./assets/images/rascal-logo-v2.1.svg",
           "visibility": "collapsed"
         }
+      ],
+      "debug": [
+        {
+          "id": "rascalmpl-debugger-view",
+          "name": "Rascal debugger",
+          "icon": "./assets/images/rascal-logo-v2.1.svg",
+          "visibility": "visible"
+        }
       ]
     },
     "viewsWelcome": [
       {
         "view": "rascalmpl-configuration-view",
         "contents": "No Rascal Projects found in the workspace"
+      },
+      {
+        "view": "rascalmpl-debugger-view",
+        "contents": "No active Rascal REPLs found"
       }
     ],
     "breakpoints": [

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -47,28 +47,8 @@
       {
         "command": "rascalmpl.importModule",
         "title": "Start Rascal Terminal and Import this module"
-      },
-      {
-        "command": "rascalmpl.startDebuggerForRepl",
-        "title": "Start Rascal debugger for REPL",
-        "icon": "$(debug)"
       }
     ],
-    "menus": {
-      "commandPalette": [
-        {
-          "command": "rascalmpl.startDebuggerForRepl",
-          "when": "false"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "rascalmpl.startDebuggerForRepl",
-          "when": "view == rascalmpl-debugger-view && viewItem == 'canStartDebugging'",
-          "group": "inline"
-        }
-      ]
-    },
     "languages": [
       {
         "id": "rascalmpl",

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -108,7 +108,7 @@
         {
           "id": "rascalmpl-debugger-view",
           "name": "Rascal debugger",
-          "icon": "./assets/images/rascal-logo-v2.1.svg",
+          "icon": "$(debug)",
           "visibility": "visible"
         }
       ]

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -51,10 +51,7 @@
       {
         "command": "rascalmpl.startDebuggerForRepl",
         "title": "Start Rascal debugger for REPL",
-        "icon": {
-          "light": "./assets/images/rascal-logo-v2.1.svg",
-          "dark": "./assets/images/rascal-logo-v2.1.svg"
-        }
+        "icon": "$(debug)"
       }
     ],
     "menus": {

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -107,7 +107,7 @@
       "debug": [
         {
           "id": "rascalmpl-debugger-view",
-          "name": "Rascal debugger",
+          "name": "Debug Rascal Terminal",
           "icon": "$(debug)",
           "visibility": "visible"
         }

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -57,7 +57,7 @@ export class RascalExtension implements vscode.Disposable {
         checkForJVMUpdate();
 
         vscode.window.registerTreeDataProvider('rascalmpl-configuration-view', new RascalLibraryProvider(this.rascal.rascalClient));
-        vscode.window.registerTreeDataProvider('rascalmpl-debugger-view', new RascalDebugViewProvider(this.rascal.rascalDebugClient));
+        vscode.window.registerTreeDataProvider('rascalmpl-debugger-view', new RascalDebugViewProvider(this.rascal.rascalDebugClient, context));
         vscode.window.registerTerminalLinkProvider(new RascalTerminalLinkProvider(this.rascal.rascalClient));
     }
 

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -53,7 +53,7 @@ export class RascalExtension implements vscode.Disposable {
         this.registerTerminalCommand();
         this.registerMainRun();
         this.registerImportModule();
-        this.registerDebuggerCommands();
+        this.registerDebuggerCommand();
         checkForJVMUpdate();
 
         vscode.window.registerTreeDataProvider('rascalmpl-configuration-view', new RascalLibraryProvider(this.rascal.rascalClient));
@@ -106,21 +106,11 @@ export class RascalExtension implements vscode.Disposable {
         );
     }
 
-    private registerDebuggerCommands() {
+    private registerDebuggerCommand() {
         this.context.subscriptions.push(
             vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
                 if (replNode.serverPort !== undefined) {
                     this.rascal.rascalDebugClient.startDebuggingSession(replNode.serverPort);
-                }
-            })
-        );
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand("rascalmpl.stopDebuggerForRepl", (replNode: RascalReplNode) => {
-                console.log("start debugger!!");
-                console.log(replNode);
-                if (replNode.serverPort !== undefined) {
-                    console.log("Stopping debug session!");
-                    // this.rascal.rascalDebugClient.term
                 }
             })
         );

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -36,7 +36,7 @@ import { RascalTerminalLinkProvider } from './RascalTerminalLinkProvider';
 import { VSCodeUriResolverServer } from './fs/VSCodeURIResolver';
 import { RascalLibraryProvider } from './ux/LibraryNavigator';
 import { FileType } from 'vscode';
-import { RascalReplNode, RascalDebugViewProvider } from './dap/RascalDebugView';
+import { RascalDebugViewProvider } from './dap/RascalDebugView';
 
 export class RascalExtension implements vscode.Disposable {
     private readonly vfsServer: VSCodeUriResolverServer;
@@ -53,7 +53,6 @@ export class RascalExtension implements vscode.Disposable {
         this.registerTerminalCommand();
         this.registerMainRun();
         this.registerImportModule();
-        this.registerDebuggerCommand();
         checkForJVMUpdate();
 
         vscode.window.registerTreeDataProvider('rascalmpl-configuration-view', new RascalLibraryProvider(this.rascal.rascalClient));
@@ -102,16 +101,6 @@ export class RascalExtension implements vscode.Disposable {
                     return;
                 }
                 this.startTerminal(text.document.uri, "--loadModule", moduleName);
-            })
-        );
-    }
-
-    private registerDebuggerCommand() {
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
-                if (replNode.serverPort !== undefined) {
-                    this.rascal.rascalDebugClient.startDebuggingSession(replNode.serverPort);
-                }
             })
         );
     }

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -36,6 +36,7 @@ import { RascalTerminalLinkProvider } from './RascalTerminalLinkProvider';
 import { VSCodeUriResolverServer } from './fs/VSCodeURIResolver';
 import { RascalLibraryProvider } from './ux/LibraryNavigator';
 import { FileType } from 'vscode';
+import { RascalReplNode, RascalDebugViewProvider } from './dap/RascalDebugView';
 
 export class RascalExtension implements vscode.Disposable {
     private readonly vfsServer: VSCodeUriResolverServer;
@@ -52,9 +53,11 @@ export class RascalExtension implements vscode.Disposable {
         this.registerTerminalCommand();
         this.registerMainRun();
         this.registerImportModule();
+        this.registerDebuggerCommands();
         checkForJVMUpdate();
 
         vscode.window.registerTreeDataProvider('rascalmpl-configuration-view', new RascalLibraryProvider(this.rascal.rascalClient));
+        vscode.window.registerTreeDataProvider('rascalmpl-debugger-view', new RascalDebugViewProvider(this.rascal.rascalDebugClient));
         vscode.window.registerTerminalLinkProvider(new RascalTerminalLinkProvider(this.rascal.rascalClient));
     }
 
@@ -99,6 +102,31 @@ export class RascalExtension implements vscode.Disposable {
                     return;
                 }
                 this.startTerminal(text.document.uri, "--loadModule", moduleName);
+            })
+        );
+    }
+
+    private registerDebuggerCommands() {
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
+                console.log("start debugger!!");
+                console.log(replNode);
+                console.log(`type: ${typeof replNode}`);
+                console.log(`serverPort: ${replNode.serverPort}`);
+                if (replNode.serverPort !== undefined) {
+                    console.log("Starting debug session!");
+                    this.rascal.rascalDebugClient.startDebuggingSession(replNode.serverPort);
+                }
+            })
+        );
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("rascalmpl.stopDebuggerForRepl", (replNode: RascalReplNode) => {
+                console.log("start debugger!!");
+                console.log(replNode);
+                if (replNode.serverPort !== undefined) {
+                    console.log("Stopping debug session!");
+                    // this.rascal.rascalDebugClient.term
+                }
             })
         );
     }

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -109,12 +109,7 @@ export class RascalExtension implements vscode.Disposable {
     private registerDebuggerCommands() {
         this.context.subscriptions.push(
             vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
-                console.log("start debugger!!");
-                console.log(replNode);
-                console.log(`type: ${typeof replNode}`);
-                console.log(`serverPort: ${replNode.serverPort}`);
                 if (replNode.serverPort !== undefined) {
-                    console.log("Starting debug session!");
                     this.rascal.rascalDebugClient.startDebuggingSession(replNode.serverPort);
                 }
             })

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -37,7 +37,7 @@ export class RascalDebugClient {
     debugSocketServersPorts: Map<number, number>; // Terminal processID -> socket server port for debug
     runningDebugSessionsPorts: Set<number>; // Stores all running debug session server ports
 
-    private portEventEmitter = new EventEmitter<undefined>();
+    private portEventEmitter = new EventEmitter<{processId: number, serverPort: number}>();
     readonly portRegistrationEvent = this.portEventEmitter.event;
 
     constructor(){
@@ -78,7 +78,7 @@ export class RascalDebugClient {
 
     registerDebugServerPort(processID: number, serverPort: number){
         this.debugSocketServersPorts.set(processID, serverPort);
-        this.portEventEmitter.fire(undefined);
+        this.portEventEmitter.fire({"processId": processID, "serverPort": serverPort});
     }
 
     getServerPort(processId: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import { debug, DebugConfiguration, DebugSession, Terminal, window, commands } from "vscode";
+import { debug, DebugConfiguration, DebugSession, Terminal, window, EventEmitter } from "vscode";
 import { RascalDebugAdapterDescriptorFactory } from "./RascalDebugAdapterDescriptorFactory";
 import { RascalDebugConfigurationProvider } from "./RascalDebugConfigurationProvider";
 
@@ -37,7 +37,8 @@ export class RascalDebugClient {
     debugSocketServersPorts: Map<number, number>; // Terminal processID -> socket server port for debug
     runningDebugSessionsPorts: Set<number>; // Stores all running debug session server ports
 
-
+    private portEventEmitter = new EventEmitter<undefined>();
+    readonly portRegistrationEvent = this.portEventEmitter.event;
 
     constructor(){
         this.rascalDescriptorFactory = new RascalDebugAdapterDescriptorFactory();
@@ -77,7 +78,7 @@ export class RascalDebugClient {
 
     registerDebugServerPort(processID: number, serverPort: number){
         this.debugSocketServersPorts.set(processID, serverPort);
-        commands.executeCommand('rascalmpl.updateDebugView');
+        this.portEventEmitter.fire(undefined);
     }
 
     getServerPort(processId: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import { debug, DebugConfiguration, DebugSession, Terminal, window } from "vscode";
+import { debug, DebugConfiguration, DebugSession, Terminal, window, commands } from "vscode";
 import { RascalDebugAdapterDescriptorFactory } from "./RascalDebugAdapterDescriptorFactory";
 import { RascalDebugConfigurationProvider } from "./RascalDebugConfigurationProvider";
 
@@ -77,6 +77,7 @@ export class RascalDebugClient {
 
     registerDebugServerPort(processID: number, serverPort: number){
         this.debugSocketServersPorts.set(processID, serverPort);
+        commands.executeCommand('rascalmpl.updateDebugView');
     }
 
     getServerPort(processId: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -79,11 +79,8 @@ export class RascalDebugClient {
         this.debugSocketServersPorts.set(processID, serverPort);
     }
 
-    getServerPort(processID: number | undefined){
-        if(processID !== undefined && this.debugSocketServersPorts.has(processID)){
-            return this.debugSocketServersPorts.get(processID);
-        }
-        return undefined;
+    getServerPort(processId: number){
+        return this.debugSocketServersPorts.get(processId);
     }
 
     isConnectedToDebugServer(serverPort: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugConfigurationProvider.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugConfigurationProvider.ts
@@ -59,6 +59,9 @@ export class RascalDebugConfigurationProvider implements DebugConfigurationProvi
 
         if (!debugConfiguration['serverPort']){
             const terminalProcessID = await window.activeTerminal?.processId;
+            if (terminalProcessID === undefined) {
+                throw Error("Active terminal has no associated process ID!");
+            }
             const port = this.debugClient.getServerPort(terminalProcessID);
             if(port === undefined) {
                 throw Error("Active terminal has not a debug server port registered !");

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+import * as vscode from 'vscode';
+import { RascalDebugClient } from './RascalDebugClient';
+
+export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalReplNode> {
+    private changeEmitter = new vscode.EventEmitter<RascalReplNode | undefined>();
+    readonly onDidChangeTreeData = this.changeEmitter.event;
+
+    constructor(private readonly rascalDebugClient: RascalDebugClient) {
+        vscode.window.onDidOpenTerminal(_e => {
+            console.log("onDidOpenTerminal");
+            this.changeEmitter.fire(undefined);
+        });
+        vscode.window.onDidCloseTerminal(_e => {
+            console.log("onDidCloseTerminal");
+            this.changeEmitter.fire(undefined);
+        });
+        vscode.window.onDidChangeActiveTerminal(_e => {
+            console.log("onDidChangeActiveTerminal");
+            this.changeEmitter.fire(undefined);
+        });
+        vscode.debug.onDidStartDebugSession(_e => {
+            console.log("onDidStartDebugSession");
+            this.changeEmitter.fire(undefined);
+        });
+        vscode.debug.onDidTerminateDebugSession(_e => {
+            console.log("onDidTerminateDebugSession");
+            this.changeEmitter.fire(undefined);
+        });
+        vscode.workspace.onDidChangeWorkspaceFolders(_e => {
+            this.changeEmitter.fire(undefined);
+        });
+    }
+
+    getTreeItem(element: RascalReplNode): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+    getChildren(element?: RascalReplNode | undefined): vscode.ProviderResult<RascalReplNode[]> {
+        if (element === undefined) {
+            return this.updateRascalDebugView();
+        }
+        return [];
+    }
+    getParent?(_element: RascalReplNode): vscode.ProviderResult<RascalReplNode> {
+        return undefined;
+    }
+    resolveTreeItem?(item: vscode.TreeItem, _element: RascalReplNode, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TreeItem> {
+        return item;
+    }
+
+    async updateRascalDebugView() : Promise<vscode.TreeItem[]> {
+        console.log(`Update Rascal Debug View. Found (${vscode.window.terminals.length} terminals.`);
+        console.log(console.log(this.rascalDebugClient.debugSocketServersPorts));
+        const result : RascalReplNode[] = [];
+        for (const terminal of vscode.window.terminals) {
+            const processId = await terminal.processId;
+            if (processId === undefined) {
+                console.log(`Found one (${terminal.name}, no processId)`);
+                continue;
+            }
+            console.log(`\tFound one (${terminal.name}): ${await terminal.processId}`);
+            if (terminal.name.includes("Rascal terminal")) {
+                let label = terminal.name;
+                if (await this.isActiveTerminal(terminal.processId)) {
+                    label += "***";
+                }
+                const serverPort = this.rascalDebugClient.getServerPort(await terminal.processId);
+                console.log(`ServerPort: ${serverPort}`);
+                const replNode = new RascalReplNode(label, serverPort);
+                if (serverPort !== undefined && this.rascalDebugClient.isConnectedToDebugServer(serverPort)) {
+                    replNode.contextValue = "isDebugging";
+                } else {
+                    replNode.contextValue = "isNotDebugging";
+                }
+                result.push(replNode);
+            }
+        }
+        console.log("Repl Nodes:");
+        console.log(result);
+        return result;
+    }
+
+    async isActiveTerminal(processId : Thenable<number | undefined>) : Promise<boolean> {
+        const activeTerminal = vscode.window.activeTerminal;
+        if (activeTerminal === undefined) {
+            return false;
+        }
+        return await processId === await activeTerminal.processId;
+    }
+
+}
+
+export class RascalReplNode extends vscode.TreeItem {
+    serverPort? : number | undefined;
+
+    constructor(label : string | vscode.TreeItemLabel, serverPort : number | undefined) {
+        super(label, vscode.TreeItemCollapsibleState.None);
+        this.serverPort = serverPort;
+    }
+}

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -35,20 +35,21 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         const fireEmitter = (_: vscode.Terminal | vscode.DebugSession | undefined) : void => {
             this.changeEmitter.fire(undefined);
         };
-        context.subscriptions.push(vscode.window.onDidOpenTerminal(fireEmitter));
-        context.subscriptions.push(vscode.window.onDidCloseTerminal(fireEmitter));
-        context.subscriptions.push(vscode.window.onDidChangeActiveTerminal(fireEmitter));
-        context.subscriptions.push(vscode.debug.onDidStartDebugSession(fireEmitter));
-        context.subscriptions.push(vscode.debug.onDidTerminateDebugSession(fireEmitter));
 
-        context.subscriptions.push(this.rascalDebugClient.portRegistrationEvent(fireEmitter));
+        vscode.window.onDidOpenTerminal(fireEmitter, this, context.subscriptions);
+        vscode.window.onDidCloseTerminal(fireEmitter, this, context.subscriptions);
+        vscode.window.onDidChangeActiveTerminal(fireEmitter, this, context.subscriptions);
+        vscode.debug.onDidStartDebugSession(fireEmitter, this, context.subscriptions);
+        vscode.debug.onDidTerminateDebugSession(fireEmitter, this, context.subscriptions);
+
+        this.rascalDebugClient.portRegistrationEvent(fireEmitter, this, context.subscriptions);
 
         this.context.subscriptions.push(
             vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
                 if (replNode.serverPort !== undefined) {
                     this.rascalDebugClient.startDebuggingSession(replNode.serverPort);
                 }
-            })
+            }, this)
         );
     }
 

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -26,7 +26,6 @@
  */
 import * as vscode from 'vscode';
 import { RascalDebugClient } from './RascalDebugClient';
-import { Command } from 'vscode-languageclient';
 
 export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalReplNode> {
     private changeEmitter = new vscode.EventEmitter<RascalReplNode | undefined>();
@@ -88,7 +87,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         return label;
     }
 
-    async updateRascalDebugView() : Promise<RascalReplNode[]> {
+    async updateRascalDebugView() : Promise<vscode.TreeItem[]> {
         const result : RascalReplNode[] = [];
         for (const terminal of vscode.window.terminals) {
             const processId = await terminal.processId;
@@ -99,8 +98,10 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
                 const label = await this.makeLabel(terminal.name, processId);
                 const serverPort = this.rascalDebugClient.getServerPort(processId);
                 const isDebugging = serverPort !== undefined && this.rascalDebugClient.isConnectedToDebugServer(serverPort);
-                const canStartDebugging = serverPort !== undefined && !isDebugging;
-                const replNode = new RascalReplNode(label, serverPort, isDebugging, canStartDebugging);
+                const replNode = new RascalReplNode(label, serverPort, isDebugging);
+                if (serverPort !== undefined && !isDebugging) {
+                    replNode.contextValue = "canStartDebugging";
+                }
                 result.push(replNode);
             }
         }
@@ -118,11 +119,9 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 }
 
 export class RascalReplNode extends vscode.TreeItem {
-    constructor(label : string | vscode.TreeItemLabel, readonly serverPort : number | undefined, isDebugging : boolean, canStartDebugging : boolean) {
+    constructor(label : string | vscode.TreeItemLabel, readonly serverPort : number | undefined, isDebugging : boolean) {
         super(label, vscode.TreeItemCollapsibleState.None);
+        this.serverPort = serverPort;
         this.iconPath = new vscode.ThemeIcon(isDebugging ? "debug" : "terminal");
-        if (canStartDebugging) {
-            this.command = Command.create("Debug Rascal REPL", "rascalmpl.startDebuggerForRepl", this, {"icon":"$(debug)"});
-        }
     }
 }

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -88,8 +88,9 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
             if (terminal.name.includes("Rascal terminal")) {
                 const label = await this.makeLabel(terminal.name, processId);
                 const serverPort = this.rascalDebugClient.getServerPort(processId);
-                const replNode = new RascalReplNode(label, serverPort);
-                if (serverPort !== undefined && !this.rascalDebugClient.isConnectedToDebugServer(serverPort)) {
+                const isDebugging = serverPort !== undefined && this.rascalDebugClient.isConnectedToDebugServer(serverPort);
+                const replNode = new RascalReplNode(label, serverPort, isDebugging);
+                if (serverPort !== undefined && !isDebugging) {
                     replNode.contextValue = "canStartDebugging";
                 }
                 result.push(replNode);
@@ -111,8 +112,9 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 export class RascalReplNode extends vscode.TreeItem {
     serverPort? : number | undefined;
 
-    constructor(label : string | vscode.TreeItemLabel, serverPort : number | undefined) {
+    constructor(label : string | vscode.TreeItemLabel, serverPort : number | undefined, isDebugging : boolean) {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.serverPort = serverPort;
+        this.iconPath = new vscode.ThemeIcon(isDebugging ? "debug" : "terminal");
     }
 }

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -31,7 +31,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
     private changeEmitter = new vscode.EventEmitter<RascalReplNode | undefined>();
     readonly onDidChangeTreeData = this.changeEmitter.event;
 
-    constructor(private readonly rascalDebugClient: RascalDebugClient) {
+    constructor(private readonly rascalDebugClient: RascalDebugClient, readonly context: vscode.ExtensionContext) {
         vscode.window.onDidOpenTerminal(_e => {
             this.changeEmitter.fire(undefined);
         });
@@ -50,6 +50,9 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         vscode.debug.onDidReceiveDebugSessionCustomEvent(_e => {
             this.changeEmitter.fire(undefined);
         });
+        context.subscriptions.push(vscode.commands.registerCommand('rascalmpl.updateDebugView', () => {
+            this.changeEmitter.fire(undefined);
+        }));
     }
 
     getTreeItem(element: RascalReplNode): vscode.TreeItem | Thenable<vscode.TreeItem> {

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -110,9 +110,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 }
 
 export class RascalReplNode extends vscode.TreeItem {
-    serverPort? : number | undefined;
-
-    constructor(label : string | vscode.TreeItemLabel, serverPort : number | undefined, isDebugging : boolean) {
+    constructor(label : string | vscode.TreeItemLabel, readonly serverPort : number | undefined, isDebugging : boolean) {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.serverPort = serverPort;
         this.iconPath = new vscode.ThemeIcon(isDebugging ? "debug" : "terminal");

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -33,23 +33,18 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 
     constructor(private readonly rascalDebugClient: RascalDebugClient) {
         vscode.window.onDidOpenTerminal(_e => {
-            console.log("onDidOpenTerminal");
             this.changeEmitter.fire(undefined);
         });
         vscode.window.onDidCloseTerminal(_e => {
-            console.log("onDidCloseTerminal");
             this.changeEmitter.fire(undefined);
         });
         vscode.window.onDidChangeActiveTerminal(_e => {
-            console.log("onDidChangeActiveTerminal");
             this.changeEmitter.fire(undefined);
         });
         vscode.debug.onDidStartDebugSession(_e => {
-            console.log("onDidStartDebugSession");
             this.changeEmitter.fire(undefined);
         });
         vscode.debug.onDidTerminateDebugSession(_e => {
-            console.log("onDidTerminateDebugSession");
             this.changeEmitter.fire(undefined);
         });
         vscode.workspace.onDidChangeWorkspaceFolders(_e => {

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NWO-I CWI and Swat.engineering
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -111,7 +111,6 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 export class RascalReplNode extends vscode.TreeItem {
     constructor(label : string | vscode.TreeItemLabel, readonly serverPort : number | undefined, isDebugging : boolean) {
         super(label, vscode.TreeItemCollapsibleState.None);
-        this.serverPort = serverPort;
         this.iconPath = new vscode.ThemeIcon(isDebugging ? "debug" : "terminal");
     }
 }

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -32,7 +32,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
     readonly onDidChangeTreeData = this.changeEmitter.event;
 
     constructor(private readonly rascalDebugClient: RascalDebugClient, readonly context: vscode.ExtensionContext) {
-        const fireEmitter = (_: vscode.Terminal | vscode.DebugSession | undefined) : void => {
+        const fireEmitter = (_: vscode.Terminal | vscode.DebugSession | {processId: number, serverPort: number} | undefined) : void => {
             this.changeEmitter.fire(undefined);
         };
 

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -53,6 +53,14 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         context.subscriptions.push(vscode.commands.registerCommand('rascalmpl.updateDebugView', () => {
             this.changeEmitter.fire(undefined);
         }));
+
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
+                if (replNode.serverPort !== undefined) {
+                    this.rascalDebugClient.startDebuggingSession(replNode.serverPort);
+                }
+            })
+        );
     }
 
     getTreeItem(element: RascalReplNode): vscode.TreeItem | Thenable<vscode.TreeItem> {

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -32,27 +32,16 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
     readonly onDidChangeTreeData = this.changeEmitter.event;
 
     constructor(private readonly rascalDebugClient: RascalDebugClient, readonly context: vscode.ExtensionContext) {
-        vscode.window.onDidOpenTerminal(_e => {
+        const fireEmitter = (_: vscode.Terminal | vscode.DebugSession | undefined) : void => {
             this.changeEmitter.fire(undefined);
-        });
-        vscode.window.onDidCloseTerminal(_e => {
-            this.changeEmitter.fire(undefined);
-        });
-        vscode.window.onDidChangeActiveTerminal(_e => {
-            this.changeEmitter.fire(undefined);
-        });
-        vscode.debug.onDidStartDebugSession(_e => {
-            this.changeEmitter.fire(undefined);
-        });
-        vscode.debug.onDidTerminateDebugSession(_e => {
-            this.changeEmitter.fire(undefined);
-        });
-        vscode.debug.onDidReceiveDebugSessionCustomEvent(_e => {
-            this.changeEmitter.fire(undefined);
-        });
-        context.subscriptions.push(vscode.commands.registerCommand('rascalmpl.updateDebugView', () => {
-            this.changeEmitter.fire(undefined);
-        }));
+        };
+        context.subscriptions.push(vscode.window.onDidOpenTerminal(fireEmitter));
+        context.subscriptions.push(vscode.window.onDidCloseTerminal(fireEmitter));
+        context.subscriptions.push(vscode.window.onDidChangeActiveTerminal(fireEmitter));
+        context.subscriptions.push(vscode.debug.onDidStartDebugSession(fireEmitter));
+        context.subscriptions.push(vscode.debug.onDidTerminateDebugSession(fireEmitter));
+
+        context.subscriptions.push(this.rascalDebugClient.portRegistrationEvent(fireEmitter));
 
         this.context.subscriptions.push(
             vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -69,23 +69,18 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
     }
 
     async updateRascalDebugView() : Promise<vscode.TreeItem[]> {
-        console.log(`Update Rascal Debug View. Found (${vscode.window.terminals.length} terminals.`);
-        console.log(console.log(this.rascalDebugClient.debugSocketServersPorts));
         const result : RascalReplNode[] = [];
         for (const terminal of vscode.window.terminals) {
             const processId = await terminal.processId;
             if (processId === undefined) {
-                console.log(`Found one (${terminal.name}, no processId)`);
                 continue;
             }
-            console.log(`\tFound one (${terminal.name}): ${await terminal.processId}`);
             if (terminal.name.includes("Rascal terminal")) {
                 let label = terminal.name;
                 if (await this.isActiveTerminal(terminal.processId)) {
                     label += "***";
                 }
                 const serverPort = this.rascalDebugClient.getServerPort(await terminal.processId);
-                console.log(`ServerPort: ${serverPort}`);
                 const replNode = new RascalReplNode(label, serverPort);
                 if (serverPort !== undefined && this.rascalDebugClient.isConnectedToDebugServer(serverPort)) {
                     replNode.contextValue = "isDebugging";
@@ -95,8 +90,6 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
                 result.push(replNode);
             }
         }
-        console.log("Repl Nodes:");
-        console.log(result);
         return result;
     }
 

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -74,6 +74,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         return [];
     }
     getParent?(_element: RascalReplNode): vscode.ProviderResult<RascalReplNode> {
+        //The Rascal debug view gives a flat list of the opened Rascal terminals. As such, only root items exit in this view.
         return undefined;
     }
     resolveTreeItem?(item: vscode.TreeItem, _element: RascalReplNode, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.TreeItem> {

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -87,7 +87,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         return label;
     }
 
-    async updateRascalDebugView() : Promise<vscode.TreeItem[]> {
+    async updateRascalDebugView() : Promise<RascalReplNode[]> {
         const result : RascalReplNode[] = [];
         for (const terminal of vscode.window.terminals) {
             const processId = await terminal.processId;


### PR DESCRIPTION
This PR adds a custom view to the "Run and Debug" view container in VS Code. This view provides users with a list of running Rascal REPLs within VS Code, with a button to start a debugging session for REPLs that have been initialized and are not already actively being debugged. The active Rascal terminal (if any) is highlighted for convenience.


For a visual impression, see the attached screenshot.

![image](https://github.com/user-attachments/assets/cce5a49b-1cf9-4927-8010-cb36f5448440)

Each line represents a single active Rascal terminal. The highlighted line represents the terminal that is currently visible in the UI. The bug button to the right starts a debug session for the associated terminal. The bug icon to the left indicates that a debug session is already active for that terminal.
