### PR TITLE
[Renaming] Benchmarking and functionality improvements

### DIFF
--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -94,6 +94,9 @@ RenameResult rename(
       , str newName
       , RenameConfig config) {
 
+    jobStart(config.jobLabel, totalWork = 2 * WORKSPACE_WORK + 1);
+    jobStep(config.jobLabel, "Initializing renamer");
+
     void printDebug(str s) {
         if (config.debug) {
             println(s);
@@ -201,8 +204,6 @@ RenameResult rename(
       , void(value at, str s) { registerMessage(warning(at, s)); }
       , void(value at, str s) { registerMessage(error(at, s)); }
     );
-
-    jobStart(config.jobLabel, totalWork = 2 * WORKSPACE_WORK);
 
     jobStep(config.jobLabel, "Resolving definitions of <cursor[0].src>", work = WORKSPACE_WORK);
     defs = getCursorDefinitions(cursor, parseLocCached, getTModelCached, r);

--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -94,6 +94,13 @@ RenameResult rename(
       , str newName
       , RenameConfig config) {
 
+    /* Initially, we expect at least the following work
+      - 1 unit of work to initialize the renaming
+      - 1 unit of 'workspace work' to resolve definitions
+      - 1 unit of 'workspace work' to find all files with occurrences
+
+      Any additional work will be added based on the results of above steps.
+    */
     jobStart(config.jobLabel, totalWork = 2 * WORKSPACE_WORK + 1);
     jobStep(config.jobLabel, "Initializing renamer");
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -149,7 +149,7 @@ void rascalCheckCausesDoubleDeclarations(Define cD, str newName, TModel tm, Rena
     }
 
     if (isFieldRole(cD.idRole)) {
-        for (Define dataDef <- findAdditionalDataLikeDefinitions({cD}, cD.defined.top, tm, r)
+        for (Define dataDef <- findAdditionalDataLikeDefinitions({cD}, tm, r)
            , loc nD <- (newNameDefs<idRole, defined>)[{fieldId(), keywordFieldId()}] & (tm.defines<idRole, scope, defined>)[{fieldId(), keywordFieldId()}, dataDef.defined]
         ) {
             r.error(cD.defined, "Cannot rename to \'<newName>\', since this would clash with an existing definition at <nD>.");
@@ -292,10 +292,13 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
     set[Define] cursorDefs = {};
     if (Tree c <- cursor) {
         if (tm.definitions[c.src]?) {
+            // Cursor at definition
             cursorDefs = {tm.definitions[c.src]};
         } else if (useDefs: {_, *_} := tm.useDef[c.src]) {
-            cursorDefs = {defTm.definitions[d] | d <- useDefs, defTm := getModel(getTree(d.top))};
+            // Cursor at use
+            cursorDefs = {defTm.definitions[d] | loc d <- useDefs, defTm := getModel(getTree(d.top))};
         } else {
+            // Try next cursor candidate in focus list
             fail;
         }
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -246,7 +246,9 @@ TModel augmentTModel(loc l, TModel tm, PathConfig(loc) getPathConfig) {
         tm = augmentFieldUses(tr, tm, getModel);
         tm = augmentFormalUses(tr, tm, getModel);
         tm = augmentTypeParams(tr, tm);
-    } catch _: {;}
+    } catch e: {
+        println("Suppressed error during TModel augmentation: <e>");
+    }
     return tm;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -125,7 +125,7 @@ void rascalCheckCausesCaptures(set[Define] currentDefs, str newName, Tree tr, TM
 }
 
 void rascalCheckLegalNameByRole(Define _:<_, _, _, role, at, _>, str name, Renamer r) {
-    escName = reEscape(name);
+    escName = normalizeEscaping(name);
     <t, desc> = asType(role);
     if (tryParseAs(t, escName) is nothing) {
         r.error(at, "<escName> is not a valid <desc>");
@@ -314,7 +314,7 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
 }
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    escNewName = reEscape(newName);
+    escNewName = normalizeEscaping(newName);
     for (role <- defs.idRole) {
         hasError = false;
         <t, desc> = asType(role);
@@ -345,7 +345,7 @@ void renameDefinition(Define d, loc nameLoc, str newName, TModel tm, Renamer r) 
     rascalCheckLegalNameByRole(d, newName, r);
     rascalCheckDefinitionOutsideWorkspace(d, tm, r);
 
-    renameDefinitionUnchecked(d, nameLoc, reEscape(newName), tm, r);
+    renameDefinitionUnchecked(d, nameLoc, normalizeEscaping(newName), tm, r);
 }
 
 private loc nameSuffix(loc l, set[Define] defs, Renamer r) {
@@ -360,7 +360,7 @@ private loc nameSuffix(loc l, set[Define] defs, Renamer r) {
 }
 
 void renameUses(set[Define] defs, str newName, TModel tm, Renamer r) {
-    escName = reEscape(newName);
+    escName = normalizeEscaping(newName);
 
     definitions = {<d.defined, d> | d <- defs};
     useDefs = toMap(tm.useDef o definitions);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -125,7 +125,7 @@ void rascalCheckCausesCaptures(set[Define] currentDefs, str newName, Tree tr, TM
 }
 
 void rascalCheckLegalNameByRole(Define _:<_, _, _, role, at, _>, str name, Renamer r) {
-    escName = escapeReservedNames(name);
+    escName = reEscape(name);
     <t, desc> = asType(role);
     if (tryParseAs(t, escName) is nothing) {
         r.error(at, "<escName> is not a valid <desc>");
@@ -312,7 +312,7 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) getTree, TModel(Tr
 }
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFiles(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    escNewName = escapeReservedNames(newName);
+    escNewName = reEscape(newName);
     for (role <- defs.idRole) {
         hasError = false;
         <t, desc> = asType(role);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -258,7 +258,7 @@ TModel tmodelForLoc(loc l, PathConfig(loc) getPathConfig) {
     ms = rascalTModelForNames([mname], ccfg, dummy_compile1);
 
     <found, tm, ms> = getTModelForModule(mname, ms);
-    if (!found) throw ms.messages;
+    if (!found) throw "No TModel for module \'<mname>\'";
     return augmentTModel(l, tm, TModel(loc f) {
         // Prevent endless recursion
         if (f == l) return tm;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -269,7 +269,7 @@ public Edits rascalRenameSymbol(loc cursorLoc, list[Tree] cursor, str newName, s
     extendFocusWithConcreteSyntax(cursor, cursorLoc)
   , newName
   , rconfig(
-        Tree(loc l) { return parse(#start[Module], l); }
+        Tree(loc l) { return parseModuleWithSpaces(l); }
       , TModel(Tree t) { return tmodelForTree(t, getPathConfig); }
       , workspaceFolders = workspaceFolders
       , getPathConfig = getPathConfig

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -78,7 +78,7 @@ str escapeReservedName(str name) = name in reservedNames ? forceEscapeSingleName
 str perName(str qname, str(str) f, str sep = "::") = intercalate(sep, [f(n) | n <- split(sep, qname)]);
 
 @memo{maximumSize(100), expireAfter(minutes=5)}
-str reEscape(str qname, str sep = "::") = perName(qname, str(str n) { return escapeMinusIdentifier(escapeReservedName(forceUnescapeNames(n))); }, sep = sep);
+str normalizeEscaping(str qname, str sep = "::") = perName(qname, str(str n) { return escapeMinusIdentifier(escapeReservedName(forceUnescapeNames(n))); }, sep = sep);
 
 Tree parseAsOrEmpty(type[&T <: Tree] T, str name) =
     just(Tree t) := tryParseAs(T, name) ? t : char(0);
@@ -86,7 +86,7 @@ Tree parseAsOrEmpty(type[&T <: Tree] T, str name) =
 private tuple[Tree, Tree] escapePair(type[&T <: Tree] T, str n) = <parseAsOrEmpty(T, n), parseAsOrEmpty(T, forceEscapeSingleName(n))>;
 
 bool(Tree) allNameSortsFilter(str name) {
-    escName = reEscape(name);
+    escName = normalizeEscaping(name);
 
     <n1, en1> = escapePair(#Name, escName);
     <nt1, ent1> = escapePair(#Nonterminal, escName);
@@ -100,7 +100,7 @@ bool(Tree) allNameSortsFilter(str name) {
             case (NonterminalLabel) `<NonterminalLabel n>`: if (n := ntl1 || n := entl1) return true;
             case (QualifiedName) `<QualifiedName n>`: {
                 if (n.names[0].src == n.src) fail; // skip unqualified names
-                if (n := qn1 || qn1 := [QualifiedName] reEscape("<n>")) return true;
+                if (n := qn1 || qn1 := [QualifiedName] normalizeEscaping("<n>")) return true;
             }
         }
 
@@ -108,11 +108,11 @@ bool(Tree) allNameSortsFilter(str name) {
     };
 }
 
-&T reEscape(type[&T <: Tree] T, &T t) = parse(T, "<reEscape("<t>")>");
+&T normalizeEscaping(type[&T <: Tree] T, &T t) = parse(T, "<normalizeEscaping("<t>")>");
 
 tuple[bool, bool](Tree) allNameSortsFilter(str name1, str name2) {
-    sname1 = reEscape(name1);
-    sname2 = reEscape(name2);
+    sname1 = normalizeEscaping(name1);
+    sname2 = normalizeEscaping(name2);
 
     <n1, en1> = escapePair(#Name, sname1);
     <nt1, ent1> = escapePair(#Nonterminal, sname1);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -72,10 +72,13 @@ private set[str] reservedNames = getRascalReservedIdentifiers();
 
 str forceUnescapeNames(str name) = replaceAll(name, "\\", "");
 str forceEscapeSingleName(str name) = startsWith(name, "\\") ? name : "\\<name>";
-str escapeReservedNames(str name, str sep = "::") = intercalate(sep, [n in reservedNames ? forceEscapeSingleName(n) : n | n <- split(sep, name)]);
-str unescapeNonReservedNames(str name, str sep = "::") = intercalate(sep, [n in reservedNames ? n : forceUnescapeNames(n) | n <- split(sep, name)]);
-str reEscape(str name) = escapeMinusIdentifier(escapeReservedNames(forceUnescapeNames(name)));
 str escapeMinusIdentifier(str name) = (contains(name, "-") && !startsWith(name, "\\")) ? "\\<name>" : name;
+str escapeReservedName(str name) = name in reservedNames ? forceEscapeSingleName(name) : name;
+
+str perName(str qname, str(str) f, str sep = "::") = intercalate(sep, [f(n) | n <- split(sep, qname)]);
+
+@memo{maximumSize(100), expireAfter(minutes=5)}
+str reEscape(str qname, str sep = "::") = perName(qname, str(str n) { return escapeMinusIdentifier(escapeReservedName(forceUnescapeNames(n))); }, sep = sep);
 
 Tree parseAsOrEmpty(type[&T <: Tree] T, str name) =
     just(Tree t) := tryParseAs(T, name) ? t : char(0);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -195,7 +195,7 @@ tuple[bool, bool](Tree) allNameSortsFilter(str name1, str name2) {
 }
 
 set[loc] filterFiles(set[loc] fs, bool(Tree) treeFilter, Tree(loc) getTree) {
-    j = "Checking files for occurrences of relevant names";
+    j = "Checking files for occurrences of relevant name";
     jobStart(j, totalWork = size(fs));
     set[loc] filteredFs = {};
     for (loc f <- fs) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -70,7 +70,7 @@ set[Define] getFieldDefinitions(set[Define] containerDefs, rel[IdRole, str] fiel
 
 @synopsis{Collect all definitions for the field <fieldName> by ADT/constructor type.}
 set[Define] getFieldDefinitions(set[AType] containerTypes, str fieldName, TModel tm, TModel(loc) getModel) {
-    rel[AType, IdRole, Define] definesByType = {<d.defInfo.atype, d.idRole, d> | d <- tm.defines};
+    rel[AType, IdRole, Define] definesByType = {<d.defInfo.atype, d.idRole, d> | d <- tm.defines, d.defInfo.atype?};
     // Find all type-like definitions (but omit variable definitions etc.)
     set[Define] containerTypeDefs = definesByType[containerTypes, dataOrSyntaxRoles];
     // Since we do not know (based on tree) what kind of field role (positional, keyword) we are looking for, select them all
@@ -83,7 +83,7 @@ set[Define] getFieldDefinitions(Tree container, str fieldName, TModel tm, TModel
         return flatMapPerFile(defs, set[Define](loc f, set[loc] localContainerDefs) {
             fileTm = getModel(f);
 
-            set[Define] containerDefs = {fileTm.definitions[d] | loc d <- localContainerDefs};
+            set[Define] containerDefs = {fileTm.definitions[d] | loc d <- localContainerDefs, fileTm.definitions[d]?};
             // Find the type of the container. For a constructor value, the type is its ADT type.
             set[AType] containerDefTypes = {acons(AType adt, _, _) := di.atype ? adt : di.atype | DefInfo di <- containerDefs.defInfo};
             return getFieldDefinitions(containerDefTypes, fieldName, fileTm, getModel);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
@@ -47,7 +47,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] def
     when role in syntaxRoles;
 
 set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, IdRole role, _, _>, *_}, Tree tr, TModel tm, Renamer r) =
-    findAdditionalDataLikeDefinitions(cursorDefs, tr.src.top, tm, r)
+    findAdditionalDataLikeDefinitions(cursorDefs, tm, r)
     when role in syntaxRoles;
 
 void renameDefinitionUnchecked(Define d: <_, _, _, nonterminalId(), _, _>, loc _, str _, TModel _, Renamer _) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -55,7 +55,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
     set[loc] newFiles = {};
 
     modName = [QualifiedName] curModName;
-    newModName = reEscape(newName);
+    newModName = normalizeEscaping(newName);
 
     for (loc f <- getSourceFiles(r)) {
         bottom-up-break visit (getTree(f)) {
@@ -65,13 +65,13 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
             }
             case QualifiedName qn: {
                 // Import of redundantly escaped module name
-                escQn = reEscape("<qn>");
+                escQn = normalizeEscaping("<qn>");
                 if (curModName == escQn) useFiles += f;
                 else if (newModName == escQn) newFiles += f;
                 else {
                     // Qualified use of declaration in module
                     // If through extends, there might be no import
-                    qualPref = reEscape(qualifiedPrefix(qn).name);
+                    qualPref = normalizeEscaping(qualifiedPrefix(qn).name);
                     if (qualPref == curModName) useFiles += f;
                     if (qualPref == newModName) newFiles += f;
                 }
@@ -103,7 +103,7 @@ void renameAdditionalUses(set[Define] _:{<_, moduleName, _, moduleId(), modDef, 
     // That's intended, since this function is only supposed to rename uses.
     if ({loc u, *_} := tm.useDef<0>) {
         for (/QualifiedName qn := r.getConfig().parseLoc(u.top), any(d <- tm.useDef[qn.src], d.top == modDef.top),
-            pref := qualifiedPrefix(qn), moduleName == reEscape(pref.name)) {
+            pref := qualifiedPrefix(qn), moduleName == normalizeEscaping(pref.name)) {
             r.textEdit(replace(pref.l, newName));
         }
     }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -67,11 +67,11 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
 }
 
 set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, dataId(), _, _>, *_}, Tree tr, TModel tm, Renamer r) =
-    findAdditionalDataLikeDefinitions(cursorDefs, tr.src.top, tm, r);
+    findAdditionalDataLikeDefinitions(cursorDefs, tm, r);
 
-public set[Define] findAdditionalDataLikeDefinitions(set[Define] cursorDefs, loc currentLoc, TModel tm, Renamer r) {
+public set[Define] findAdditionalDataLikeDefinitions(set[Define] defs, TModel tm, Renamer r) {
     reachable = rascalGetReflexiveModulePaths(tm).to;
-    reachableCursorDefs = {d.defined | Define d <- cursorDefs, any(loc modScope <- reachable, isContainedInScope(d.defined, modScope, tm))};
+    reachableCursorDefs = {d.defined | Define d <- defs, any(loc modScope <- reachable, isContainedInScope(d.defined, modScope, tm))};
 
     if ({} := reachableCursorDefs) return {};
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -44,6 +44,9 @@ import util::Util;
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] defs:{<_, _, _, dataId(), _, _>, *_}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) =
     findDataLikeOccurrenceFilesUnchecked(defs, cursor, newName, getTree, r);
 
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, typeVarId(), _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
+    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
+
 public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     if (size(defs.id) > 1) {
         r.error(cursor[0], "Cannot find files for ADT definitions with multiple names (<defs.id>)");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -56,13 +56,13 @@ map[str, num] benchmarks(loc projDir) {
       , "[bird] formal param": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "typeFormals", occurrence = 1, libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] global function": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "collectAnnos", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] local var": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "imported", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
-    //   , "[typepal] module name": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "analysis::typepal::Version", srcDirs = ["src"])
-    //   , "[typepal] constructor": run(typepalProj(projDir), "src/analysis/typepal/Collector.rsc", "collector", srcDirs = ["src"])
-    //   , "[typepal] global var": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "currentTplVersion", srcDirs = ["src"])
-    //   , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/ATypeUtils.rsc", "prettyAType")
-    //     "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc", "msgs")
-    //   , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
-    //   , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
+      , "[typepal] module name": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "analysis::typepal::Version", srcDirs = ["src"])
+      , "[typepal] constructor": run(typepalProj(projDir), "src/analysis/typepal/Collector.rsc", "collector", srcDirs = ["src"])
+      , "[typepal] global var": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "currentTplVersion", srcDirs = ["src"])
+      , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/ATypeUtils.rsc", "prettyAType")
+      , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc", "msgs")
+      , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
+      , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
     ));
     iprintln(results);
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -41,13 +41,12 @@ loc birdProj(loc projDir) = projDir + "bird/bird-core"; // removed RASCAL.MF
 public loc typepalLib = |mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|;
 
 void() run(loc proj, str file, str oldName, str newName = "<oldName>2", int occurrence = 0, list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) = void() {
-    println("Rename \'<oldName>\' in <proj + file>");
+    println("Renameing \'<oldName>\' to \'<newName>\' in <proj + file>");
     <edits, msgs> = testProjectOnDisk(proj, file, oldName, newName = newName, occurrence = occurrence, srcDirs = srcDirs, libs = libs);
     if (errors:{_, *_} := {msg | msg <- msgs, msg is error}) throw errors;
     if (size({r | /r:replace(_, _) := edits}) < 2) throw "Unexpected number of edits: <edits>";
 };
 
-int NUM_RUNS = 3;
 map[str, num] benchmarks(loc projDir) = benchmark((
         "[bird] nonterminal": run(birdProj(projDir), "src/main/rascal/lang/bird/Syntax.rsc", "TopLevelDecl", libs = [typepalLib])
       , "[bird] formal param": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "typeFormals", occurrence = 1, libs = [typepalLib])
@@ -61,14 +60,13 @@ map[str, num] benchmarks(loc projDir) = benchmark((
     //   , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e")
     //   , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
     //   , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
-), safeMinimum(realTimeOf));
+), safeRuns(3, min, realTimeOf));
 
-int(void()) safeMinimum(int(void()) measure) = int(void() f) {
+num(void()) safeRuns(int numRuns, &T(set[&T]) aggregate, int(void()) measure) = int(void() f) {
     try {
-        return min({measure(f) | _ <- [0..NUM_RUNS]});
+        return aggregate({measure(f) | _ <- [0..numRuns]});
     } catch e: {
-        println("Renaming \'<oldName>\' to \'<newName>\' in <proj + file> resulted in error:");
-        println(e);
+        println("[ERROR] <e>");
         return -1;
     }
 };

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -49,8 +49,7 @@ void() run(loc proj, str file, str oldName, str newName = "<oldName>2", int occu
     }
 };
 
-map[str, num] benchmarks(loc projDir) {
-    results = benchmark((
+map[str, num] benchmarkSingleRun(loc projDir) = benchmark((
         "[bird] nonterminal": run(birdProj(projDir), "src/main/rascal/lang/bird/Syntax.rsc", "TopLevelDecl", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] formal param": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "typeFormals", occurrence = 1, libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] global function": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "collectAnnos", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
@@ -64,7 +63,10 @@ map[str, num] benchmarks(loc projDir) {
       , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
       , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
     ));
-    iprintln(results);
 
-    return results;
+void benchmarks(loc projDir) {
+    println("First run (cold): ");
+    iprintln(benchmarkSingleRun(projDir));
+    println("Second run (warm): ");
+    iprintln(benchmarkSingleRun(projDir));
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -51,16 +51,16 @@ void() run(loc proj, str file, str oldName, str newName = "<oldName>2", int occu
 
 map[str, num] benchmarks(loc projDir) {
     results = benchmark((
-        // "[typepal] local var": run(typepalProj(projDir), "src/analysis/typepal/Solver.rsc", "facts", srcDirs = ["src"])
         "[bird] nonterminal": run(birdProj(projDir), "src/main/rascal/lang/bird/Syntax.rsc", "TopLevelDecl", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] formal param": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "typeFormals", occurrence = 1, libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] global function": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "collectAnnos", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
       , "[bird] local var": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "imported", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
-      , "[typepal] module name": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "analysis::typepal::Version", srcDirs = ["src"])
+      , "[bird] module name": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "lang::bird::Checker", libs = [|mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|])
+      , "[typepal] local var": run(typepalProj(projDir), "src/analysis/typepal/Solver.rsc", "facts", srcDirs = ["src"])
       , "[typepal] constructor": run(typepalProj(projDir), "src/analysis/typepal/Collector.rsc", "collector", srcDirs = ["src"])
       , "[typepal] global var": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "currentTplVersion", srcDirs = ["src"])
-      , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/ATypeUtils.rsc", "prettyAType")
-      , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc", "msgs")
+      , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/m3/AST.rsc", "astNodeSpecification")
+      , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e")
       , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
       , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
     ));

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -29,8 +29,10 @@ module lang::rascal::tests::rename::Benchmark
 import lang::rascal::tests::rename::ProjectOnDisk;
 
 import IO;
+import List;
 import Set;
 import util::Benchmark;
+import util::Math;
 import analysis::diff::edits::TextEdits;
 
 loc rascalProj(loc projDir) = projDir + "rascal";
@@ -60,11 +62,11 @@ map[str, num] benchmarks(loc projDir) = benchmark((
     //   , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e")
     //   , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
     //   , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
-), safeRuns(3, min, realTimeOf));
+), safeRuns(3, intMedian, realTimeOf));
 
-num(void()) safeRuns(int numRuns, &T(set[&T]) aggregate, int(void()) measure) = int(void() f) {
+num(void()) safeRuns(int numRuns, num(list[num]) aggregate, int(void()) measure) = int(void() f) {
     try {
-        return aggregate({measure(f) | _ <- [0..numRuns]});
+        return aggregate([measure(f) | _ <- [0..numRuns]]);
     } catch e: {
         println("[ERROR] <e>");
         return -1;
@@ -75,4 +77,22 @@ void cleanBenchmarkTargets(loc projDir) {
     for (loc d <- {rascalProj(projDir), typepalProj(projDir), birdProj(projDir)}) {
         remove(d + "target", recursive = true);
     }
+}
+
+int intMedian(list[num] nums) = toInt(median(nums));
+
+// Copied from analysis::statistics::Descriptive
+default real median(list[num] nums:[_, *_])
+	= mean(middle(nums));
+
+real mean(list[num] nums:[_, *_]) = toReal(sum(nums)) / size(nums);
+
+private list[&T] middle(list[&T] nums) {
+	nums = sort(nums);
+	n = size(nums);
+	if (n % 2 == 1) {
+		return [nums[n/2]];
+	}
+	n = n / 2;
+	return nums[n-1..n+1];
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -1,0 +1,66 @@
+@license{
+Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+}
+module lang::rascal::tests::rename::Benchmark
+
+import lang::rascal::tests::rename::ProjectOnDisk;
+
+import IO;
+import util::Benchmark;
+
+loc rascalProj(loc projDir) = projDir + "rascal";
+loc typepalProj(loc projDir) = projDir + "typepal";
+loc birdProj(loc projDir) = projDir + "../bird/bird-core";
+
+void() run(loc proj, str file, str oldName, str newName = "<oldName>2", int occ = 0, list[str] srcDirs = ["src/main/rascal"]) = void() {
+    println("Rename \'<oldName>\' in <proj + file>");
+    try {
+        testProjectOnDisk(proj, file, oldName, newName = newName, occurrence = occ, srcDirs = srcDirs);
+    } catch e: {
+        println("Renaming \'<oldName>\' to \'<newName>\' in <proj + file> resulted in error:");
+        println(e);
+    }
+};
+
+map[str, num] benchmarks(loc projDir) {
+    results = benchmark((
+        // "[typepal] local var": run(typepalProj(projDir), "src/analysis/typepal/Solver.rsc", "facts", srcDirs = ["src"])
+        "[bird] nonterminal": run(birdProj(projDir), "src/main/rascal/lang/bird/Syntax.rsc", "TopLevelDecl")
+      , "[bird] formal param": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "typeFormals")
+      , "[bird] global function": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "collectAnnos")
+      , "[bird] local var": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "imported")
+      , "[typepal] module name": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "analysis::typepal::Version", srcDirs = ["src"])
+      , "[typepal] constructor": run(typepalProj(projDir), "src/analysis/typepal/Collector.rsc", "collector", srcDirs = ["src"])
+      , "[typepal] global var": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "currentTplVersion", srcDirs = ["src"])
+    //   , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/ATypeUtils.rsc", "prettyAType")
+    //     "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/compiler/lang/rascalcore/check/Checker.rsc", "msgs")
+    //   , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
+    //   , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
+    ));
+    iprintln(results);
+
+    return results;
+}

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -66,7 +66,7 @@ test bool commonKeywordField() = testRenameOccurrences({0, 1, 2, 3}, "
     , skipCursors = {3}
 );
 
-test bool commonKeywordFieldFromOtherModule() = testRenameOccurrences({
+test bool commonKeywordFieldFromDefinition() = testRenameOccurrences({
     byText("Foo", "data D(int foo = 0, int baz = 0) = d();", {0})
   , byText("Bar",
         "import Foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Grammars.rsc
@@ -39,6 +39,11 @@ test bool productionConcreteType() = testRenameOccurrences({0, 1, 2, 3, 4}, "
 ", decls = "syntax Foo = Foo child;"
 , oldName = "Foo", newName = "Bar");
 
+test bool productionConcreteArgument() = testRenameOccurrences({1, 2}, "
+    'Foo func((Foo) `\<Foo foo\>`) = foo;
+", decls = "syntax Foo = Foo foo;"
+);
+
 test bool productionPattern() = testRenameOccurrences({0, 1, 2}, "
     'Tree t;
     'if (/Foo f := t) x = f;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -34,7 +34,7 @@ import lang::rascalcore::check::Checker;
 
 import analysis::diff::edits::TextEdits;
 
-tuple[list[DocumentEdit], set[Message]] testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"]) {
+tuple[list[DocumentEdit], set[Message]] testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) {
     PathConfig pcfg;
     if (projectDir.file == "rascal-core") {
         pcfg = getRascalCorePathConfig(projectDir);
@@ -43,13 +43,14 @@ tuple[list[DocumentEdit], set[Message]] testProjectOnDisk(loc projectDir, str fi
             srcs = [ projectDir + "src/org/rascalmpl/library"
                    , projectDir + "src/org/rascalmpl/compiler"
                    , projectDir + "test/org/rascalmpl/benchmark"],
-            bin = projectDir + "target/classes"
+            bin = projectDir + "target/classes",
+            libs = libs
         );
     } else {
         pcfg = pathConfig(
             srcs = [projectDir + dir | dir <- srcDirs],
             bin = projectDir + "target/classes",
-            libs = [calculateRascalLib(), |jar+mvn://org/rascalmpl/typepal/0.15.1/typepal-0.15.1.jar|]
+            libs = [calculateRascalLib(), *libs]
         );
     }
     // extension for Rascal compiler

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -34,7 +34,7 @@ import lang::rascalcore::check::Checker;
 
 import analysis::diff::edits::TextEdits;
 
-tuple[list[DocumentEdit], set[Message]] testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) {
+Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) {
     PathConfig pcfg;
     if (projectDir.file == "rascal-core") {
         pcfg = getRascalCorePathConfig(projectDir);

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -34,21 +34,22 @@ import lang::rascalcore::check::Checker;
 
 import analysis::diff::edits::TextEdits;
 
-tuple[list[DocumentEdit], set[Message]] testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new") {
+tuple[list[DocumentEdit], set[Message]] testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"]) {
     PathConfig pcfg;
     if (projectDir.file == "rascal-core") {
         pcfg = getRascalCorePathConfig(projectDir);
     } else if (projectDir.file == "rascal") {
         pcfg = pathConfig(
             srcs = [ projectDir + "src/org/rascalmpl/library"
+                   , projectDir + "src/org/rascalmpl/compiler"
                    , projectDir + "test/org/rascalmpl/benchmark"],
             bin = projectDir + "target/classes"
         );
     } else {
         pcfg = pathConfig(
-            srcs = [ projectDir + "src" ],
+            srcs = [projectDir + dir | dir <- srcDirs],
             bin = projectDir + "target/classes",
-            libs = [calculateRascalLib()]
+            libs = [calculateRascalLib(), |jar+mvn://org/rascalmpl/typepal/0.15.1/typepal-0.15.1.jar|]
         );
     }
     // extension for Rascal compiler

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -51,6 +51,7 @@ import util::FileSystem;
 import util::LanguageServer;
 import util::Math;
 import util::Maybe;
+import util::Monitor;
 import util::Reflective;
 import util::Util;
 
@@ -269,8 +270,14 @@ void throwMessagesIfError(set[Message] msgs) {
 }
 
 Edits getEdits(loc singleModule, set[loc] projectDirs, int cursorAtOldNameOccurrence, str oldName, str newName, PathConfig(loc) getPathConfig) {
+    j = "Testing renaming <cursorAtOldNameOccurrence>th occurrence of \'<oldName>\' in <singleModule>";
+    jobStart(j, totalWork = 3);
+    jobStep(j, "Finding cursor focus tree");
     <cursor, focus> = findCursor(singleModule, oldName, cursorAtOldNameOccurrence);
-    return rascalRenameSymbol(cursor, focus, newName, projectDirs, getPathConfig);
+    jobStep(j, "Performing renaming");
+    res =  rascalRenameSymbol(cursor, focus, newName, projectDirs, getPathConfig);
+    jobEnd(j);
+    return res;
 }
 
 tuple[Edits, set[int]] getEditsAndOccurrences(loc singleModule, loc projectDir, int cursorAtOldNameOccurrence, str oldName, str newName, PathConfig pcfg = getTestPathConfig(projectDir)) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/TestUtils.rsc
@@ -320,19 +320,19 @@ private tuple[Edits, set[int]] getEditsAndModule(str stmtsStr, int cursorAtOldNa
 private set[str] reservedNames = getRascalReservedIdentifiers();
 str forceUnescapeNames(str name) = replaceAll(name, "\\", "");
 str escapeReservedNames(str name, str sep = "::") = intercalate(sep, [n in reservedNames ? "\\<n>" : n | n <- split(sep, name)]);
-str reEscape(str name) = escapeReservedNames(forceUnescapeNames(name));
+str normalizeEscaping(str name) = escapeReservedNames(forceUnescapeNames(name));
 
 private lrel[int, loc, Maybe[Tree]] collectNameTrees(start[Module] m, str name) {
     lrel[loc, Maybe[Tree]] names = [];
-    sname = reEscape(name);
+    sname = normalizeEscaping(name);
     top-down-break visit (m) {
         case QualifiedName qn: {
-            if (reEscape("<qn>") == sname) {
+            if (normalizeEscaping("<qn>") == sname) {
                 names += <qn.src, just(qn)>;
             }
             else {
                 modPrefix = prefix([n | n <- qn.names]);
-                if ([_, *_] := modPrefix && reEscape(intercalate("::", ["<n>" | n <- modPrefix])) == sname) {
+                if ([_, *_] := modPrefix && normalizeEscaping(intercalate("::", ["<n>" | n <- modPrefix])) == sname) {
                     names += <cover([n.src | n <- modPrefix]), nothing()>;
                 } else {
                     fail;
@@ -341,13 +341,13 @@ private lrel[int, loc, Maybe[Tree]] collectNameTrees(start[Module] m, str name) 
         }
         // 'Normal' names
         case Name n:
-            if (reEscape("<n>") == sname) names += <n.src, just(n)>;
+            if (normalizeEscaping("<n>") == sname) names += <n.src, just(n)>;
         // Nonterminals (grammars)
         case Nonterminal s:
-            if (reEscape("<s>") == sname) names += <s.src, just(s)>;
+            if (normalizeEscaping("<s>") == sname) names += <s.src, just(s)>;
         // Labels for nonterminals (grammars)
         case NonterminalLabel label:
-            if (reEscape("<label>") == sname) names += <label.src, just(label)>;
+            if (normalizeEscaping("<label>") == sname) names += <label.src, just(label)>;
     }
 
     return [<i, l, mt> | <i, <l, mt>> <- zip2(index(names), names)];

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ValidNames.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ValidNames.rsc
@@ -39,6 +39,10 @@ test bool renameToReservedName() {
     return newNames == {"\\int"};
 }
 
+test bool renameFromMinusName() = testRenameOccurrences({0}, "int \\foo-bar = 0;", oldName = "foo-bar");
+
+test bool renameToMinusName() = testRenameOccurrences({0}, "int foo = 0;", newName = "foo-bar");
+
 test bool renameToUnescapedQualifiedName() = testRenameOccurrences({
     byText("FooSyntax", "syntax S = \"s\";", {0}, newName = "syntax::Foo"),
     byText("Main", "


### PR DESCRIPTION
This PR implements benchmarking on some existing projects and fixes a couple of bugs that came up when running renamings on those projects.

Baseline benchmarks

| project | role of name under cursor | elapsed time (3 runs, median, in seconds) |
|---------|------------------------------|-----------------------------------------|
| bird | local var | 86 |
| bird | global function | 321 |
| bird | formal param | 3 |
| bird | nonterminal | 639 |
| bird | module name | 163 |
| typepal | local var | 41 |
| typepal | constructor | 311 |
| typepal | global var | 1 |
| rascal | function | (not ran) |
| rascal | local var | (not ran) |
| rascal | type param | (not ran) |
| rascal | nonterminal label | (not ran) |
| rascal | grammar constructor | (not ran) |