### PR TITLE
Rename: type parameters

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -158,18 +158,6 @@ void rascalCheckCausesDoubleDeclarations(Define cD, str newName, TModel tm, Rena
             r.error(cD.defined, "Cannot rename to \'<newName>\', since this would clash with an existing definition at <nD>.");
         }
     }
-
-    // TODO Re-do once we decided how to treat definitions that are not in tm.defines
-    // rel[loc old, loc new] doubleTypeParamDeclarations = {<cD, nD>
-    //     | loc cD <- currentDefs
-    //     , tm.facts[cD]?
-    //     , cT: aparameter(_, _) := tm.facts[cD]
-    //     , Define fD: <_, _, _, _, _, defType(afunc(_, funcParams:/cT, _))> <- tm.defines
-    //     , isContainedIn(cD, fD.defined)
-    //     , <loc nD, nT: aparameter(newName, _)> <- toRel(tm.facts)
-    //     , isContainedIn(nD, fD.defined)
-    //     , /nT := funcParams
-    // };
 }
 
 void rascalCheckDefinitionOutsideWorkspace(Define d, TModel tm, Renamer r) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -558,6 +558,7 @@ default list[Tree] extendFocusWithConcreteSyntax(list[Tree] cursor, loc _) = cur
 TModel augmentTModel(Tree tr, TModel tm, TModel(loc) tmodelForLoc) {
     tm = augmentFieldUses(tr, tm, tmodelForLoc);
     tm = augmentFormalUses(tr, tm, tmodelForLoc);
+    tm = augmentTypeParams(tr, tm);
     return tm;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -85,6 +85,7 @@ public set[Define] findAdditionalDataLikeDefinitions(set[Define] cursorDefs, loc
 tuple[type[Tree] as, str desc] asType(aliasId()) = <#Name, "type name">;
 tuple[type[Tree] as, str desc] asType(annoId()) = <#Name, "annotation name">;
 tuple[type[Tree] as, str desc] asType(dataId()) = <#Name, "ADT name">;
+tuple[type[Tree] as, str desc] asType(typeVarId()) = <#Name, "type variable name">;
 
 alias Environment = tuple[TModel tm, map[str, loc] defs];
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Functions.rsc
@@ -181,7 +181,7 @@ test bool nestedTypeParamClash() = testRename("
     'void f(&S s, &T t) {
     '   &S g(&S s) = s;
     '   &T g(&T t) = t;
-    }
+    '}
 ", oldName = "S", newName = "T", cursorAtOldNameOccurrence = 1);
 
 test bool adjacentTypeParams() = testRenameOccurrences({0, 1}, "


### PR DESCRIPTION
Implement the renaming of type parameters. This works around TModel limitations w.r.t. type parameters as described in https://github.com/usethesource/rascal/issues/2185.