### PR TITLE
Rename: Fix incremental type check issues

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -49,6 +49,7 @@ import String;
 import lang::rascal::\syntax::Rascal;
 
 import lang::rascalcore::check::Checker;
+import lang::rascalcore::check::BasicRascalConfig;
 
 import lang::rascal::lsp::refactor::rename::Modules;
 
@@ -486,6 +487,12 @@ private bool rascalContainsName(loc l, str name) {
     return false;
 }
 
+private TModel getTModel(str modName, ModuleStatus ms) {
+    <found, tm, ms> = getTModelForModule(modName, ms);
+    if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'\n<toString(ms.messages)>");
+    return convertTModel2PhysicalLocs(tm);
+}
+
 private set[TModel] rascalTModels(set[loc] fs, PathConfig pcfg) {
     if (fs == {}) return {};
 
@@ -494,13 +501,16 @@ private set[TModel] rascalTModels(set[loc] fs, PathConfig pcfg) {
     list[str] topModuleNames = [getModuleName(mloc, pcfg) | mloc <- fs];
     ms = rascalTModelForNames(topModuleNames, ccfg, dummy_compile1);
 
-    set[TModel] tmodels = {};
-    for (str modName <- ms.moduleLocs) {
-        <found, tm, ms> = getTModelForModule(modName, ms);
-        if (!found) throw unexpectedFailure("Cannot read TModel for module \'<modName>\'\n<toString(ms.messages)>");
-        tmodels += convertTModel2PhysicalLocs(tm);
+    map[str, TModel] tmodels = ();
+    modsToDo = toSet(topModuleNames);
+    while ({str modName, *rest} := modsToDo) {
+        modsToDo = rest;
+        tm = getTModel(modName, ms);
+        tmodels[modName] = tm;
+        depNames = domain(tm.store[key_bom]);
+        modsToDo += depNames - domain(tmodels);
     }
-    return tmodels;
+    return range(tmodels);
 }
 
 ProjectFiles preloadFiles(set[loc] workspaceFolders, loc cursorLoc) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
@@ -62,5 +62,6 @@ test bool incrementalTypeCheck() {
 
     ms = rascalTModelForNames([modName], rascalCompilerConfig(pcfg), dummy_compile1);
     res = testRenameOccurrences({byLoc(modName, moduleLoc, {0, 1})});
+    remove(procLoc);
     return res;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
@@ -29,7 +29,12 @@ module lang::rascal::tests::rename::Performance
 import lang::rascal::tests::rename::TestUtils;
 import lang::rascal::lsp::refactor::Exception;
 
+import lang::rascalcore::check::Checker;
+import lang::rascalcore::check::RascalConfig;
+
+import IO;
 import List;
+import util::Reflective;
 
 int LARGE_TEST_SIZE = 200;
 test bool largeTest() = testRenameOccurrences(({0} | it + {foos + 3, foos + 4, foos + 5} | i <- [0..LARGE_TEST_SIZE], foos := 5 * i), (
@@ -42,3 +47,20 @@ test bool largeTest() = testRenameOccurrences(({0} | it + {foos + 3, foos + 4, f
 
 @expected{unsupportedRename}
 test bool failOnError() = testRename("int foo = x + y;");
+
+test bool incrementalTypeCheck() {
+    procLoc = |memory://tests/incremental|;
+    pcfg = getTestPathConfig(procLoc);
+    procSrc = pcfg.srcs[0];
+
+    modName = "A";
+    moduleLoc = procSrc + "<modName>.rsc";
+    writeFile(moduleLoc, "module <modName>
+        'int foo() = 1;
+        'void main() { x = foo(); }
+    ");
+
+    ms = rascalTModelForNames([modName], rascalCompilerConfig(pcfg), dummy_compile1);
+    res = testRenameOccurrences({byLoc(modName, moduleLoc, {0, 1})});
+    return res;
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -27,6 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 module lang::rascal::tests::rename::ProjectOnDisk
 
 import lang::rascal::lsp::refactor::Rename;
+import lang::rascal::lsp::refactor::Util;
 import lang::rascal::tests::rename::TestUtils;
 import util::Reflective;
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -81,8 +81,7 @@ private void verifyTypeCorrectRenaming(loc root, Edits edits, PathConfig pcfg) {
 
     // Restore back-up
     remove(root, recursive = true);
-    copy(backupLoc, root, recursive = true);
-    remove(backupLoc, recursive = true);
+    move(backupLoc, root, overwrite = true);
 }
 
 bool expectEq(&T expected, &T actual, str epilogue = "") {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -161,8 +161,8 @@ bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str new
             success = false;
         }
 
-        for (success, src <- pcfg.srcs) {
-            verifyTypeCorrectRenaming(src, edits, pcfg);
+        if (success) {
+            verifyTypeCorrectRenaming(testDir, edits, pcfg);
         }
 
         if (!moduleExistsOnDisk) {


### PR DESCRIPTION
When a TModel for the module under cursor already exists (real-world, untested scenario), the renaming failed to load any TModel. This consistently led to failed renamings. This PR fixes this, by not relying on module status caches anymore.