### PR TITLE
Added a button to error pop-ups to copy the stack trace to the clipboard

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
@@ -190,7 +190,7 @@ public class EvaluatorUtil {
                         var content = new StringSelection(stackTrace);
                         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(content, content);
                     }
-                } 
+                }
             });
     }
 


### PR DESCRIPTION
The error pop-up in VS Code now has an additional button to copy the stack trace to the clipboard.

![image](https://github.com/user-attachments/assets/fb7ace60-e28f-4142-8fcf-4d078d117e8f)
