### PR TITLE
Rename: parse/type error handling

### DIFF
--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -34,6 +34,7 @@ import analysis::typepal::TModel;
 
 import util::Monitor;
 
+import Exception;
 import IO;
 import List;
 import Map;
@@ -103,7 +104,11 @@ RenameResult rename(
     // Tree & TModel caching
 
     @memo{maximumSize(50)}
-    TModel getTModelCached(Tree t) = config.tmodelForTree(t);
+    TModel getTModelCached(Tree t) {
+        tm = config.tmodelForTree(t);
+        if (msg <- tm.messages, msg is error) registerMessage(error(t.src.top, "Renaming failed, since this file has type error(s)."));
+        return tm;
+    }
 
     @memo{maximumSize(50)}
     Tree parseLocCached(loc l) {
@@ -112,7 +117,12 @@ RenameResult rename(
             return cursor[-1];
         }
 
-        return config.parseLoc(l);
+        try {
+            return config.parseLoc(l);
+        } catch ParseError(_): {
+            registerMessage(error(l, "Renaming failed, since an error occurred while parsing this file."));
+            return char(-1);
+        }
     }
 
     // Make sure user uses cached functions

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Performance.rsc
@@ -48,6 +48,19 @@ test bool largeTest() = testRenameOccurrences(({0} | it + {foos + 3, foos + 4, f
 @expected{illegalRename}
 test bool failOnError() = testRename("int foo = x + y;");
 
+@expected{illegalRename}
+test bool failOnErrorInImport() = testRenameOccurrences({
+    byText("Foo", "int foo = x + y;", {0}, skipCursors = {0}),
+    byText("Main", "import Foo;
+                   'int baz = Foo::foo;", {0})
+});
+
+@ignore{TODO Currently broken, since all files are marked as potential uses (due to https://github.com/usethesource/rascal/issues/2147)}
+test bool doNotFailOnUnrelatedError() = testRenameOccurrences({
+    byText("Unrelated", "int x = \"notanumber\";", {}),
+    byText("Main", "int foo = 8;", {0})
+});
+
 test bool incrementalTypeCheck() {
     procLoc = |memory://tests/incremental|;
     pcfg = getTestPathConfig(procLoc);


### PR DESCRIPTION
This PR changes the framework to abort the renaming early on errors from the parse and type check hooks.

Companion framework PR: https://github.com/SWAT-engineering/rascal-rename-framework/pull/8