### PR TITLE
Fix rename refactoring name check

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -554,19 +554,16 @@ ProjectFiles preloadFiles(set[loc] workspaceFolders, loc cursorLoc) {
 }
 
 ProjectFiles allWorkspaceFiles(set[loc] workspaceFolders, str cursorName, bool(loc, str) containsName, PathConfig(loc) getPathConfig) {
-    ProjectFiles fs = {};
-    for (folder <- workspaceFolders) {
-        pcfg = getPathConfig(folder);
-        for (srcFolder <- pcfg.srcs) {
-            for (loc f <- find(srcFolder, "rsc")) {
-                // If we do not find any occurrences of the name under the cursor in a module,
-                // we are not interested in loading the model, but we still want to inform the
-                // renaming framework about the existence of the file.
-                fs += <folder, containsName(f, cursorName), f>;
-            }
-        }
-    }
-    return fs;
+    return {
+        // If we do not find any occurrences of the name under the cursor in a module,
+        // we are not interested in loading the model, but we still want to inform the
+        // renaming framework about the existence of the file.
+        <folder, containsName(file, cursorName), file>
+        | folder <- workspaceFolders
+        , PathConfig pcfg := getPathConfig(folder)
+        , srcFolder <- pcfg.srcs
+        , file <- find(srcFolder, "rsc")
+    };
 }
 
 set[TModel] tmodelsForProjectFiles(ProjectFiles projectFiles, set[TModel](set[loc], PathConfig) tmodelsForFiles, PathConfig(loc) getPathConfig) =

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -484,17 +484,17 @@ private bool(loc) rascalContainsNameFilter(str n) {
 
     // Since QualifiedName is the most liberal and all the others are subsets of it,
     // we default to QualifiedName in case parsing as something else fails.
-    qName = [QualifiedName] n;
     qNameEsc = [QualifiedName] en;
 
     Tree tryNameParse(type[&T <: Tree] a, str s) {
         try {
             return parse(a, s);
         } catch _: {
-            return qName;
+            return qNameEsc;
         }
     }
 
+    qName = tryNameParse(#QualifiedName, n);
     name = tryNameParse(#QualifiedName, n);
     nameEsc = tryNameParse(#QualifiedName, en);
     nonTerm = tryNameParse(#Nonterminal, n);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -532,16 +532,19 @@ ProjectFiles preloadFiles(set[loc] workspaceFolders, loc cursorLoc) {
 }
 
 ProjectFiles allWorkspaceFiles(set[loc] workspaceFolders, str cursorName, bool(loc, str) containsName, PathConfig(loc) getPathConfig) {
-    return {
-        // If we do not find any occurrences of the name under the cursor in a module,
-        // we are not interested in loading the model, but we still want to inform the
-        // renaming framework about the existence of the file.
-        <folder, containsName(file, cursorName), file>
-        | folder <- workspaceFolders
-        , PathConfig pcfg := getPathConfig(folder)
-        , srcFolder <- pcfg.srcs
-        , file <- find(srcFolder, "rsc")
-    };
+    ProjectFiles fs = {};
+    for (folder <- workspaceFolders) {
+        pcfg = getPathConfig(folder);
+        for (srcFolder <- pcfg.srcs) {
+            for (loc f <- find(srcFolder, "rsc")) {
+                // If we do not find any occurrences of the name under the cursor in a module,
+                // we are not interested in loading the model, but we still want to inform the
+                // renaming framework about the existence of the file.
+                fs += <folder, containsName(f, cursorName), f>;
+            }
+        }
+    }
+    return fs;
 }
 
 set[TModel] tmodelsForProjectFiles(ProjectFiles projectFiles, set[TModel](set[loc], PathConfig) tmodelsForFiles, PathConfig(loc) getPathConfig) =

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -479,12 +479,21 @@ private Cursor rascalGetCursor(TModel ws, Tree cursorT) {
     return cursor(kind, min(locsContainingCursor.l), cursorName);
 }
 
+@memo{maximumSize(1000), expireAfter(minutes=5)}
 private set[str] rascalNameToEquivalentNames(str name) =
     {name, startsWith(name, "\\") ? name : "\\<name>"};
 
 private bool rascalContainsName(loc l, str name) {
     m = parseModuleWithSpacesCached(l);
-    if (/Tree t := m, "<t>" in rascalNameToEquivalentNames(name)) return true;
+    names = rascalNameToEquivalentNames(name);
+    bool matches(Tree t) = "<t>" in names;
+
+    visit (m) {
+        case Name n: if (matches(n)) return true;
+        case QualifiedName n: if (matches(n)) return true;
+        case Nonterminal n: if (matches(n)) return true;
+        case NonterminalLabel n: if (matches(n)) return true;
+    }
     return false;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -484,16 +484,21 @@ private set[str] rascalNameToEquivalentNames(str name) =
     {name, startsWith(name, "\\") ? name : "\\<name>"};
 
 private bool rascalContainsName(loc l, str name) {
-    m = parseModuleWithSpacesCached(l);
     names = rascalNameToEquivalentNames(name);
     bool matches(Tree t) = "<t>" in names;
 
-    visit (m) {
-        case Name n: if (matches(n)) return true;
-        case QualifiedName n: if (matches(n)) return true;
-        case Nonterminal n: if (matches(n)) return true;
-        case NonterminalLabel n: if (matches(n)) return true;
+    try {
+        m = parseModuleWithSpacesCached(l);
+        visit (m) {
+            case Name n: if (matches(n)) return true;
+            case QualifiedName n: if (matches(n)) return true;
+            case Nonterminal n: if (matches(n)) return true;
+            case NonterminalLabel n: if (matches(n)) return true;
+        }
     }
+    catch Java("ParseError", _): return false;
+    catch ParseError(_): return false;
+
     return false;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -36,6 +36,16 @@ Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 
     PathConfig pcfg;
     if (projectDir.file == "rascal-core") {
         pcfg = getRascalCorePathConfig(projectDir);
+    } else if (projectDir.file == "rascal") {
+        pcfg = pathConfig(
+            srcs = [ projectDir + "src/org/rascalmpl/library"
+                   , projectDir + "test/org/rascalmpl/benchmark"
+                   , projectDir + "test/org/rascalmpl/test/data"],
+            bin = projectDir + "target/classes",
+            generatedSources = projectDir + "target/generated-sources/src/main/java/",
+            generatedTestSources = projectDir + "target/generated-test/sources/src/main/java/",
+            resources = projectDir + "target/generated-resources/src/main/java/"
+        );
     } else {
         pcfg = pathConfig(
             srcs = [ projectDir + "src" ],


### PR DESCRIPTION
This PR fixes issues when renaming something in the Rascal project, reported by @PieterOlivier.

1. When looking for the use of a name in a module, trying all possible sub trees caused a stack overflow. Besides that, pretty-printing all of those sub trees was really expensive. This is now rewritten to a more sensible implementation using `visit`.
2. Rewrite the workspace crawl to use less environments.
3. Make the name check robust against modules with parse errors.