### PR TITLE
Workaround for flaky UI test

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -582,7 +582,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     @Override
-    public void registerLanguage(LanguageParameter lang) {
+    public synchronized void registerLanguage(LanguageParameter lang) {
         logger.info("registerLanguage({})", lang.getName());
 
         for (var extension: lang.getExtensions()) {
@@ -626,7 +626,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     @Override
-    public void unregisterLanguage(LanguageParameter lang) {
+    public synchronized void unregisterLanguage(LanguageParameter lang) {
         boolean removeAll = lang.getMainModule() == null || lang.getMainModule().isEmpty();
         if (!removeAll) {
             if (!contributions.get(lang.getName()).removeContributor(buildContributionKey(lang))) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -104,7 +104,7 @@ public class Diagnostics {
         List<Template> diagnostics = new ArrayList<>();
 
         // Highlight selected parts of the error tree
-        if (ERROR_LOCATION_HIGHLIGHT != null) { // NOSONAR
+        if (ERROR_LOCATION_HIGHLIGHT != null) {
             // Just the error location
             ISourceLocation errorLoc = factory.sourceLocation(skippedLoc,
                     skippedLoc.getOffset(), 1,
@@ -114,12 +114,12 @@ public class Diagnostics {
                     ERROR_LOCATION_HIGHLIGHT, "parser"));
         }
 
-        if (ERROR_TREE_HIGHLIGHT != null) { // NOSONAR
+        if (ERROR_TREE_HIGHLIGHT != null) {
             // The whole error tree
             diagnostics.add(cm -> new Diagnostic(toRange(errorTreeLoc, cm), "Recovered parse error", ERROR_TREE_HIGHLIGHT, "parser"));
         }
 
-        if (PREFIX_HIGHLIGHT != null) { // NOSONAR
+        if (PREFIX_HIGHLIGHT != null) {
             // The recognized prefix
             int prefixLength = skippedLoc.getOffset()-errorTreeLoc.getOffset();
             if (prefixLength > 0) {
@@ -131,7 +131,7 @@ public class Diagnostics {
             }
         }
 
-        if (SKIPPED_HIGHLIGHT != null && skippedLoc.getLength() > 0) { // NOSONAR
+        if (SKIPPED_HIGHLIGHT != null && skippedLoc.getLength() > 0) {
             // The skipped part
             diagnostics.add(cm -> new Diagnostic(toRange(skippedLoc, cm), "Recovered parse error skipped", SKIPPED_HIGHLIGHT, "parser"));
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -104,7 +104,7 @@ public class Diagnostics {
         List<Template> diagnostics = new ArrayList<>();
 
         // Highlight selected parts of the error tree
-        if (ERROR_LOCATION_HIGHLIGHT != null) {
+        if (ERROR_LOCATION_HIGHLIGHT != null) { // NOSONAR
             // Just the error location
             ISourceLocation errorLoc = factory.sourceLocation(skippedLoc,
                     skippedLoc.getOffset(), 1,
@@ -114,12 +114,12 @@ public class Diagnostics {
                     ERROR_LOCATION_HIGHLIGHT, "parser"));
         }
 
-        if (ERROR_TREE_HIGHLIGHT != null) {
+        if (ERROR_TREE_HIGHLIGHT != null) { // NOSONAR
             // The whole error tree
             diagnostics.add(cm -> new Diagnostic(toRange(errorTreeLoc, cm), "Recovered parse error", ERROR_TREE_HIGHLIGHT, "parser"));
         }
 
-        if (PREFIX_HIGHLIGHT != null) {
+        if (PREFIX_HIGHLIGHT != null) { // NOSONAR
             // The recognized prefix
             int prefixLength = skippedLoc.getOffset()-errorTreeLoc.getOffset();
             if (prefixLength > 0) {
@@ -131,7 +131,7 @@ public class Diagnostics {
             }
         }
 
-        if (SKIPPED_HIGHLIGHT != null && skippedLoc.getLength() > 0) {
+        if (SKIPPED_HIGHLIGHT != null && skippedLoc.getLength() > 0) { // NOSONAR
             // The skipped part
             diagnostics.add(cm -> new Diagnostic(toRange(skippedLoc, cm), "Recovered parse error skipped", SKIPPED_HIGHLIGHT, "parser"));
         }

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -201,8 +201,6 @@ Register the Pico language and the contributions that supply the IDE with featur
 Any feedback (errors and exceptions) is faster and more clearly printed in the terminal.
 }
 void main(bool errorRecovery=false) {
-    // since error recovery has an influence on which contributor we register, we have to unregister all existing registrations
-    unregisterLanguage("Pico", {"pico", "pico-new"});
     registerLanguage(
         language(
             pathConfig(),

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/OldStyleLanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/OldStyleLanguageServer.rsc
@@ -183,8 +183,6 @@ Register the Pico language and the contributions that supply the IDE with featur
 Any feedback (errors and exceptions) is faster and more clearly printed in the terminal.
 }
 void main(bool errorRecovery=false) {
-    // since error recovery has an influence on which contributor we register, we have to unregister all existing registrations
-    unregisterLanguage("Pico", {"pico", "pico-new"});
     registerLanguage(
         language(
             pathConfig(),


### PR DESCRIPTION
#### This PR...

...provides a workaround for a flaky UI test.

#### Background

The feature PR (#490) to integrate error recovery into the VS Code extension runs (some of) the UI tests first **without** error recovery and then **with** error recovery. Between without/with, Pico needs to be unregistered. This unregistration is new in the feature PR. However, it turns out there are races between unregistration/registration of DSLs that manifest when executed quickly in succession, as reported in #630. As a result, the UI test sometimes fails.

Note: The race exists already in `main`, so it's beyond the scope of the feature PR to fix it. However, unlike `main`, the feature PR triggers the race (because of the new unregistration, which doesn't exist in `main`). To make sure the workflow reliably succeeds in the feature PR, at least a workaround is needed for now.

Note: The workflow sometimes fails for another UI test, but it's very very flaky. I've been able to trigger the same failure locally in `main` as well, so it's not directly related to error recovery. See #638.
