### PR TITLE
Upgrading to rascal 0.40.18 with improved performance for loading eva…

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.40.17</version>
+      <version>0.40.18</version>
     </dependency>
     <dependency>
       <groupId>org.rascalmpl</groupId>


### PR DESCRIPTION
This improves performance of the startup time of rascal evaluators