### PR TITLE
Rename: fields

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -551,6 +551,10 @@ Tree findCursorInTree(Tree t, loc cursorLoc) {
 list[Tree] extendFocusWithConcreteSyntax([Concrete c, *tail], loc cursorLoc) = [findCursorInTree(c, cursorLoc), c, *tail];
 default list[Tree] extendFocusWithConcreteSyntax(list[Tree] cursor, loc _) = cursor;
 
+@synopsis{
+    Augment the TModel with 'missing' use/def information.
+    Workaround until the typechecker generates this. https://github.com/usethesource/rascal/issues/2172
+}
 TModel augmentTModel(Tree tr, TModel tm, TModel(loc) tmodelForLoc) {
     tm = augmentFieldUses(tr, tm, tmodelForLoc);
     tm = augmentFormalUses(tr, tm);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -562,7 +562,7 @@ TModel augmentTModel(Tree tr, TModel tm, TModel(loc) tmodelForLoc) {
 }
 
 TModel tmodelForLoc(loc l, PathConfig(loc) getPathConfig)
-    = tmodelForTree(parse(#start[Module], l), getPathConfig);
+    = tmodelForTree(parseModuleWithSpaces(l), getPathConfig);
 
 TModel tmodelForTree(Tree t, PathConfig(loc) getPathConfig) {
     loc l = t.src.top;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -599,6 +599,8 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
 
     loc cursorLoc = cursor[0].src;
     TModel tm = getModel(cursor[-1]);
+    if (isUnsupportedCursor(cursor, tm, r)) return {};
+
     for (Tree c <- cursor) {
         if (tm.definitions[c.src]?) {
             return {tm.definitions[c.src]};

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -596,8 +596,6 @@ public Edits rascalRenameSymbol(loc cursorLoc, list[Tree] cursor, str newName, s
 Edits rascalRenameModule(list[tuple[loc old, loc new]] renames, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
     propagateModuleRenames(renames, workspaceFolders, getPathConfig);
 
-default tuple[bool, set[Define]] getCursorDefinitions(Tree _, list[Tree] _, TModel _, Renamer _) = <false, {}>;
-
 set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tree) getModel, Renamer r) {
     if (isUnsupportedCursor(cursor, r)) return {};
 
@@ -610,8 +608,6 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
             return {tm.definitions[c.src]};
         } else if (useDefs: {_, *_} := tm.useDef[c.src]) {
             return {defTm.definitions[d] | d <- useDefs, defTm := getModel(getTree(d.top))};
-        } else if (<true, defs> := getCursorDefinitions(c, cursor, tm, r)) {
-            return defs;
         }
     }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -577,6 +577,8 @@ public Edits rascalRenameSymbol(loc cursorLoc, list[Tree] cursor, str newName, s
 Edits rascalRenameModule(list[tuple[loc old, loc new]] renames, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
     propagateModuleRenames(renames, workspaceFolders, getPathConfig);
 
+default tuple[bool, set[Define]] getCursorDefinitions(Tree _, TModel _, Tree(loc) _, TModel(Tree) _, Renamer _) = <false, {}>;
+
 set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tree) getModel, Renamer r) {
     if (isUnsupportedCursor(cursor, r)) return {};
 
@@ -587,6 +589,8 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
             return {tm.definitions[c.src]};
         } else if (useDefs: {_, *_} := tm.useDef[c.src]) {
             return {defTm.definitions[d] | d <- useDefs, defTm := getModel(getTree(d.top))};
+        } else if (<true, defs> := getCursorDefinitions(c, tm, getTree, getModel, r)) {
+            return defs;
         }
     }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -577,7 +577,7 @@ public Edits rascalRenameSymbol(loc cursorLoc, list[Tree] cursor, str newName, s
 Edits rascalRenameModule(list[tuple[loc old, loc new]] renames, set[loc] workspaceFolders, PathConfig(loc) getPathConfig) =
     propagateModuleRenames(renames, workspaceFolders, getPathConfig);
 
-default tuple[bool, set[Define]] getCursorDefinitions(Tree _, TModel _, Tree(loc) _, TModel(Tree) _, Renamer _) = <false, {}>;
+default tuple[bool, set[Define]] getCursorDefinitions(Tree _, list[Tree] _, TModel _, Renamer _) = <false, {}>;
 
 set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tree) getModel, Renamer r) {
     if (isUnsupportedCursor(cursor, r)) return {};
@@ -589,7 +589,7 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
             return {tm.definitions[c.src]};
         } else if (useDefs: {_, *_} := tm.useDef[c.src]) {
             return {defTm.definitions[d] | d <- useDefs, defTm := getModel(getTree(d.top))};
-        } else if (<true, defs> := getCursorDefinitions(c, tm, getTree, getModel, r)) {
+        } else if (<true, defs> := getCursorDefinitions(c, cursor, tm, r)) {
             return defs;
         }
     }
@@ -657,7 +657,7 @@ void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
     renameAdditionalUses(defs, escName, tm, r);
 }
 
-void renameAdditionalUses(set[Define] defs:{<_, id, _, IdRole role, _, _>, *_}, str newName, TModel tm, Renamer r) {
+void renameAdditionalUses(set[Define] defs:{<_, _, _, IdRole role, _, _>, *_}, str newName, TModel tm, Renamer r) {
     // The role `keywordFormalId()` is used for both formal keyword parameters to functions and constructors
     if (isFieldRole(role)) renameAdditionalFieldUses(defs, newName, tm, r);
     if (isFormalId(role)) renameAdditionalParameterUses(defs, newName, tm, r);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -557,7 +557,7 @@ default list[Tree] extendFocusWithConcreteSyntax(list[Tree] cursor, loc _) = cur
 }
 TModel augmentTModel(Tree tr, TModel tm, TModel(loc) tmodelForLoc) {
     tm = augmentFieldUses(tr, tm, tmodelForLoc);
-    tm = augmentFormalUses(tr, tm);
+    tm = augmentFormalUses(tr, tm, tmodelForLoc);
     return tm;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -616,19 +616,19 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
 }
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    if ({IdRole role} := defs.idRole) {
+    escNewName = escapeReservedNames(newName);
+    for (role <- defs.idRole) {
+        hasError = false;
         <t, desc> = asType(role);
-        escNewName = escapeReservedNames(newName);
         if (tryParseAs(t, escNewName) is nothing) {
+            hasError = true;
             r.error(cursor[0], "\'<escNewName>\' is not a valid <desc>");
-            return <{}, {}, {}>;
         }
 
-        return findOccurrenceFilesUnchecked(defs, cursor, escNewName, getTree, r);
+        if (hasError) return <{}, {}, {}>;
     }
 
-    r.error(cursor[0], "Cannot find occurrence files for mixed-role definitions.");
-    return <{}, {}, {}>;
+    return findOccurrenceFilesUnchecked(defs, cursor, escNewName, getTree, r);
 }
 
 void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree tr, Renamer r) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -656,3 +656,9 @@ void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
 
     renameAdditionalUses(defs, escName, tm, r);
 }
+
+void renameAdditionalUses(set[Define] defs:{<_, id, _, IdRole role, _, _>, *_}, str newName, TModel tm, Renamer r) {
+    // The role `keywordFormalId()` is used for both formal keyword parameters to functions and constructors
+    if (isFieldRole(role)) renameAdditionalFieldUses(defs, newName, tm, r);
+    if (isFormalId(role)) renameAdditionalParameterUses(defs, newName, tm, r);
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -64,6 +64,8 @@ bool isContainedInScope(loc l, loc scope, TModel tm) {
     return any(loc fromScope <- reachableFrom, isContainedIn(l, fromScope));
 }
 
+loc getModuleFile(TModel tm) = getModuleScopes(tm)[tm.modelName].top;
+
 private set[str] reservedNames = getRascalReservedIdentifiers();
 
 str forceUnescapeNames(str name) = replaceAll(name, "\\", "");

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -238,4 +238,8 @@ set[&T] flatMapPerFile(set[Define] defs, set[&T](loc, set[Define]) func) =
 
 default void renameAdditionalUses(set[Define] defs, str newName, TModel tm, Renamer r) {}
 
+@synopsis{Decide if a cursor is supported based on focus list only.}
 default bool isUnsupportedCursor(list[Tree] cursor, Renamer _) = false;
+
+@synopsis{Decide whether a cursor is supported based on type information.}
+default bool isUnsupportedCursor(list[Tree] cursor, TModel tm, Renamer _) = false;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -214,6 +214,15 @@ rel[loc from, loc to] rascalGetReflexiveModulePaths(TModel tm) =
   + (tm.paths<pathRole, from, to>)[importPath()]
   + (tm.paths<pathRole, from, to>)[extendPath()];
 
+loc parentScope(loc l, TModel tm) {
+    if (tm.scopes[l]?) {
+        return tm.scopes[l];
+    } else if (just(loc scope) := findSmallestContaining(tm.scopes<inner>, l, containmentPred = isStrictlyContainedIn)) {
+        return scope;
+    }
+    return |global-scope:///|;
+}
+
 set[&T] flatMapPerFile(set[loc] locs, set[&T](loc, set[loc]) func) {
     rel[loc file, loc l] fs = {<l.top, l> | loc l <- locs};
     return {*func(f, fs[f]) | loc f <- fs.file};

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -175,7 +175,7 @@ tuple[set[loc], set[loc]] filterFiles(set[loc] fs, tuple[bool, bool](Tree) treeF
 
 default tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     if ({str id} := defs.id) {
-        <curFiles, newFiles> = filterFiles(getSourceFiles(r), allNameSortsFilter("<cursor[0]>", newName), getTree);
+        <curFiles, newFiles> = filterFiles(getSourceFiles(r), allNameSortsFilter(id, newName), getTree);
         return <curFiles, curFiles, newFiles>;
     }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
@@ -69,10 +69,10 @@ set[Define] findAdditionalConstructorDefinitions(set[Define] cursorDefs, Tree tr
     // Find overloads of this ADT
     adtDefs += findAdditionalDefinitions(adtDefs, tr, tm, r);
 
-    return {d | d <- findConstructorDefinitions(adtDefs), d.id in cursorDefs.id};
+    return {d | d <- findConstructorDefinitions(adtDefs, r), d.id in cursorDefs.id};
 }
 
-set[Define] findConstructorDefinitions(set[Define] adtDefs) {
+set[Define] findConstructorDefinitions(set[Define] adtDefs, Renamer r) {
     // Find all constructors with the same name in these ADT definitions
     return flatMapPerFile(adtDefs, set[Define](loc f, set[Define] fileDefs) {
         fileTm = r.getConfig().tmodelForLoc(f);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -101,7 +101,12 @@ tuple[bool, set[Define]] getCursorDefinitions(Name n, list[Tree] _:[*_, (Pattern
 TModel augmentFieldUses(Tree tr, TModel tm, TModel(loc) getModel) {
     void addFieldUse(Tree container, Tree fieldName) {
         fieldDefs = getFieldDefinitions(container, "<fieldName>", tm, getModel);
-        tm = tm[useDef = tm.useDef + {<fieldName.src, d> | d <- fieldDefs.defined}];
+        // Common/ADT keyword field uses currently point to their parent ADT definition instead of the field definition
+        // https://github.com/usethesource/rascal/issues/2172?issue=usethesource%7Crascal%7C2186
+        augmentedUseDefs
+            = (tm.useDef - {<fieldName.src, d> | d <- fieldDefs.scope})
+            + {<fieldName.src, d> | d <- fieldDefs.defined};
+        tm = tm[useDef = augmentedUseDefs];
     }
 
     visit (tr) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -32,6 +32,7 @@ import lang::rascal::lsp::refactor::rename::Common;
 
 import lang::rascalcore::check::ATypeBase;
 import lang::rascalcore::check::BasicRascalConfig;
+import lang::rascalcore::check::BuiltinFields;
 
 import lang::rascal::lsp::refactor::rename::Constructors;
 import lang::rascal::lsp::refactor::rename::Types;
@@ -161,3 +162,16 @@ tuple[type[Tree] as, str desc] asType(fieldId()) = <#NonterminalLabel, "field na
 
 // Keyword fields
 tuple[type[Tree] as, str desc] asType(keywordFieldId()) = <#Name, "keyword field name">;
+
+bool isUnsupportedCursor(list[Tree] _: [*_, Name n1, *_, (Expression) `<Expression e>.<Name n2>`,*_], TModel tm, Renamer r) {
+    builtinFields = getBuiltinFieldMap();
+    if (just(AType lhsType) := getFact(tm, e.src), builtinFields[lhsType]?) {
+        for (fieldName <- domain(builtinFields[lhsType])) {
+            if (builtin := [Name] fieldName, n1 := builtin, n2 := n1) {
+                r.error(n1, "Cannot rename builtin field \'<fieldName>\'");
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -139,7 +139,7 @@ bool isUnsupportedCursor(list[Tree] _: [*_, Name n1, *_, (Expression) `<Expressi
     builtinFields = getBuiltinFieldMap();
     if (just(AType lhsType) := getFact(tm, e.src), builtinFields[lhsType]?) {
         for (fieldName <- domain(builtinFields[lhsType])) {
-            if (builtin := [Name] fieldName, n1 := builtin, n2 := n1) {
+            if (n1 := [Name] fieldName, n2 := n1) {
                 r.error(n1, "Cannot rename builtin field \'<fieldName>\'");
                 return true;
             }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -46,9 +46,7 @@ import analysis::diff::edits::TextEdits;
 import Map;
 import util::Maybe;
 
-set[IdRole] keywordFieldRoles = {keywordFieldId(), keywordFormalId()};
-set[IdRole] fieldRoles = {fieldId()} + keywordFieldRoles;
-
+set[IdRole] fieldRoles = {fieldId(), keywordFieldId(), keywordFormalId()};
 bool isFieldRole(IdRole role) = role in fieldRoles;
 
 set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, role, _, _>, *_}, Tree tr, TModel tm, Renamer r) {
@@ -87,27 +85,6 @@ set[Define] getFieldDefinitions(Tree container, str fieldName, TModel tm, TModel
 
         return defRel[fieldDefs];
     });
-
-tuple[bool, set[Define]] getCursorDefinitions((Expression) `<Expression e> has <Name n>`, list[Tree] _, TModel tm, Renamer r) =
-    <true, getFieldDefinitions(e, "<n>", tm, r.getConfig().tmodelForLoc)>;
-
-tuple[bool, set[Define]] getCursorDefinitions((Expression) `<Expression e>.<Name n>`, list[Tree] _, TModel tm, Renamer r) =
-    <true, getFieldDefinitions(e, "<n>", tm, r.getConfig().tmodelForLoc)>;
-
-tuple[bool, set[Define]] getCursorDefinitions((Assignable) `<Assignable rec>.<Name n>`, list[Tree] _, TModel tm, Renamer r) =
-    <true, getFieldDefinitions(rec, "<n>", tm, r.getConfig().tmodelForLoc)>;
-
-tuple[bool, set[Define]] getCursorDefinitions(Name n, list[Tree] _:[*_, (Expression) `<Expression e> ( <{Expression ","}* args> <KeywordArguments[Expression] kwArgs> )`, *_], TModel tm, Renamer r) =
-    <true, getFieldDefinitions(e, "<n>", tm, r.getConfig().tmodelForLoc)>
-    when kwArgs is \default, kwArg <- kwArgs.keywordArgumentList, n := kwArg.name;
-
-tuple[bool, set[Define]] getCursorDefinitions(Name n, list[Tree] _:[*_, (Pattern) `<Pattern e> ( <{Pattern ","}* args> <KeywordArguments[Pattern] kwArgs> )`, *_], TModel tm, Renamer r) =
-    <true, getFieldDefinitions(e, "<n>", tm, r.getConfig().tmodelForLoc)>
-    when kwArgs is \default, kwArg <- kwArgs.keywordArgumentList, n := kwArg.name;
-
-tuple[bool, set[Define]] getCursorDefinitions(Name n, list[Tree] _:[*_, (Expression) `<Expression e>\<<{Field ","}+ fields>\>`, *_], TModel tm, Renamer r)
-    = <true, getFieldDefinitions(e, "<n>", tm, r.getConfig().tmodelForLoc)>
-    when name(n) <- fields;
 
 @synopsis{Add artificial definitions and use/def relations for fields, until they exist in the TModel.}
 TModel augmentFieldUses(Tree tr, TModel tm, TModel(loc) getModel) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -77,7 +77,6 @@ set[Define] getFieldDefinitions(Tree container, str fieldName, TModel tm, TModel
         set[AType] containerDefTypes = {acons(AType adt, _, _) := di.atype ? adt : di.atype | DefInfo di <- containerDefs.defInfo};
         rel[AType, IdRole, Define] definesByType = {<d.defInfo.atype, d.idRole, d> | d <- fileTm.defines};
         // Find all type-like definitions (but omit variable definitions etc.)
-        // TODO Consider functions that overload constructors, and their parameter names
         set[Define] containerTypeDefs = definesByType[containerDefTypes, dataOrSyntaxRoles];
 
         // Since we do not know (based on tree) what kind of field role (positional, keyword) we are looking for, select them all

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Functions.rsc
@@ -47,6 +47,5 @@ set[Define] findAdditionalFunctionDefinitions(set[Define] cursorDefs, TModel tm)
 
 // TODO:
 // - Type variables (&Foo). Currently, these are not represented as a `Define`, and cannot be easily modeled by this framework.
-// - Keyword parameters. Currently, they are defined, but references at call sites do not appear as a use in the use/def relation.
 
 tuple[type[Tree] as, str desc] asType(functionId()) = <#Name, "function name">;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Functions.rsc
@@ -29,6 +29,7 @@ module lang::rascal::lsp::refactor::rename::Functions
 
 extend framework::Rename;
 import lang::rascal::lsp::refactor::rename::Common;
+import lang::rascal::lsp::refactor::rename::Constructors;
 
 import lang::rascal::\syntax::Rascal;
 import analysis::typepal::TModel;
@@ -36,7 +37,12 @@ import lang::rascalcore::check::BasicRascalConfig;
 
 import util::Maybe;
 
-set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, functionId(), _, _>, *_}, Tree _, TModel tm, Renamer _) =
+set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, functionId(), _, _>, *_}, Tree tr, TModel tm, Renamer r)
+    = findAdditionalFunctionDefinitions(cursorDefs, tm)
+    + findAdditionalConstructorDefinitions(cursorDefs, tr, tm, r)
+    ;
+
+set[Define] findAdditionalFunctionDefinitions(set[Define] cursorDefs, TModel tm) =
     {d | d <- tm.defines, rascalMayOverloadSameName(cursorDefs.defined + d.defined, tm.definitions)};
 
 // TODO:

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
@@ -38,7 +38,6 @@ import lang::rascalcore::check::BasicRascalConfig;
 data Tree;
 
 // TODO
-// - `has` uses: These do not appear in use/def relations
 // - 'except constructors', like Sym sym!otherSym. These do not appear in use/def relations.
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] defs:{<_, _, _, IdRole role, _, _>, *_}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) =

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -58,9 +58,15 @@ TModel augmentFormalUses(Tree tr, TModel tm, TModel(loc) getModel) {
     visit (tr) {
         case (Expression) `<Expression e>(<{Expression ","}* _> <KeywordArguments[Expression] kwArgs>)`: {
             funcKwDefs = keywordFormalDefs[tm.useDef[e.src]];
-            for (/(KeywordArgument[Expression]) `<Name kw> = <Expression _>` := kwArgs
-              , loc d <- funcKwDefs["<kw>"]) {
-                tm = tm[useDef = tm.useDef + <kw.src, d>];
+
+            // Since `KeywordArguments` is not a list, we use a visit here
+            top-down visit (kwArgs) {
+                case callOrTree(_, _, _): break; // Only visit uses of our keyword arguments - do not go into nested calls
+                case (KeywordArgument[Expression]) `<Name kw> = <Expression _>`: {
+                    for (loc d <- funcKwDefs["<kw>"]) {
+                        tm = tm[useDef = tm.useDef + <kw.src, d>];
+                    }
+                }
             }
         }
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -50,15 +50,13 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
 
 @synopsis{Add use/def relations for keyword function parameters, until they exist in the TModel.}
 TModel augmentFormalUses(Tree tr, TModel tm) {
-    void addUseDef(loc use, loc def) { tm = tm[useDef = tm.useDef + <use, def>]; }
-
     visit (tr) {
         case (Expression) `<Expression e>(<{Expression ","}* _> <KeywordArguments[Expression] kwArgs>)`: {
             funcDefs = tm.useDef[e.src];
             keywordFormalDefs = (tm.defines<idRole, scope, id, defined>)[keywordFormalId(), funcDefs];
             for (/(KeywordArgument[Expression]) `<Name kw> = <Expression _>` := kwArgs
               , loc d <- keywordFormalDefs["<kw>"]) {
-                addUseDef(kw.src, d);
+                tm = tm[useDef = tm.useDef + <kw.src, d>];
             }
         }
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -30,6 +30,7 @@ module lang::rascal::lsp::refactor::rename::Parameters
 extend framework::Rename;
 import framework::TextEdits;
 extend lang::rascal::lsp::refactor::rename::Common;
+import lang::rascal::lsp::refactor::rename::Fields;
 
 import lang::rascal::\syntax::Rascal;
 import analysis::typepal::TModel;
@@ -45,7 +46,7 @@ tuple[type[Tree] as, str desc] asType(IdRole idRole) = <#Name, "formal parameter
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, IdRole role, _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>
-    when isFormalId(role);
+    when isFormalId(role) && !isFieldRole(role);
 
 private set[loc] rascalGetKeywordArgs(none()) = {};
 private set[loc] rascalGetKeywordArgs(\default(_, {KeywordArgument[Pattern] ","}+ keywordArgs), str argName) =
@@ -69,7 +70,7 @@ void renameAdditionalParameterUses(set[Define] defs:{<_, id, _, IdRole role, _, 
     // We get the module location from the uses. If there are no uses, this is skipped.
     // That's intended, since this function is only supposed to rename uses.
     if ({loc u, *_} := tm.useDef<0>) {
-        set[Define] funcDefs = {d | d:<_, _, _, functionId(), _, _> <- tm.defines, d.defined in defs.scope};
+        set[Define] funcDefs = {d | Define d:<_, _, _, functionId(), _, _> <- tm.defines, d.defined in defs.scope};
         set[loc] funcCalls = invert(tm.useDef)[funcDefs.defined];
 
         // TODO Typepal: if the TModel would register kw arg names at call sites as uses, this tree visit would not be necessary

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -57,7 +57,7 @@ private set[loc] rascalGetKeywordArgs(\default(_, {KeywordArgument[Expression] "
     | kwArg <- keywordArgs
     , "<kwArg.name>" == argName};
 
-void renameAdditionalUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>, *_}, str newName, TModel tm, Renamer r) {
+void renameAdditionalParameterUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>, *_}, str newName, TModel tm, Renamer r) {
     if (size(defs.id) > 1) {
         for (loc l <- defs.defined) {
             r.error(l, "Cannot rename multiple names at once (<defs.id>)");

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -58,10 +58,8 @@ TModel augmentFormalUses(Tree tr, TModel tm, TModel(loc) getModel) {
     visit (tr) {
         case (Expression) `<Expression e>(<{Expression ","}* _> <KeywordArguments[Expression] kwArgs>)`: {
             funcKwDefs = keywordFormalDefs[tm.useDef[e.src]];
-
-            // Since `KeywordArguments` is not a list, we use a visit here
-            top-down visit (kwArgs) {
-                case callOrTree(_, _, _): break; // Only visit uses of our keyword arguments - do not go into nested calls
+            // Only visit uses of our keyword arguments - do not go into nested calls
+            top-down-break visit (kwArgs) {
                 case (KeywordArgument[Expression]) `<Name kw> = <Expression _>`: {
                     for (loc d <- funcKwDefs["<kw>"]) {
                         tm = tm[useDef = tm.useDef + <kw.src, d>];

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -46,16 +46,20 @@ tuple[type[Tree] as, str desc] asType(IdRole idRole) = <#Name, "formal parameter
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, IdRole role, _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
     <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>
-    when isFormalId(role) && !isFieldRole(role);
+    when role in positionalFormalRoles;
 
 @synopsis{Add use/def relations for keyword function parameters, until they exist in the TModel.}
-TModel augmentFormalUses(Tree tr, TModel tm) {
+TModel augmentFormalUses(Tree tr, TModel tm, TModel(loc) getModel) {
+    rel[loc funcDef, str kwName, loc kwLoc] keywordFormalDefs = {
+        *(fileTm.defines<idRole, scope, id, defined>)[keywordFormalId()]
+        | loc f <- getModuleFile(tm) + (tm.paths<to>)
+        , fileTm := getModel(f.top)
+    };
     visit (tr) {
         case (Expression) `<Expression e>(<{Expression ","}* _> <KeywordArguments[Expression] kwArgs>)`: {
-            funcDefs = tm.useDef[e.src];
-            keywordFormalDefs = (tm.defines<idRole, scope, id, defined>)[keywordFormalId(), funcDefs];
+            funcKwDefs = keywordFormalDefs[tm.useDef[e.src]];
             for (/(KeywordArgument[Expression]) `<Name kw> = <Expression _>` := kwArgs
-              , loc d <- keywordFormalDefs["<kw>"]) {
+              , loc d <- funcKwDefs["<kw>"]) {
                 tm = tm[useDef = tm.useDef + <kw.src, d>];
             }
         }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -57,7 +57,8 @@ private set[loc] rascalGetKeywordArgs(\default(_, {KeywordArgument[Expression] "
     | kwArg <- keywordArgs
     , "<kwArg.name>" == argName};
 
-void renameAdditionalParameterUses(set[Define] defs:{<_, id, _, keywordFormalId(), _, _>, *_}, str newName, TModel tm, Renamer r) {
+void renameAdditionalParameterUses(set[Define] defs:{<_, id, _, IdRole role, _, _>, *_}, str newName, TModel tm, Renamer r) {
+    if (role != keywordFormalId()) return;
     if (size(defs.id) > 1) {
         for (loc l <- defs.defined) {
             r.error(l, "Cannot rename multiple names at once (<defs.id>)");

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -50,16 +50,16 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
 
 @synopsis{Add use/def relations for keyword function parameters, until they exist in the TModel.}
 TModel augmentFormalUses(Tree tr, TModel tm) {
+    void addUseDef(loc use, loc def) { tm = tm[useDef = tm.useDef + <use, def>]; }
+
     visit (tr) {
         case (Expression) `<Expression e>(<{Expression ","}* _> <KeywordArguments[Expression] kwArgs>)`: {
             funcDefs = tm.useDef[e.src];
             keywordFormalDefs = (tm.defines<idRole, scope, id, defined>)[keywordFormalId(), funcDefs];
-            keywordFormalUseDefs = {<kw.src, d>
-                | /(KeywordArgument[Expression]) `<Name kw> = <Expression _>` := kwArgs
-                , loc d <- keywordFormalDefs["<kw>"]
-            };
-
-            tm = tm[useDef = tm.useDef + keywordFormalUseDefs];
+            for (/(KeywordArgument[Expression]) `<Name kw> = <Expression _>` := kwArgs
+              , loc d <- keywordFormalDefs["<kw>"]) {
+                addUseDef(kw.src, d);
+            }
         }
     }
     return tm;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -48,6 +48,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
     <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>
     when isFormalId(role) && !isFieldRole(role);
 
+@synopsis{Add use/def relations for keyword function parameters, until they exist in the TModel.}
 TModel augmentFormalUses(Tree tr, TModel tm) {
     visit (tr) {
         case (Expression) `<Expression e>(<{Expression ","}* _> <KeywordArguments[Expression] kwArgs>)`: {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
@@ -45,6 +45,14 @@ test bool disjunctConstructor() = testRenameOccurrences({
            "data Foo = foo();", {})
 });
 
+test bool functionOverloadsConstructor() = testRenameOccurrences({
+    byText("ConsDefiner", "data Foo = foo(int i);", {0}),
+    byText("FuncOverload", "import ConsDefiner;
+                           'Foo foo(int i, int j) = foo(i + j);", {0, 1}),
+    byText("Main", "import ConsDefiner;
+                   'Foo f = foo(8);", {0})
+});
+
 test bool differentADTsDuplicateConstructorNames() = testRenameOccurrences({
     byText("A", "data Bar = foo();", {0})
   , byText("B",

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Constructors.rsc
@@ -53,6 +53,11 @@ test bool functionOverloadsConstructor() = testRenameOccurrences({
                    'Foo f = foo(8);", {0})
 });
 
+test bool functionDoesNotOverloadConstructor() = testRenameOccurrences({
+    byText("ConsDefiner", "data Foo = foo(int i);", {0}),
+    byText("FuncDefiner", "int foo(int i) = i;", {})
+});
+
 test bool differentADTsDuplicateConstructorNames() = testRenameOccurrences({
     byText("A", "data Bar = foo();", {0})
   , byText("B",

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -181,15 +181,6 @@ test bool extendedConstructorField() = testRenameOccurrences({
         ", {0, 1})
 });
 
-test bool dataTypeReusedName() = testRenameOccurrences({
-    byText("Scratch1", "
-        'data Foo = f();
-        ", {0}),
-    byText("Scratch2", "
-        'data Foo = g();
-        ", {})
-}, oldName = "Foo", newName = "Bar");
-
 test bool dataFieldReusedName() = testRenameOccurrences({
     byText("Scratch1", "
         'data Foo = f(int foo);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -222,45 +222,39 @@ test bool dataAsFormalField() = testRenameOccurrences({0, 1}, "
     'int getChild(D d) = d.foo;
 ", decls = "data D = x(int foo);");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool relField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'f = r.foo;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool lrelField() = testRenameOccurrences({0, 1}, "
     'lrel[str foo, str baz] r = [];
     'f = r.foo;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool relSubscript() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'x = r\<foo\>;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool relSubscriptWithVar() = testRenameOccurrences({0, 2}, "
     'rel[str foo, str baz] r = {};
     'str foo = \"foo\";
     'x = r\<foo\>;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool tupleFieldSubscriptUpdate() = testRenameOccurrences({0, 1, 2}, "
     'tuple[str foo, int baz] t = \<\"one\", 1\>;
     'u = t[foo = \"two\"];
     'v = u.foo;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool tupleFieldAccessUpdate() = testRenameOccurrences({0, 1}, "
     'tuple[str foo, int baz] t = \<\"one\", 1\>;
     't.foo = \"two\";
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
+@ignore{Ignore this for now, until we figure out the desired semantics here. https://github.com/usethesource/rascal/issues/2188}
 test bool similarCollectionTypes() = testRenameOccurrences({0, 1, 2, 3, 4}, "
     'rel[str foo, int baz] r = {};
     'lrel[str foo, int baz] lr = [];
@@ -269,7 +263,6 @@ test bool similarCollectionTypes() = testRenameOccurrences({0, 1, 2, 3, 4}, "
     'tuple[str foo, int baz] t = \<\"\", 0\>;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool differentRelWithSameField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, int baz] r1 = {};
     'foos1 = r1.foo;
@@ -277,7 +270,6 @@ test bool differentRelWithSameField() = testRenameOccurrences({0, 1}, "
     'foos2 = r2.foo;
 ");
 
-@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool tupleField() = testRenameOccurrences({0, 1}, "
     'tuple[int foo] t = \<8\>;
     'y = t.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -46,7 +46,6 @@ test bool constructorKeywordField() = testRenameOccurrences({0, 1, 2, 3}, "
     'x = dd.foo;
     'b = dd has foo;
     ", decls="data D = d(int foo = 0, int baz = 0);"
-    , skipCursors = {2} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool constructorKeywordFieldFromOtherModule() = testRenameOccurrences({
@@ -62,7 +61,6 @@ test bool commonKeywordField() = testRenameOccurrences({0, 1, 2, 3}, "
     'x = oneTwo.foo;
     'b = oneTwo has foo;
     ", decls = "data D(int foo = 0, int baz = 0) = d();"
-    , skipCursors = {2} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool commonKeywordFieldFromOtherModule() = testRenameOccurrences({
@@ -104,7 +102,6 @@ test bool commonKeywordFieldsSameType() = testRenameOccurrences({0, 1},
     'xy = x.baz;
     ",
     decls = "data D (set[loc] foo = {}, set[loc] baz = {})= d();"
-, skipCursors = {1} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool sameNameFields() = testRenameOccurrences({0, 2, 3}, "
@@ -161,7 +158,6 @@ test bool complexDataType() = testRenameOccurrences({0, 1},
     '   set[TModel](ProjectFiles) tmodelsForLocs
     ');"
 , oldName = "sourceFiles", newName = "sources"
-, skipCursors = {1} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool crossModuleConstructorField() = testRenameOccurrences({

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -46,6 +46,7 @@ test bool constructorKeywordField() = testRenameOccurrences({0, 1, 2, 3}, "
     'x = dd.foo;
     'b = dd has foo;
     ", decls="data D = d(int foo = 0, int baz = 0);"
+    , skipCursors = {2} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool constructorKeywordFieldFromOtherModule() = testRenameOccurrences({
@@ -61,6 +62,7 @@ test bool commonKeywordField() = testRenameOccurrences({0, 1, 2, 3}, "
     'x = oneTwo.foo;
     'b = oneTwo has foo;
     ", decls = "data D(int foo = 0, int baz = 0) = d();"
+    , skipCursors = {2} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool commonKeywordFieldFromOtherModule() = testRenameOccurrences({
@@ -102,6 +104,7 @@ test bool commonKeywordFieldsSameType() = testRenameOccurrences({0, 1},
     'xy = x.baz;
     ",
     decls = "data D (set[loc] foo = {}, set[loc] baz = {})= d();"
+, skipCursors = {1} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
 );
 
 test bool sameNameFields() = testRenameOccurrences({0, 2, 3}, "
@@ -157,7 +160,9 @@ test bool complexDataType() = testRenameOccurrences({0, 1},
     '   ProjectFiles() allFiles,
     '   set[TModel](ProjectFiles) tmodelsForLocs
     ');"
-, oldName = "sourceFiles", newName = "sources");
+, oldName = "sourceFiles", newName = "sources"
+, skipCursors = {1} // TODO Unsupported: use of keyword field refers to full ADT def (https://github.com/usethesource/rascal/issues/2193)
+);
 
 test bool crossModuleConstructorField() = testRenameOccurrences({
     byText("Foo", "data D = a(int foo) | b(int baz);", {0}),
@@ -221,38 +226,45 @@ test bool dataAsFormalField() = testRenameOccurrences({0, 1}, "
     'int getChild(D d) = d.foo;
 ", decls = "data D = x(int foo);");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool relField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'f = r.foo;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool lrelField() = testRenameOccurrences({0, 1}, "
     'lrel[str foo, str baz] r = [];
     'f = r.foo;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool relSubscript() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'x = r\<foo\>;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool relSubscriptWithVar() = testRenameOccurrences({0, 2}, "
     'rel[str foo, str baz] r = {};
     'str foo = \"foo\";
     'x = r\<foo\>;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool tupleFieldSubscriptUpdate() = testRenameOccurrences({0, 1, 2}, "
     'tuple[str foo, int baz] t = \<\"one\", 1\>;
     'u = t[foo = \"two\"];
     'v = u.foo;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool tupleFieldAccessUpdate() = testRenameOccurrences({0, 1}, "
     'tuple[str foo, int baz] t = \<\"one\", 1\>;
     't.foo = \"two\";
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool similarCollectionTypes() = testRenameOccurrences({0, 1, 2, 3, 4}, "
     'rel[str foo, int baz] r = {};
     'lrel[str foo, int baz] lr = [];
@@ -261,6 +273,7 @@ test bool similarCollectionTypes() = testRenameOccurrences({0, 1, 2, 3, 4}, "
     'tuple[str foo, int baz] t = \<\"\", 0\>;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool differentRelWithSameField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, int baz] r1 = {};
     'foos1 = r1.foo;
@@ -268,6 +281,7 @@ test bool differentRelWithSameField() = testRenameOccurrences({0, 1}, "
     'foos2 = r2.foo;
 ");
 
+@ignore{Structured type fields have no definition: https://github.com/usethesource/rascal/issues/2188}
 test bool tupleField() = testRenameOccurrences({0, 1}, "
     'tuple[int foo] t = \<8\>;
     'y = t.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -212,6 +212,15 @@ test bool dataAsFormalField() = testRenameOccurrences({0, 1}, "
     'int getChild(D d) = d.foo;
 ", decls = "data D = x(int foo);");
 
+@ignore{Will be supported in the future.}
+test bool functionOverloadsConstructorFields() = testRenameOccurrences({
+    byText("ConsDefiner", "data F = f(int foo = 8);", {0}),
+    byText("FuncOverload", "import ConsDefiner;
+                           'F f(int foo = 8, int baz = 9) = f(foo = foo + baz);", {0, 1, 2}),
+    byText("Main", "import ConsDefiner;
+                   'F x = f(foo=8);", {0})
+});
+
 test bool relField() = testRenameOccurrences({0, 1}, "
     'rel[str foo, str baz] r = {};
     'f = r.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -157,8 +157,7 @@ test bool complexDataType() = testRenameOccurrences({0, 1},
     '   ProjectFiles() allFiles,
     '   set[TModel](ProjectFiles) tmodelsForLocs
     ');"
-, oldName = "sourceFiles", newName = "sources"
-);
+, oldName = "sourceFiles", newName = "sources");
 
 test bool crossModuleConstructorField() = testRenameOccurrences({
     byText("Foo", "data D = a(int foo) | b(int baz);", {0}),

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -75,6 +75,12 @@ test bool keywordParameter() = testRenameOccurrences({0, 1, 2},
     , decls="int f(int foo = 8) = foo;"
 );
 
+test bool keywordParameterCrossModule() = testRenameOccurrences({
+    byText("Definer", "int f(int foo = 8) = foo + 1;", {0, 1}),
+    byText("Main", "import Definer;
+                   'int x = f(foo = 9);", {0})
+});
+
 test bool functionIsNotConstructor() = testRenameOccurrences({0, 1, 3},
     "int x = f(foo = 10);"
     , decls="int f(int foo = 8) = foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -76,6 +76,13 @@ test bool keywordParameter() = testRenameOccurrences({0, 1, 2},
     , skipCursors = {2}
 );
 
+test bool functionIsNotConstructor() = testRenameOccurrences({0, 1, 3},
+    "int x = f(foo = 10);"
+    , decls="int f(int foo = 8) = foo;
+            'data F = g(int foo = 8);"
+    , skipCursors = {3}
+);
+
 @expected{illegalRename} test bool doubleParameterDeclaration1() = testRename("int f(int foo, int bar) = 1;");
 @expected{illegalRename} test bool doubleParameterDeclaration2() = testRename("int f(int bar, int foo) = 1;");
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -67,8 +67,8 @@ test bool privateFunctionParameter() = testRenameOccurrences({0, 1}, "", decls =
 
 test bool nestedKeywordParameter() = testRenameOccurrences({0, 1, 2}, "
     'int f(int foo = 8) = foo;
-    'int x = f(foo = 10);"
-);
+    'int x = f(foo = 10);
+");
 
 test bool keywordParameter() = testRenameOccurrences({0, 1, 2},
     "int x = f(foo = 10);"

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -67,20 +67,18 @@ test bool privateFunctionParameter() = testRenameOccurrences({0, 1}, "", decls =
 
 test bool nestedKeywordParameter() = testRenameOccurrences({0, 1, 2}, "
     'int f(int foo = 8) = foo;
-    'int x = f(foo = 10);
-", skipCursors = {2});
+    'int x = f(foo = 10);"
+);
 
 test bool keywordParameter() = testRenameOccurrences({0, 1, 2},
     "int x = f(foo = 10);"
     , decls="int f(int foo = 8) = foo;"
-    , skipCursors = {2}
 );
 
 test bool functionIsNotConstructor() = testRenameOccurrences({0, 1, 3},
     "int x = f(foo = 10);"
     , decls="int f(int foo = 8) = foo;
             'data F = g(int foo = 8);"
-    , skipCursors = {3}
 );
 
 @expected{illegalRename} test bool doubleParameterDeclaration1() = testRename("int f(int foo, int bar) = 1;");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/FormalParameters.rsc
@@ -65,9 +65,15 @@ test bool privateFunctionParameter() = testRenameOccurrences({0, 1}, "", decls =
     '}
 ");
 
-test bool nestedKeywordParameter() = testRenameOccurrences({0, 1, 2}, "
+test bool nestedFunctionKeywordParameter() = testRenameOccurrences({0, 1, 2}, "
     'int f(int foo = 8) = foo;
     'int x = f(foo = 10);
+");
+
+test bool nestedKeywordParameter() = testRenameOccurrences({2, 3, 5}, "
+    'int f(int foo = 1) = foo + 1;
+    'int g(int foo = 2) = foo + 1; // rename `foo`s in `g` only
+    'int i = f(foo = g(foo = 3));
 ");
 
 test bool keywordParameter() = testRenameOccurrences({0, 1, 2},

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -134,9 +134,9 @@ bool testRenameOccurrences(set[TestModule] modules, str oldName = "foo", str new
 
         for (m <- modulesByLocation) {
             try {
-                parseModuleWithSpaces(m.file);
-            } catch _: {
-                throw "Parse error in test module <ml>";
+                parse(#start[Module], m.file);
+            } catch ParseError(l): {
+                throw "Parse error in test module <m.file>: <l>";
             }
         }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Types.rsc
@@ -184,3 +184,12 @@ test bool sameIdRoleOnly() = testRenameOccurrences({
   , byText("D", "import C;
                 'int baz = C::foo + 1;", {0})
 });
+
+test bool dataTypeReusedName() = testRenameOccurrences({
+    byText("Scratch1", "
+        'data Foo = f();
+        ", {0}),
+    byText("Scratch2", "
+        'data Foo = g();
+        ", {})
+}, oldName = "Foo", newName = "Bar");

--- a/rascal-lsp/src/main/rascal/util/Util.rsc
+++ b/rascal-lsp/src/main/rascal/util/Util.rsc
@@ -103,3 +103,10 @@ bool isShorterTuple(tuple[loc, &T] t1, tuple[loc, &T] t2) = isShorter(t1[0], t2[
 
 set[&T] flatMap(set[&U] us, set[&T](&U) f) =
     {*ts | u <- us, ts := f(u)};
+
+str describeTree(appl(p, _)) = printSymbol(p.def, false);
+str describeTree(cycle(sym, length)) = "cycle[<length>] of <printSymbol(sym, false)>";
+str describeTree(amb(alts)) = intercalate("|", [describeTree(alt) | alt <- alts]);
+str describeTree(char(int c)) = "char <c>";
+
+list[str] describeTrees(list[Tree] trees) = [describeTree(t) | t <- trees];


### PR DESCRIPTION
Renaming of positional/keyword fields of constructors, ADTs and collections.

This PR also introduces TModel augmentation. This works around missing definitions and missing/unusable use/def relations in the TModel, until https://github.com/usethesource/rascal/issues/2172 is fixed.