### PR TITLE
Renaming: Detect overload of new name uses

### DIFF
--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -193,7 +193,7 @@ RenameResult rename(
 
     printDebug("+ Finding occurrences of cursor");
     <maybeDefFiles, maybeUseFiles> = findOccurrenceFiles(defs, cursor, parseLocCached, r);
-    <newNameDefFiles, newNameUseFiles> = findNewNameOccurrenceFiles(defs, newName, parseLocCached, r);
+    <newNameDefFiles, newNameUseFiles> = findNewNameOccurrenceFiles(defs, cursor, newName, parseLocCached, r);
 
     if (maybeDefFiles != {}) {
         printDebug("+ Finding additional definitions");
@@ -339,7 +339,7 @@ default tuple[set[loc] defFiles, set[loc] useFiles] findOccurrenceFiles(set[Defi
     return <{f}, {f}>;
 }
 
-default tuple[set[loc] defFiles, set[loc] useFiles] findNewNameOccurrenceFiles(set[Define] cursorDefs, str name, Tree(loc) _, Renamer _) {
+default tuple[set[loc] defFiles, set[loc] useFiles] findNewNameOccurrenceFiles(set[Define] cursorDefs, list[Tree] cursor, str name, Tree(loc) _, Renamer _) {
     set[loc] defFiles = {d.defined.top | d <- cursorDefs};
     set[loc] fs = {f
         | loc f <- defFiles

--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -191,7 +191,7 @@ RenameResult rename(
     if (errorReported()) return <sortDocEdits(docEdits), getMessages()>;
 
     printDebug("+ Finding occurrences of cursor");
-    <maybeDefFiles, maybeUseFiles> = findOccurrenceFiles(defs, cursor, parseLocCached, r);
+    <maybeDefFiles, maybeUseFiles> = findOccurrenceFiles(defs, cursor, newName, parseLocCached, r);
 
     if (maybeDefFiles != {}) {
         printDebug("+ Finding additional definitions");
@@ -310,7 +310,7 @@ default set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) _, TModel(
     return {};
 }
 
-default tuple[set[loc] defFiles, set[loc] useFiles] findOccurrenceFiles(set[Define] cursorDefs, list[Tree] cursor, Tree(loc) _, Renamer r) {
+default tuple[set[loc] defFiles, set[loc] useFiles] findOccurrenceFiles(set[Define] cursorDefs, list[Tree] cursor, str newName, Tree(loc) _, Renamer r) {
     loc f = cursor[0].src.top;
     if (any(d <- cursorDefs, f != d.defined.top)) {
         r.error(cursor[0].src, "Rename not implemented for cross-file definitions. Please overload `findOccurrenceFiles`.");

--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -201,7 +201,7 @@ RenameResult rename(
             printDebug("  - ... in <f>");
             tr = parseLocCached(f);
             tm = getTModelCached(tr);
-            fileAdditionalDefs = findAdditionalDefinitions(defs, tr, tm);
+            fileAdditionalDefs = findAdditionalDefinitions(defs, tr, tm, r);
             printDebug("    (found <size(fileAdditionalDefs)>)");
             additionalDefs += fileAdditionalDefs;
         }
@@ -328,7 +328,7 @@ default tuple[set[loc] defFiles, set[loc] useFiles, set[loc] newNameFiles] findO
     return <{f}, {f}, {}>;
 }
 
-default set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm) = {};
+default set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm, Renamer r) = {};
 
 default void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree _, Renamer r) {}
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -135,7 +135,7 @@ void rascalCheckLegalNameByRole(Define _:<_, _, _, role, at, _>, str name, Renam
     }
 }
 
-void rascalCheckCausesDoubleDeclarations(Define cD, TModel tm, str newName, Renamer r) {
+void rascalCheckCausesDoubleDeclarations(Define cD, str newName, TModel tm, Renamer r) {
     set[Define] newNameDefs = {def | Define def:<_, newName, _, _, _, _> <- tm.defines};
 
     // Is newName already resolvable from a scope where <current-name> is currently declared?
@@ -679,7 +679,7 @@ void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree tr, Re
     tm = r.getConfig().tmodelForTree(tr);
     rascalCheckCausesCaptures(cursorDefs, newName, tr, tm, r);
     for (d <- cursorDefs) {
-        rascalCheckCausesDoubleDeclarations(d, tm, newName, r);
+        rascalCheckCausesDoubleDeclarations(d, newName, tm, r);
     }
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -666,23 +666,19 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[T
         set[loc] defFiles = {};
         set[loc] useFiles = {};
         set[loc] newNameFiles = {};
-        try {
-            if (role notin {variableId(), patternVariableId(), moduleId()}) {
-                defFiles = findSortOccurrenceFiles(t, name, sourceFiles, getTree);
-                useFiles = defFiles;
-                newNameFiles = defFiles;
-            } else {
-                <defFiles, useFiles> = findOccurrenceFiles(defs, cursor, sourceFiles, getTree, r);
-                newNameFiles = defFiles + useFiles;
-            }
 
-            if (!isLocal(role)) newNameFiles = findAllSortsOccurrenceFiles(newName, sourceFiles, getTree);
-
-            return <defFiles, useFiles, newNameFiles>;
-        } catch ParseError(_): {
-            r.error(cursor[0], "\'<name>\' is not a valid <desc>");
-            return <{}, {}, {}>;
+        if (role notin {variableId(), patternVariableId(), moduleId()}) {
+            defFiles = findAllSortsOccurrenceFiles(rascalEscapeName(name), sourceFiles, getTree);
+            useFiles = defFiles;
+            newNameFiles = defFiles;
+        } else {
+            <defFiles, useFiles> = findOccurrenceFiles(defs, cursor, sourceFiles, getTree, r);
+            newNameFiles = defFiles + useFiles;
         }
+
+        if (!isLocal(role)) newNameFiles = findAllSortsOccurrenceFiles(rascalEscapeName(newName), sourceFiles, getTree);
+
+        return <defFiles, useFiles, newNameFiles>;
     }
 
     r.error(cursor[0], "Cannot find occurrence files for mixed-role definitions.");

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -655,9 +655,9 @@ private bool isLocal(IdRole role) = role in variableRoles && role !:= moduleVari
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     if ({IdRole role} := defs.idRole) {
-        <t, _> = asType(role);
+        <t, desc> = asType(role);
         if (tryParseAs(t, rascalEscapeName(newName)) is nothing) {
-            r.error(cursor[0], "Name \'<newName>\' is not valid at this location.");
+            r.error(cursor[0], "\'<newName>\' is not a valid <desc>");
             return <{}, {}, {}>;
         }
 
@@ -680,7 +680,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[T
 
             return <defFiles, useFiles, newNameFiles>;
         } catch ParseError(_): {
-            r.error(cursor[0], "\'<name>\' is not a valid name at this position");
+            r.error(cursor[0], "\'<name>\' is not a valid <desc>");
             return <{}, {}, {}>;
         }
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -655,21 +655,20 @@ private set[loc]() getSourceFiles(Renamer r) {
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     if ({IdRole role} := defs.idRole) {
         <t, _> = asType(role);
-        // TODO Check if specific subtype of Tree is correct here
-        newNameFiles = findSortOccurrenceFiles(t, newName, getSourceFiles(r), getTree);
-
-        if (role notin {variableId(), patternVariableId(), moduleId()}) {
-            name = "<cursor[0]>";
-            try {
+        try {
+            // TODO Check if specific subtype of Tree is correct here
+            newNameFiles = findSortOccurrenceFiles(t, newName, getSourceFiles(r), getTree);
+            if (role notin {variableId(), patternVariableId(), moduleId()}) {
+                name = "<cursor[0]>";
                 defUseFiles = findSortOccurrenceFiles(t, name, getSourceFiles(r), getTree);
                 return <defUseFiles, defUseFiles, newNameFiles>;
-            } catch ParseError(_): {
-                r.error(cursor[0], "\'<name>\' is not a valid name at this position");
-                return <{}, {}, {}>;
             }
+            <defFiles, useFiles> = findOccurrenceFiles(defs, cursor, getSourceFiles(r), getTree, r);
+            return <defFiles, useFiles, newNameFiles>;
+        } catch ParseError(_): {
+            r.error(cursor[0], "\'<name>\' is not a valid name at this position");
+            return <{}, {}, {}>;
         }
-        <defFiles, useFiles> = findOccurrenceFiles(defs, cursor, getSourceFiles(r), getTree, r);
-        return <defFiles, useFiles, newNameFiles>;
     }
 
     r.error(cursor[0], "Cannot find occurrence files for mixed-role definitions.");

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -668,15 +668,15 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[T
         set[loc] newNameFiles = {};
 
         if (role notin {variableId(), patternVariableId(), moduleId()}) {
-            defFiles = findAllSortsOccurrenceFiles(rascalEscapeName(name), sourceFiles, getTree);
+            defFiles = findNameOccurrenceFiles(rascalEscapeName(name), sourceFiles, getTree);
             useFiles = defFiles;
             newNameFiles = defFiles;
         } else {
-            <defFiles, useFiles> = findOccurrenceFiles(defs, cursor, sourceFiles, getTree, r);
+            <defFiles, useFiles> = findDefOccurrenceFiles(defs, cursor, sourceFiles, getTree, r);
             newNameFiles = defFiles + useFiles;
         }
 
-        if (!isLocal(role)) newNameFiles = findAllSortsOccurrenceFiles(rascalEscapeName(newName), sourceFiles, getTree);
+        if (!isLocal(role)) newNameFiles = findNameOccurrenceFiles(rascalEscapeName(newName), sourceFiles, getTree);
 
         return <defFiles, useFiles, newNameFiles>;
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -657,16 +657,26 @@ tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] curso
     if ({IdRole role} := defs.idRole
       && role notin {variableId(), patternVariableId(), moduleId()}) {
         <t, _> = asType(role);
-        return findOccurrenceFilesSymmetric(t, "<cursor[0]>", getSourceFiles(r), getTree);
+        name = "<cursor[0]>";
+        try {
+            return findOccurrenceFilesSymmetric(t, name, getSourceFiles(r), getTree);
+        } catch ParseError(_): {
+            r.error(cursor[0], "\'<name>\' is not a valid name at this position");
+            return <{}, {}>;
+        }
     }
 
     return findOccurrenceFiles(defs, cursor, getSourceFiles(r), getTree, r);
 }
 
-tuple[set[loc], set[loc]] findNewNameOccurrenceFiles(set[Define] defs, str name, Tree(loc) getTree, Renamer r) {
+tuple[set[loc], set[loc]] findNewNameOccurrenceFiles(set[Define] defs, list[Tree] cursor, str name, Tree(loc) getTree, Renamer r) {
     if ({IdRole role} := defs.idRole) {
         <t, _> = asType(role);
-        return findOccurrenceFilesSymmetric(t, name, getSourceFiles(r), getTree);
+        try {
+            return findOccurrenceFilesSymmetric(t, name, getSourceFiles(r), getTree);
+        } catch ParseError(_): {
+            r.error(cursor[0], "\'<name>\' is not a valid name at this position");
+        }
     }
     return <{}, {}>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -697,18 +697,18 @@ void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree tr, Re
     }
 }
 
-default void renameDefinitionUnchecked(Define _, loc nameLoc, str newName, Tree _, TModel _, Renamer r) {
+default void renameDefinitionUnchecked(Define _, loc nameLoc, str newName, TModel _, Renamer r) {
     r.textEdit(replace(nameLoc, newName));
 }
 
-void renameDefinition(Define d, loc nameLoc, str newName, Tree tr, TModel tm, Renamer r) {
+void renameDefinition(Define d, loc nameLoc, str newName, TModel tm, Renamer r) {
     rascalCheckLegalNameByRole(d, newName, r);
     rascalCheckDefinitionOutsideWorkspace(d, tm, r);
 
-    renameDefinitionUnchecked(d, nameLoc, rascalEscapeName(newName), tr, tm, r);
+    renameDefinitionUnchecked(d, nameLoc, rascalEscapeName(newName), tm, r);
 }
 
-void renameUses(set[Define] defs, str newName, Tree tr, TModel tm, Renamer r) {
+void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
     set[loc] uses = invert(tm.useDef)[defs.defined] - defs.defined;
     escName = rascalEscapeName(newName);
 
@@ -716,5 +716,5 @@ void renameUses(set[Define] defs, str newName, Tree tr, TModel tm, Renamer r) {
         r.textEdit(replace(u, escName));
     }
 
-    renameAdditionalUses(defs, newName, tr, tm, r);
+    renameAdditionalUses(defs, escName, tm, r);
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -619,6 +619,7 @@ public Edits rascalRenameSymbol(loc cursorLoc, list[Tree] cursor, str newName, s
       }
       , workspaceFolders = workspaceFolders
       , getPathConfig = getPathConfig
+      , debug = false
   )
 );
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -655,11 +655,11 @@ private set[loc]() getSourceFiles(Renamer r) {
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     if ({IdRole role} := defs.idRole) {
         <t, _> = asType(role);
+        name = "<cursor[0]>";
         try {
             // TODO Check if specific subtype of Tree is correct here
             newNameFiles = findSortOccurrenceFiles(t, newName, getSourceFiles(r), getTree);
             if (role notin {variableId(), patternVariableId(), moduleId()}) {
-                name = "<cursor[0]>";
                 defUseFiles = findSortOccurrenceFiles(t, name, getSourceFiles(r), getTree);
                 return <defUseFiles, defUseFiles, newNameFiles>;
             }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -75,12 +75,9 @@ bool isContainedInScope(loc l, loc scope, TModel tm) {
     return any(loc fromScope <- reachableFrom, isContainedIn(l, fromScope));
 }
 
-set[loc] findSortOccurrenceFiles(type[&T <: Tree] N, str curName, set[loc]() getSourceFiles, Tree(loc) getTree) {
-    containsName = containsFilter(N, curName, rascalEscapeName, getTree);
-    return {f
-        | loc f <- getSourceFiles()
-        , containsName(f)
-    };
+set[loc] findSortOccurrenceFiles(type[&T <: Tree] N, str name, set[loc] sourceFiles, Tree(loc) getTree) {
+    containsName = containsFilter(N, name, rascalEscapeName, getTree);
+    return {f | loc f <- sourceFiles, containsName(f)};
 }
 
 // Workaround to be able to pattern match on the emulated `src` field

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -77,7 +77,7 @@ bool isContainedInScope(loc l, loc scope, TModel tm) {
     return any(loc fromScope <- reachableFrom, isContainedIn(l, fromScope));
 }
 
-set[loc] findAllSortsOccurrenceFiles(str name, set[loc] sourceFiles, Tree(loc) getTree) {
+set[loc] findNameOccurrenceFiles(str name, set[loc] sourceFiles, Tree(loc) getTree) {
     containsName = containsFilter(#Name, name, getTree);
     containsQName = containsFilter(#QualifiedName, name, getTree);
     containsNonTerm = containsFilter(#Nonterminal, name, getTree);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -146,9 +146,9 @@ rel[loc from, loc to] rascalGetReflexiveModulePaths(TModel tm) =
   + (tm.paths<pathRole, from, to>)[extendPath()];
 
 set[loc] rascalGetOverloadedDefs(TModel tm, set[loc] defs) {
-    if (defs == {}) return {};
+    set[Define] overloadedDefs = {tm.definitions[d] | d <- defs, tm.definitions[d]?};
+    if (overloadedDefs == {}) return {};
 
-    set[Define] overloadedDefs = {tm.definitions[d] | d <- defs};
     set[IdRole] roles = overloadedDefs.idRole;
 
     // Pre-conditions

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -65,16 +65,13 @@ bool(loc) containsFilter(type[&T <: Tree] t, str name, str(str) escape, Tree(loc
     };
 }
 
-tuple[set[loc], set[loc]] findOccurrenceFilesSymmetric(type[&T <: Tree] N, str curName, str newName, set[loc]() getSourceFiles, Tree(loc) getTree) {
-    containsCurName = containsFilter(N, curName, rascalEscapeName, getTree);
-    containsNewName = containsFilter(N, newName, rascalEscapeName, getTree);
+tuple[set[loc], set[loc]] findOccurrenceFilesSymmetric(type[&T <: Tree] N, str curName, set[loc]() getSourceFiles, Tree(loc) getTree) {
+    containsName = containsFilter(N, curName, rascalEscapeName, getTree);
     set[loc] defFiles = {};
     set[loc] useFiles = {};
     for (loc f <- getSourceFiles()) {
-        if (containsCurName(f)) {
+        if (containsName(f)) {
             defFiles += f;
-            useFiles += f;
-        } else if (containsNewName(f)) {
             useFiles += f;
         }
     }
@@ -136,6 +133,12 @@ rel[loc from, loc to] rascalGetTransitiveReflexiveModulePaths(TModel tm) {
          o (moduleI + extends+) // 0 or more extends
          ;
 }
+
+@memo{maximumSize(100), expireAfter(minutes=5)}
+rel[loc from, loc to] rascalGetReflexiveModulePaths(TModel tm) =
+    ident(getModuleScopes(tm))
+  + (tm.paths<pathRole, from, to>)[importPath()]
+  + (tm.paths<pathRole, from, to>)[extendPath()];
 
 set[loc] rascalGetOverloadedDefs(TModel tm, set[loc] defs) {
     if (defs == {}) return {};

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -252,6 +252,6 @@ set[loc] rascalGetOverloadedDefs(TModel tm, set[loc] defs) {
     return overloadedDefs.defined;
 }
 
-default void renameAdditionalUses(set[Define] defs, str newName, Tree tr, TModel tm, Renamer r) {}
+default void renameAdditionalUses(set[Define] defs, str newName, TModel tm, Renamer r) {}
 
 default bool isUnsupportedCursor(list[Tree] cursor, Renamer _) = false;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -65,17 +65,12 @@ bool(loc) containsFilter(type[&T <: Tree] t, str name, str(str) escape, Tree(loc
     };
 }
 
-tuple[set[loc], set[loc]] findOccurrenceFilesSymmetric(type[&T <: Tree] N, str curName, set[loc]() getSourceFiles, Tree(loc) getTree) {
+set[loc] findSortOccurrenceFiles(type[&T <: Tree] N, str curName, set[loc]() getSourceFiles, Tree(loc) getTree) {
     containsName = containsFilter(N, curName, rascalEscapeName, getTree);
-    set[loc] defFiles = {};
-    set[loc] useFiles = {};
-    for (loc f <- getSourceFiles()) {
-        if (containsName(f)) {
-            defFiles += f;
-            useFiles += f;
-        }
-    }
-    return <defFiles, useFiles>;
+    return {f
+        | loc f <- getSourceFiles()
+        , containsName(f)
+    };
 }
 
 // Workaround to be able to pattern match on the emulated `src` field

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -40,6 +40,7 @@ import util::refactor::WorkspaceInfo;
 import List;
 import Location;
 import Map;
+import ParseTree;
 import Relation;
 import Set;
 import String;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -65,6 +65,15 @@ bool(loc) containsFilter(type[&T <: Tree] t, str name, str(str) escape, Tree(loc
     };
 }
 
+bool isContainedInScope(loc l, loc scope, TModel tm) {
+    // lexical containment
+    if (isContainedIn(l, scope)) return true;
+
+    // via import/extend
+    set[loc] reachableFrom = (tm.paths<pathRole, to, from>)[{importPath(), extendPath()}, scope];
+    return any(loc fromScope <- reachableFrom, isContainedIn(l, fromScope));
+}
+
 set[loc] findSortOccurrenceFiles(type[&T <: Tree] N, str curName, set[loc]() getSourceFiles, Tree(loc) getTree) {
     containsName = containsFilter(N, curName, rascalEscapeName, getTree);
     return {f

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -65,10 +65,20 @@ bool(loc) containsFilter(type[&T <: Tree] t, str name, str(str) escape, Tree(loc
     };
 }
 
-tuple[set[loc], set[loc]] findOccurrenceFilesSymmetric(type[&T <: Tree] N, str name, set[loc]() getSourceFiles, Tree(loc) getTree) {
-    containsName = containsFilter(N, name, rascalEscapeName, getTree);
-    set[loc] fs = {f | loc f <- getSourceFiles(), containsName(f)};
-    return <fs, fs>;
+tuple[set[loc], set[loc]] findOccurrenceFilesSymmetric(type[&T <: Tree] N, str curName, str newName, set[loc]() getSourceFiles, Tree(loc) getTree) {
+    containsCurName = containsFilter(N, curName, rascalEscapeName, getTree);
+    containsNewName = containsFilter(N, newName, rascalEscapeName, getTree);
+    set[loc] defFiles = {};
+    set[loc] useFiles = {};
+    for (loc f <- getSourceFiles()) {
+        if (containsCurName(f)) {
+            defFiles += f;
+            useFiles += f;
+        } else if (containsNewName(f)) {
+            useFiles += f;
+        }
+    }
+    return <defFiles, useFiles>;
 }
 
 // Workaround to be able to pattern match on the emulated `src` field

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
@@ -34,7 +34,7 @@ import lang::rascalcore::check::BasicRascalConfig;
 import lang::rascal::\syntax::Rascal;
 import analysis::typepal::TModel;
 
-// set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, constructorId(), _, _>, *_}, Tree _, TModel tm) {
+// set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, constructorId(), _, _>, *_}, Tree _, TModel tm, Renamer r) {
     // Find the ADT that this constructor is part of
     // Find overloads of this ADT
     // Find all constructors with the same name in these ADT definitions

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -36,7 +36,7 @@ import analysis::typepal::TModel;
 
 import util::Maybe;
 
-// set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, constructorId(), _, _>, *_}, Tree _, TModel tm) {
+// set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, constructorId(), _, _>, *_}, Tree _, TModel tm, Renamer r) {
     // Find the ADT that this constructor is part of
     // Find overloads of this ADT
     // Find all fields with the same name in these ADT definitions

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Functions.rsc
@@ -36,7 +36,7 @@ import lang::rascalcore::check::BasicRascalConfig;
 
 import util::Maybe;
 
-set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, functionId(), _, _>, *_}, Tree _, TModel tm) =
+set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, functionId(), _, _>, *_}, Tree _, TModel tm, Renamer _) =
     {d | d <- tm.defines, rascalMayOverloadSameName(cursorDefs.defined + d.defined, tm.definitions)};
 
 // TODO:

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
@@ -39,12 +39,12 @@ data Tree;
 // - `has` uses: These do not appear in use/def relations
 // - 'except constructors', like Sym sym!otherSym. These do not appear in use/def relations.
 
-void renameDefinitionUnchecked(Define d: <_, _, _, nonterminalId(), _, _>, loc _, str _, Tree _, TModel _, Renamer _) {
+void renameDefinitionUnchecked(Define d: <_, _, _, nonterminalId(), _, _>, loc _, str _, TModel _, Renamer _) {
     // Do not register an edit for the definition, as it will appear as a use again
     // TODO Rascal Core: why register the name of a production definition as a use of itself?
 }
 
-void renameDefinitionUnchecked(Define d: <_, _, _, lexicalId(), _, _>, loc _, str _, Tree _, TModel _, Renamer _) {
+void renameDefinitionUnchecked(Define d: <_, _, _, lexicalId(), _, _>, loc _, str _, TModel _, Renamer _) {
     // Do not register an edit for the definition, as it will appear as a use again
     // TODO Rascal Core: why register the name of a production definition as a use of itself?
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,7 +49,7 @@ import util::Reflective;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc]() getSourceFiles, Tree(loc) getTree, Renamer r) {
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, str newName,  set[loc]() getSourceFiles, Tree(loc) getTree, Renamer r) {
     int modIdSize = size(modId);
     loc modFile = d.top;
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,7 +49,7 @@ import util::Reflective;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, str newName,  set[loc]() getSourceFiles, Tree(loc) getTree, Renamer r) {
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc]() getSourceFiles, Tree(loc) getTree, Renamer r) {
     int modIdSize = size(modId);
     loc modFile = d.top;
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -99,7 +99,6 @@ void renameDefinitionUnchecked(Define d:<_, currentName, _, moduleId(), _, _>, l
 void renameAdditionalUses(set[Define] defs:{<_, moduleName, _, moduleId(), _, _>, *_}, str newName, TModel tm, Renamer r) {
     if ({loc u, *_} := tm.useDef<0>) {
         set[loc] defFiles = {d.top | d <- defs.defined};
-        escName = rascalEscapeName(newName);
         Tree tr = r.getConfig().parseLoc(u.top);
         for (/QualifiedName qn := tr
         , any(d <- tm.useDef[qn.src], d.top in defFiles)

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,35 +49,36 @@ import util::Reflective;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-tuple[set[loc], set[loc]] findDefOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc] sourceFiles, Tree(loc) getTree, Renamer r) {
-    int modIdSize = size(modId);
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<_, str curModName, _, moduleId(), loc d, _>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     loc modFile = d.top;
+    set[loc] useFiles = {};
+    set[loc] newFiles = {};
 
-    if ([*_, QualifiedName modName, *_] := focus) {
-        escModName = [QualifiedName] rascalEscapeName("<modName>");
-        set[loc] useFiles = {};
-        for (loc f <- sourceFiles, f != modFile) {
-            visit (getTree(f)) {
-                case modName: {
-                    useFiles += f;
-                    continue;
-                }
-                case escModName: {
-                    useFiles += f;
-                    continue;
-                }
-                case QualifiedName qn: {
-                    if (qn.src.length > modIdSize && startsWith("<qn>", modId)) {
-                        useFiles += f;
-                        continue;
-                    }
+    modName = [QualifiedName] curModName;
+    newModName = reEscape(newName);
+
+    for (loc f <- getSourceFiles(r)) {
+        bottom-up-break visit (getTree(f)) {
+            case modName: {
+                // Import of exact module name
+                useFiles += f;
+            }
+            case QualifiedName qn: {
+                // Import of redundantly escaped module name
+                escQn = reEscape("<qn>");
+                if (curModName == escQn) useFiles += f;
+                else if (newModName == escQn) newFiles += f;
+                else {
+                    // Qualified use of declaration in module
+                    // If through extends, there might be no import
+                    qualPref = reEscape(qualifiedPrefix(qn).name);
+                    if (qualPref == curModName) useFiles += f;
+                    if (qualPref == newModName) newFiles += f;
                 }
             }
         }
-        return <{modFile}, {modFile, *useFiles}>;
     }
-
-    return <{d.top}, {d.top}>;
+    return <{modFile}, useFiles, newFiles>;
 }
 
 bool isUnsupportedCursor([*_, QualifiedName _, i:Import _, _, Header _, *_], Renamer r) {
@@ -93,32 +94,26 @@ void renameDefinitionUnchecked(Define d:<_, currentName, _, moduleId(), _, _>, l
     pcfg = r.getConfig().getPathConfig(moduleFile);
     loc relModulePath = relativize(pcfg.srcs, moduleFile);
     loc srcFolder = [srcFolder | srcFolder <- pcfg.srcs, exists(srcFolder + relModulePath.path)][0];
-    r.documentEdit(renamed(moduleFile, srcFolder + makeFileName(rascalUnescapeName(newName))));
+    r.documentEdit(renamed(moduleFile, srcFolder + makeFileName(forceUnescapeNames(newName))));
 }
 
-void renameAdditionalUses(set[Define] defs:{<_, moduleName, _, moduleId(), _, _>, *_}, str newName, TModel tm, Renamer r) {
+void renameAdditionalUses(set[Define] _:{<_, moduleName, _, moduleId(), modDef, _>}, str newName, TModel tm, Renamer r) {
+    // We get the module location from the uses. If there are no uses, this is skipped.
+    // That's intended, since this function is only supposed to rename uses.
     if ({loc u, *_} := tm.useDef<0>) {
-        set[loc] defFiles = {d.top | d <- defs.defined};
-        Tree tr = r.getConfig().parseLoc(u.top);
-        for (/QualifiedName qn := tr
-        , any(d <- tm.useDef[qn.src], d.top in defFiles)
-        , moduleName == intercalate("::", prefix(["<n>" | n <- qn.names]))) {
-            modPrefix = cover(prefix([n.src | n <- qn.names]));
-            r.textEdit(replace(modPrefix, newName));
+        for (/QualifiedName qn := r.getConfig().parseLoc(u.top), any(d <- tm.useDef[qn.src], d.top == modDef.top),
+            pref := qualifiedPrefix(qn), moduleName == reEscape(pref.name)) {
+            r.textEdit(replace(pref.l, newName));
         }
     }
 }
 
 private tuple[str, loc] fullQualifiedName(QualifiedName qn) = <"<qn>", qn.src>;
-private tuple[str, loc] qualifiedPrefix(QualifiedName qn) {
-    list[Name] names = [n | n <- qn.names];
-    if (size(names) <= 1) return <"", |unknown:///|>;
+private tuple[str name, loc l] qualifiedPrefix(QualifiedName qn) {
+    list[Name] prefixNames = prefix([n | n <- qn.names]);
+    if ([] := prefixNames) return <"", |unknown:///|>;
 
-    str fullName = "<qn>";
-    str namePrefix = fullName[..findLast(fullName, "::")];
-    loc prefixLoc = cover([n.src | Name n <- prefix(names)]);
-
-    return <namePrefix, prefixLoc>;
+    return <intercalate("::", ["<n>" | n <- prefixNames]), cover([n.src | n <- prefixNames])>;
 }
 
 private bool isReachable(PathConfig toProject, PathConfig fromProject) =

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,7 +49,7 @@ import util::Reflective;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc] sourceFiles, Tree(loc) getTree, Renamer r) {
+tuple[set[loc], set[loc]] findDefOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc] sourceFiles, Tree(loc) getTree, Renamer r) {
     int modIdSize = size(modId);
     loc modFile = d.top;
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,14 +49,14 @@ import util::Reflective;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc]() getSourceFiles, Tree(loc) getTree, Renamer r) {
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<_, str modId, _, moduleId(), loc d, _>, *_}, list[Tree] focus, set[loc] sourceFiles, Tree(loc) getTree, Renamer r) {
     int modIdSize = size(modId);
     loc modFile = d.top;
 
     if ([*_, QualifiedName modName, *_] := focus) {
         escModName = [QualifiedName] rascalEscapeName("<modName>");
         set[loc] useFiles = {};
-        for (loc f <- getSourceFiles(), f != modFile) {
+        for (loc f <- sourceFiles, f != modFile) {
             visit (getTree(f)) {
                 case modName: {
                     useFiles += f;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -43,6 +43,10 @@ bool isFormalId(IdRole role) = role in formalRoles;
 
 tuple[type[Tree] as, str desc] asType(IdRole idRole) = <#Name, "formal parameter name"> when isFormalId(idRole);
 
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, IdRole role, _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>
+    when isFormalId(role);
+
 private set[loc] rascalGetKeywordArgs(none()) = {};
 private set[loc] rascalGetKeywordArgs(\default(_, {KeywordArgument[Pattern] ","}+ keywordArgs), str argName) =
     { kwArg.name.src

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -65,8 +65,6 @@ void renameAdditionalUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>,
         set[Define] funcDefs = {d | d:<_, _, _, functionId(), _, _> <- tm.defines, d.defined in defs.scope};
         set[loc] funcCalls = invert(tm.useDef)[funcDefs.defined];
 
-        escName = rascalEscapeName(newName);
-
         // TODO Typepal: if the TModel would register kw arg names at call sites as uses, this tree visit would not be necessary
         Tree tr = r.getConfig().parseLoc(u.top);
         visit (tr) {
@@ -74,7 +72,7 @@ void renameAdditionalUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>,
                 if (e.src in funcCalls) {
                     funcCalls -= e.src;
                     for (loc ul <- rascalGetKeywordArgs(kwArgs, id)) {
-                        r.textEdit(replace(ul, escName));
+                        r.textEdit(replace(ul, newName));
                     }
                 }
             }
@@ -82,7 +80,7 @@ void renameAdditionalUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>,
                 if (e.src in funcCalls) {
                     funcCalls -= e.src;
                     for (loc ul <- rascalGetKeywordArgs(kwArgs, id)) {
-                        r.textEdit(replace(ul, escName));
+                        r.textEdit(replace(ul, newName));
                     }
                 }
             }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -61,6 +61,8 @@ void renameAdditionalUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>,
         return;
     }
 
+    // We get the module location from the uses. If there are no uses, this is skipped.
+    // That's intended, since this function is only supposed to rename uses.
     if ({loc u, *_} := tm.useDef<0>) {
         set[Define] funcDefs = {d | d:<_, _, _, functionId(), _, _> <- tm.defines, d.defined in defs.scope};
         set[loc] funcCalls = invert(tm.useDef)[funcDefs.defined];

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -36,7 +36,7 @@ import lang::rascalcore::check::BasicRascalConfig;
 
 import util::Maybe;
 
-set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, dataId(), _, _>, *_}, Tree _, TModel tm) =
+set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, dataId(), _, _>, *_}, Tree _, TModel tm, Renamer _) =
     {d | d <- tm.defines, rascalMayOverloadSameName(cursorDefs.defined + d.defined, tm.definitions)};
 
 private bool isDataRole(IdRole role) = role in dataRoles;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -39,7 +39,7 @@ import util::Maybe;
  // Variables
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc]() _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, str _, set[loc]() _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;
 
 // Global variables
@@ -48,5 +48,5 @@ tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable na
 // Pattern variables
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc]() _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, str _, set[loc]() _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -39,7 +39,7 @@ import util::Maybe;
  // Variables
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc]() _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;
 
 // Global variables
@@ -48,5 +48,5 @@ tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable na
 // Pattern variables
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc]() _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -28,7 +28,7 @@ POSSIBILITY OF SUCH DAMAGE.
 module lang::rascal::lsp::refactor::rename::Variables
 
 extend framework::Rename;
-import lang::rascal::lsp::refactor::rename::Common;
+extend lang::rascal::lsp::refactor::rename::Common;
 import lang::rascalcore::check::BasicRascalConfig;
 
 import lang::rascal::\syntax::Rascal;
@@ -39,8 +39,8 @@ import util::Maybe;
  // Variables
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
-tuple[set[loc], set[loc]] findDefOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}>;
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, str _, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, {scope.top}>;
 
 // Global variables
 tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable name">;
@@ -48,5 +48,5 @@ tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable na
 // Pattern variables
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
-tuple[set[loc], set[loc]] findDefOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}>;
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, str _, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, {scope.top}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -39,7 +39,7 @@ import util::Maybe;
  // Variables
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findDefOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;
 
 // Global variables
@@ -48,5 +48,5 @@ tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable na
 // Pattern variables
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findDefOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc] _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -39,7 +39,7 @@ import util::Maybe;
  // Variables
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, str _, set[loc]() _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, set[loc]() _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;
 
 // Global variables
@@ -48,5 +48,5 @@ tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable na
 // Pattern variables
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
-tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, str _, set[loc]() _, Tree(loc) _, Renamer _) =
+tuple[set[loc], set[loc]] findOccurrenceFiles(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, set[loc]() _, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -39,14 +39,17 @@ import util::Maybe;
  // Variables
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
-tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, variableId(), _, _>, *_}, list[Tree] _, str _, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}, {scope.top}>;
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, variableId(), _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
 
 // Global variables
 tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable name">;
 
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, moduleVariableId(), _, defType(_, vis=privateVis())>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
+
 // Pattern variables
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
-tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>, *_}, list[Tree] _, str _, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}, {scope.top}>;
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -85,6 +85,7 @@ test bool keywordParameter() = testRenameOccurrences({0, 1, 2},
 @expected{illegalRename} test bool doubleKeywordParameterDeclaration1() = testRename("int f(int foo = 8, int bar = 9) = 1;");
 @expected{illegalRename} test bool doubleKeywordParameterDeclaration2() = testRename("int f(int bar = 9, int foo = 8) = 1;");
 
+@expected{illegalRename} // TODO Support this?
 test bool renameParamToConstructorName() = testRenameOccurrences({0, 1},
     "int f(int foo) = foo;",
     decls = "data Bar = bar();"

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -270,13 +270,27 @@ test bool causesDownstreamOverloadOfLib() = testRenameOccurrences({
 }, newName = "println");
 
 @expected{illegalRename}
-test bool downstreamNonOverload() = testRenameOccurrences({
-    byText("Definer", "void foo(str s) { }", {0}),
-    byText("Main", "
-        'import Definer;
-        'void bar(str s, str t) { }
-        'void main() { bar(\"a\", \"b\"); }
-    ", {})
+test bool localOverload() = testRename("
+    'int foo() = 8;
+    'if (true) {
+        int bar() = 9;
+    '}
+");
+
+@expected{illegalRename}
+test bool extendedOverloadWithUse() = testRenameOccurrences({
+    byText("A", "int foo() = 8;", {0}),
+    byText("B", "extend A;
+                'int bar() = 9;", {}),
+    byText("C", "import B;
+                'void main() { x = bar(); }", {})
+});
+
+@expected{illegalRename}
+test bool extendedOverloadWithoutUse() = testRenameOccurrences({
+    byText("A", "int foo() = 8;", {0}),
+    byText("B", "extend A;
+                'int bar() = 9;", {})
 });
 
 test bool adjacentScopeFunctions() = testRenameOccurrences({0, 1}, "

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -278,3 +278,14 @@ test bool downstreamNonOverload() = testRenameOccurrences({
         'void main() { bar(\"a\", \"b\"); }
     ", {})
 });
+
+test bool adjacentScopeFunctions() = testRenameOccurrences({0}, "
+    '{
+    '   int foo() = 8;
+    '   i = foo();
+    '}
+    '{
+    '   int bar() = 9;
+    '   j = bar();
+    '}
+");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -248,3 +248,32 @@ test bool functionsInIIModuleStructure() = testRenameOccurrences({
                            'void main() { foo(\"foo\"); }", {0}),       byText("RightUser",     "import RightExtender;
                                                                                                 'void main() { foo(\"fu\"); }", {})
 });
+
+@expected{illegalRename}
+test bool causesDownstreamOverload() = testRenameOccurrences({
+    byText("Definer", "void foo(str s) { }", {0}),
+    byText("Main", "
+        'import Definer;
+        'void bar(str s) { }
+        'void main() { bar(\"a\"); }
+    ", {})
+});
+
+@expected{illegalRename}
+test bool causesDownstreamOverloadOfLib() = testRenameOccurrences({
+    byText("Definer", "void foo(str s) { }", {0}),
+    byText("Main", "
+        'import Definer;
+        'import IO;
+        'void main() { println(\"a\"); }
+    ", {})
+}, newName = "println");
+
+test bool downstreamNonOverload() = testRenameOccurrences({
+    byText("Definer", "void foo(str s) { }", {0}),
+    byText("Main", "
+        'import Definer;
+        'void bar(str s, str t) { }
+        'void main() { bar(\"a\", \"b\"); }
+    ", {})
+});

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -279,7 +279,7 @@ test bool downstreamNonOverload() = testRenameOccurrences({
     ", {})
 });
 
-test bool adjacentScopeFunctions() = testRenameOccurrences({0}, "
+test bool adjacentScopeFunctions() = testRenameOccurrences({0, 1}, "
     '{
     '   int foo() = 8;
     '   i = foo();

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -250,7 +250,7 @@ test bool functionsInIIModuleStructure() = testRenameOccurrences({
 });
 
 @expected{illegalRename}
-test bool causesDownstreamOverload() = testRenameOccurrences({
+test bool usedOverload() = testRenameOccurrences({
     byText("Definer", "void foo(str s) { }", {0}),
     byText("Main", "
         'import Definer;
@@ -260,12 +260,21 @@ test bool causesDownstreamOverload() = testRenameOccurrences({
 });
 
 @expected{illegalRename}
-test bool causesDownstreamOverloadOfLib() = testRenameOccurrences({
+test bool usedOverloadOfLib() = testRenameOccurrences({
     byText("Definer", "void foo(str s) { }", {0}),
     byText("Main", "
         'import Definer;
         'import IO;
         'void main() { println(\"a\"); }
+    ", {})
+}, newName = "println");
+
+@expected{illegalRename}
+test bool unusedOverloadOfLib() = testRenameOccurrences({
+    byText("Definer", "void foo(str s) { }", {0}),
+    byText("Main", "
+        'import Definer;
+        'import IO;
     ", {})
 }, newName = "println");
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -269,6 +269,7 @@ test bool causesDownstreamOverloadOfLib() = testRenameOccurrences({
     ", {})
 }, newName = "println");
 
+@expected{illegalRename}
 test bool downstreamNonOverload() = testRenameOccurrences({
     byText("Definer", "void foo(str s) { }", {0}),
     byText("Main", "

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -115,3 +115,15 @@ test bool externalImport() = testRenameOccurrences({
         'import Foo = |memory:///Foo.rsc|;
     ", {0})
 }, oldName = "Foo", newName = "Bar");
+
+test bool escapeVariants() = testRenameOccurrences({
+    byText("a::b::Foo", "public int foo = 1;", {0}, newName = "a::b::Bar"),
+    byText("EscapeReference", "import a::b::Foo;
+                       'int baz = a::b::\\Foo::foo;", {0, 1}, skipCursors = {1}),
+    byText("EscapeImport1", "import \\a::b::Foo;
+                      'int baz = foo;", {0}, skipCursors = {0}),
+    byText("EscapeImport2", "import a::\\b::Foo;
+                      'int baz = foo;", {0}, skipCursors = {0}),
+    byText("EscapeImport3", "import a::b::\\Foo;
+                      'int baz = foo;", {0}, skipCursors = {0})
+}, oldName = "a::b::Foo", newName = "a::b::Bar");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -298,16 +298,21 @@ private tuple[Edits, set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNa
     return <edits, occs>;
 }
 
+private set[str] reservedNames = getRascalReservedIdentifiers();
+str forceUnescapeNames(str name) = replaceAll(name, "\\", "");
+str escapeReservedNames(str name, str sep = "::") = intercalate(sep, [n in reservedNames ? "\\<n>" : n | n <- split(sep, name)]);
+str reEscape(str name) = escapeReservedNames(forceUnescapeNames(name));
+
 private lrel[int, loc, Maybe[Tree]] collectNameTrees(start[Module] m, str name) {
     lrel[loc, Maybe[Tree]] names = [];
         top-down-break visit (m) {
         case QualifiedName qn: {
-            if ("<qn>" == name) {
+            if (reEscape("<qn>") == reEscape(name)) {
                 names += <qn.src, just(qn)>;
             }
             else {
                 modPrefix = prefix([n | n <- qn.names]);
-                if (intercalate("::", ["<n>" | n <- modPrefix]) == name) {
+                if ([_, *_] := modPrefix && reEscape(intercalate("::", ["<n>" | n <- modPrefix])) == reEscape(name)) {
                     names += <cover([n.src | n <- modPrefix]), nothing()>;
                 } else {
                     fail;
@@ -361,7 +366,7 @@ private str modulePathToName(str path) = replaceAll(path, "/", "::");
 private tuple[loc, list[Tree]] findCursor(loc f, str id, int occ) {
     m = parseModuleWithSpaces(f);
     names = collectNameTrees(m, id);
-    if (occ >= size(names) || occ < 0) throw "Found <size(names)> occurrences of \'<id>\'; cannot use occurrence at position <occ> as cursor";
+    if (occ >= size(names) || occ < 0) throw "Found <size(names)> occurrences of \'<id>\' in <f>; cannot use occurrence at position <occ> as cursor";
     loc cl = (names<1>)[occ];
     return <cl, computeFocusList(m, cl.begin.line, cl.begin.column + 1)>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
@@ -70,12 +70,25 @@ test bool doubleVariableDeclaration() = testRename("
     'int bar = 9;
 ");
 
-test bool adjacentScopes() = testRenameOccurrences({0}, "
+test bool adjacentScopeVars() = testRenameOccurrences({0}, "
     '{
     '   int foo = 8;
     '}
     '{
     '   int bar = 9;
+    '}
+");
+
+test bool adjacentScopePatternVars() = testRenameOccurrences({0}, "
+    '{
+    '   if (int foo := 8) {
+    '       i = foo;
+    '   }
+    '}
+    '{
+    '   if (int bar := 9) {
+    '       j = bar;
+    '   }
     '}
 ");
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
@@ -216,3 +216,12 @@ test bool unrelatedVar() = testRenameOccurrences({
                       'int foo = 2;
                       'int baz = foo;", {})
 });
+
+@illegalRename
+test bool multiModuleAmbiguous() = testRenameOccurrences({
+    byText("Foo", "public int foo = 1;", {0}),
+    byText("Bar", "public int bar = 2;", {}),
+    byText("Main", "import Foo;
+                   'import Bar;
+                   'int baz = foo + bar;", {0})
+});

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Variables.rsc
@@ -79,7 +79,7 @@ test bool adjacentScopeVars() = testRenameOccurrences({0}, "
     '}
 ");
 
-test bool adjacentScopePatternVars() = testRenameOccurrences({0}, "
+test bool adjacentScopePatternVars() = testRenameOccurrences({0, 1}, "
     '{
     '   if (int foo := 8) {
     '       i = foo;

--- a/rascal-lsp/src/main/rascal/util/Util.rsc
+++ b/rascal-lsp/src/main/rascal/util/Util.rsc
@@ -72,7 +72,7 @@ bool isPrefixOf(loc prefix, loc l) = l.scheme == prefix.scheme
 @synopsis{
     Try to parse string `name` as reified type `begin` and return whether this succeeded.
 }
-Maybe[&T <: Tree] tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
+Maybe[Tree] tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
     try {
         return just(parse(begin, name, allowAmbiguity = allowAmbiguity));
     } catch ParseError(_): {


### PR DESCRIPTION
This requires a change to the renaming framework: passing the new name to more steps.

This finds imported uses of the new name and checks whether renaming any definition will result in overloading a use of an existing definition.