### PR TITLE
[Renaming] Optimize performance

### DIFF
--- a/rascal-lsp/src/main/rascal/framework/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/framework/Rename.rsc
@@ -113,6 +113,9 @@ RenameResult rename(
     }
 
     @memo{maximumSize(50)}
+    TModel getTModelForLocCached(loc l) = config.tmodelForLoc(l);
+
+    @memo{maximumSize(50)}
     Tree parseLocCached(loc l) {
         // We already have the parse tree of the module under cursor
         if (l == cursor[-1].src.top) {
@@ -128,7 +131,11 @@ RenameResult rename(
     }
 
     // Make sure user uses cached functions
-    cachedConfig = config[parseLoc = parseLocCached][tmodelForTree = getTModelCached];
+    cachedConfig = config
+        [parseLoc = parseLocCached]
+        [tmodelForTree = getTModelCached]
+        [tmodelForLoc = getTModelForLocCached]
+        ;
 
     // Messages
     set[FailMessage] messages = {};

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -316,7 +316,7 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) _, TModel(Tree) _,
         } else if (defs: {_, *_} := tm.useDef[c.src]) {
             // Cursor at use
             cursorDefs = flatMapPerFile(defs, set[Define](loc f, set[loc] localDefs) {
-                localTm = r.getConfig().augmentedTModelForLoc(f, r);
+                localTm = f == cursorLoc.top ? tm : r.getConfig().augmentedTModelForLoc(f, r);
                 return {localTm.definitions[d] | loc d <- localDefs};
             });
         } else {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -319,15 +319,21 @@ private set[Define] tryGetCursorDefinitions(list[Tree] cursor, TModel(loc) getMo
             });
         }
 
+        bool isDefNameInFocus(Tree name)
+            = any(t <- [*pre, c], name.src == t.src) && forceUnescapeNames("<name>") in cursorDefs.id;
+
         // Check if the name of the found declaration(s) actually appears in the focus list.
         // If this is not the case, we went too far up.
         if (cursorDefs != {}) {
             visit (c) {
-                case Tree tr: {
-                    if (any(t <- [*pre, c], tr.src == t.src) && reEscape("<tr>") in cursorDefs.id) return cursorDefs;
+                case Name tr: if (isDefNameInFocus(tr)) return cursorDefs;
+                case QualifiedName tr: {
+                    if (tr.names[0].src == tr.src) fail; // skip unqualified names
+                    if (isDefNameInFocus(tr)) return cursorDefs;
                 }
+                case Nonterminal tr: if (isDefNameInFocus(tr)) return cursorDefs;
+                case NonterminalLabel tr: if (isDefNameInFocus(tr)) return cursorDefs;
             }
-            return {};
         }
         // Try next cursor candidate in focus list
         fail;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -305,9 +305,12 @@ set[Define] getCursorDefinitions(list[Tree] cursor, Tree(loc) _, TModel(Tree) _,
         if (tm.definitions[c.src]?) {
             // Cursor at definition
             cursorDefs = {tm.definitions[c.src]};
-        } else if (useDefs: {_, *_} := tm.useDef[c.src]) {
+        } else if (defs: {_, *_} := tm.useDef[c.src]) {
             // Cursor at use
-            cursorDefs = {defTm.definitions[d] | loc d <- useDefs, defTm := r.getConfig().augmentedTModelForLoc(d.top, r)};
+            cursorDefs = flatMapPerFile(defs, set[Define](loc f, set[loc] localDefs) {
+                localTm = r.getConfig().augmentedTModelForLoc(f, r);
+                return {localTm.definitions[d] | loc d <- localDefs};
+            });
         } else {
             // Try next cursor candidate in focus list
             fail;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -267,6 +267,7 @@ public Edits rascalRenameSymbol(loc cursorLoc, list[Tree] cursor, str newName, s
         Augment the TModel with 'missing' use/def information.
         Workaround until the typechecker generates this. https://github.com/usethesource/rascal/issues/2172
     }
+    @memo{maximumSize(100), expireAfter(minutes=5)}
     TModel augmentTModel(loc l, Renamer r) {
         TModel getModel(loc f) = f.top == l.top ? tm : r.getConfig().tmodelForLoc(f);
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -157,7 +157,7 @@ void rascalCheckCausesDoubleDeclarations(Define cD, str newName, TModel tm, Rena
     }
 }
 
-void rascalCheckDefinitionOutsideWorkspace(Define d, TModel tm, Renamer r) {
+void rascalCheckDefinitionOutsideWorkspace(Define d, Renamer r) {
     f = d.defined.top;
     pcfg = r.getConfig().getPathConfig(f);
     if (!any(srcFolder <- pcfg.srcs, isPrefixOf(srcFolder, f))) {
@@ -335,15 +335,15 @@ void validateNewNameOccurrences(set[Define] cursorDefs, str newName, Tree tr, Re
     }
 }
 
-default void renameDefinitionUnchecked(Define _, loc nameLoc, str newName, TModel _, Renamer r) {
+default void renameDefinitionUnchecked(Define _, loc nameLoc, str newName, Renamer r) {
     r.textEdit(replace(nameLoc, newName));
 }
 
-void renameDefinition(Define d, loc nameLoc, str newName, TModel tm, Renamer r) {
+void renameDefinition(Define d, loc nameLoc, str newName, TModel _, Renamer r) {
     rascalCheckLegalNameByRole(d, newName, r);
-    rascalCheckDefinitionOutsideWorkspace(d, tm, r);
+    rascalCheckDefinitionOutsideWorkspace(d, r);
 
-    renameDefinitionUnchecked(d, nameLoc, reEscape(newName), tm, r);
+    renameDefinitionUnchecked(d, nameLoc, reEscape(newName), r);
 }
 
 private loc nameSuffix(loc l, set[Define] defs, Renamer r) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -36,6 +36,7 @@ import lang::rascalcore::check::Import;
 import lang::rascalcore::check::RascalConfig;
 import lang::rascalcore::check::BasicRascalConfig;
 
+import IO;
 import List;
 import Location;
 import Map;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -112,6 +112,8 @@ bool(Tree) singleNameFilter(str name) {
 
     return bool(Tree tr) {
         visit (tr) {
+            // Replace patterns with `n1` etc. once this issue is solved
+            // https://github.com/usethesource/rascal/issues/2147
             case (Name) `<Name n>`: if (n := n1 || n := en1) return true;
             case (Nonterminal) `<Nonterminal n>`: if (n := nt1 || n := ent1) return true;
             case (NonterminalLabel) `<NonterminalLabel n>`: if (n := ntl1 || n := entl1) return true;
@@ -146,6 +148,8 @@ tuple[bool, bool](Tree) twoNameFilter(str name1, str name2) {
         bool has1 = false;
         bool has2 = false;
         visit (tr) {
+            // Replace patterns with `n1` and `n2` once this issue is solved
+            // https://github.com/usethesource/rascal/issues/2147
             case (Name) `<Name n>`: {
                 if (!has1 && n := n1) {
                     if (has2) return <true, true>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -203,7 +203,7 @@ bool(Tree) anyNameFilter(set[str] names) {
 
     return bool(Tree tr) {
         visit (tr) {
-            case (Name) `<Name n>`: for (n1 <- escNames, n := n1) return true;
+            case (Name) `<Name n>`: for (n <- escNames) return true;
             case (Nonterminal) `<Nonterminal n>`: for (nt1 <- escNonterminals, n := nt1) return true;
             case (NonterminalLabel) `<NonterminalLabel n>`: for (ntl1 <- escNonterminalLabels, n := ntl1) return true;
             case (QualifiedName) `<QualifiedName n>`: {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -52,6 +52,7 @@ import util::Util;
 data RenameConfig(
     set[loc] workspaceFolders = {}
   , PathConfig(loc) getPathConfig = PathConfig(loc l) { throw "No path config for <l>"; }
+  , TModel(loc, Renamer) augmentedTModelForLoc = TModel(loc l, Renamer r) { throw "Not implemented."; }
 );
 
 data ChangeAnnotation = changeAnnotation(str label, str description, bool needsConfirmation = false);

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
@@ -78,15 +78,4 @@ set[Define] findAdditionalConstructorDefinitions(set[Define] cursorDefs, Tree tr
     });
 }
 
-set[Define] findConstructorDefinitions(set[Define] adtDefs, Renamer r) {
-    // Find all constructors with the same name in these ADT definitions
-    return flatMapPerFile(adtDefs, set[Define](loc f, set[Define] fileDefs) {
-        fileTm = r.getConfig().tmodelForLoc(f);
-        return {fileTm.definitions[d]
-            | loc d <- (fileTm.defines<idRole, defined>)[constructorId()]
-            , any(adt <- fileDefs.defined, isContainedIn(d, adt))
-        };
-    });
-}
-
 tuple[type[Tree] as, str desc] asType(constructorId()) = <#NonterminalLabel, "constructor name">;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
@@ -48,7 +48,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] def
         r.error(cursor[0], "Cannot find files for constructor definitions with multiple names (<defs.id>)");
         return <{}, {}, {}>;
     }
-    <curFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, containsNameCheck, getTree);
+    <curFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, getTree);
 
     return <curFiles, curFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
@@ -48,8 +48,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] def
         r.error(cursor[0], "Cannot find files for constructor definitions with multiple names (<defs.id>)");
         return <{}, {}, {}>;
     }
-
-    <curFiles, newFiles> = filterFiles(getSourceFiles(r), allNameSortsFilter("<cursor[0]>", newName), getTree);
+    <curFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
 
     return <curFiles, curFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Constructors.rsc
@@ -48,7 +48,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] def
         r.error(cursor[0], "Cannot find files for constructor definitions with multiple names (<defs.id>)");
         return <{}, {}, {}>;
     }
-    <curFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
+    <curFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, containsNameCheck, getTree);
 
     return <curFiles, curFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
@@ -50,12 +50,12 @@ set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, IdRole r
     findAdditionalDataLikeDefinitions(cursorDefs, tm, r)
     when role in syntaxRoles;
 
-void renameDefinitionUnchecked(Define d: <_, _, _, nonterminalId(), _, _>, loc _, str _, TModel _, Renamer _) {
+void renameDefinitionUnchecked(Define d: <_, _, _, nonterminalId(), _, _>, loc _, str _, Renamer _) {
     // Do not register an edit for the definition, as it will appear as a use again
     // TODO Rascal Core: why register the name of a production definition as a use of itself?
 }
 
-void renameDefinitionUnchecked(Define d: <_, _, _, lexicalId(), _, _>, loc _, str _, TModel _, Renamer _) {
+void renameDefinitionUnchecked(Define d: <_, _, _, lexicalId(), _, _>, loc _, str _, Renamer _) {
     // Do not register an edit for the definition, as it will appear as a use again
     // TODO Rascal Core: why register the name of a production definition as a use of itself?
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,36 +49,68 @@ import util::Util;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<_, str curModName, _, moduleId(), loc d, _>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    loc modFile = d.top;
+@memo list[Name] asNames(QualifiedName qn) = [n | Name n <- qn.names];
+
+tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<_, str defName, _, moduleId(), loc d, _>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
+    // if (getModuleLocation(reEscape(newName), r.getConfig().getPathConfig()))
+
     set[loc] useFiles = {};
     set[loc] newFiles = {};
 
-    modName = [QualifiedName] curModName;
+    modName = reEscape(defName);
+    modNameTree = [QualifiedName] modName;
     newModName = reEscape(newName);
+    newModNameTree = [QualifiedName] newModName;
+
+    modNameNumberOfNames = size(findAll(modName, "::")) + 1;
+    newModNameNumberOfNames = size(findAll(newModName, "::")) + 1;
+
+    try {
+        loc oldLoc = getModuleLocation(modName, r.getConfig().getPathConfig(d.top));
+        loc newLoc = getModuleLocation(newModName, r.getConfig().getPathConfig(d.top));
+        if (oldLoc != newLoc) {
+            r.error(d, "Cannot rename, since module \'<newModName>\' already exists at <newLoc>");
+            return <{}, {}, {}>;
+        }
+    } catch _: {;}
 
     for (loc f <- getSourceFiles(r)) {
-        bottom-up-break visit (getTree(f)) {
-            case modName: {
+        m = getTree(f);
+
+        bool markedNew = false;
+        bool markedUse = false;
+
+        top-down-break visit (m.top.header.imports) {
+            case modNameTree: {
                 // Import of exact module name
                 useFiles += f;
+                markedUse = true;
             }
+        }
+        bottom-up-break visit(m) {
             case QualifiedName qn: {
                 // Import of redundantly escaped module name
-                escQn = reEscape("<qn>");
-                if (curModName == escQn) useFiles += f;
-                else if (newModName == escQn) newFiles += f;
-                else {
-                    // Qualified use of declaration in module
-                    // If through extends, there might be no import
-                    qualPref = reEscape(qualifiedPrefix(qn).name);
-                    if (qualPref == curModName) useFiles += f;
-                    if (qualPref == newModName) newFiles += f;
+                qnSize = size(asNames(qn));
+                if (qnSize == modNameNumberOfNames && modName == reEscape("<qn>")) {
+                    useFiles += f;
+                    markedUse = true;
                 }
+                else if (qnSize == modNameNumberOfNames + 1 || qnSize == newModNameNumberOfNames + 1) {
+                    qualPref = qualifiedPrefix(qn);
+                    if (qualPref.name == modName || reEscape(qualPref.name) == modName) {
+                        useFiles += f;
+                        markedUse = true;
+                    }
+                    else if (qualPref.name == newModName || reEscape(qualPref.name) == newModName) {
+                        newFiles += f;
+                        markedNew = true;
+                    }
+                }
+                if (markedUse && markedNew) continue;
             }
         }
     }
-    return <{modFile}, useFiles, newFiles>;
+    return <{d.top}, useFiles, newFiles>;
 }
 
 bool isUnsupportedCursor(list[Tree] _:[*_, QualifiedName _, i:Import _, _, Header _, *_], Renamer r) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -86,7 +86,7 @@ bool isUnsupportedCursor(list[Tree] _:[*_, QualifiedName _, i:Import _, _, Heade
     return true;
 }
 
-void renameDefinitionUnchecked(Define d:<_, currentName, _, moduleId(), _, _>, loc nameLoc, str newName, TModel tm, Renamer r) {
+void renameDefinitionUnchecked(Define d:<_, currentName, _, moduleId(), _, _>, loc nameLoc, str newName, Renamer r) {
     r.textEdit(replace(nameLoc, newName));
 
     // Additionally, we rename the file

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -49,8 +49,6 @@ import util::Util;
 
 tuple[type[Tree] as, str desc] asType(moduleId()) = <#QualifiedName, "module name">;
 
-@memo list[Name] asNames(QualifiedName qn) = [n | Name n <- qn.names];
-
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<_, str defName, _, moduleId(), loc d, _>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     // if (getModuleLocation(reEscape(newName), r.getConfig().getPathConfig()))
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Parameters.rsc
@@ -44,7 +44,7 @@ bool isFormalId(IdRole role) = role in formalRoles;
 tuple[type[Tree] as, str desc] asType(IdRole idRole) = <#Name, "formal parameter name"> when isFormalId(idRole);
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, IdRole role, _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>
+    <{scope.top}, {scope.top}, singleNameFilter(newName)(cursor[-1]) ? {scope.top} : {}>
     when role in positionalFormalRoles;
 
 @synopsis{Add use/def relations for keyword function parameters, until they exist in the TModel.}

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -55,14 +55,14 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
 
     sourceFiles = getSourceFiles(r);
 
-    <curAdtFiles, newFiles> = filterFiles(sourceFiles, "<cursor[0]>", newName, containsNameCheck, getTree);
+    <curAdtFiles, newFiles> = filterFiles(sourceFiles, "<cursor[0]>", newName, getTree);
 
     consIds = flatMapPerFile(defs, set[str](loc f, set[Define] localDataDefs) {
         localTm = r.getConfig().tmodelForLoc(f);
         return {consId | <Define _:<_, _, _, _, _, defType(AType adtType)>, Define _:<_, str consId, _, constructorId(), _, defType(acons(adtType, _, _))>> <- localDataDefs * localTm.defines};
     });
 
-    consFiles = filterFiles(sourceFiles, consIds, containsNameCheck, getTree);
+    consFiles = filterFiles(sourceFiles, consIds, getTree);
 
     return <curAdtFiles + consFiles, curAdtFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -55,11 +55,10 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
 
     <curAdtFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
 
-    consIds = {consId
-        | Define _:<_, _, _, _, loc dataDef, defType(AType adtType)> <- defs
-        , tm := r.getConfig().tmodelForLoc(dataDef.top)
-        , Define _:<_, str consId, _, constructorId(), _, defType(acons(adtType, _, _))> <- tm.defines
-    };
+    consIds = flatMapPerFile(defs, set[str](loc f, set[Define] localDataDefs) {
+        localTm = r.getConfig().tmodelForLoc(f);
+        return {consId | <Define _:<_, _, _, _, _, defType(AType adtType)>, Define _:<_, str consId, _, constructorId(), _, defType(acons(adtType, _, _))>> <- localDataDefs * localTm.defines};
+    });
 
     consFiles = {*filterFiles(getSourceFiles(r), consId, singleNameFilter, getTree) | consId <- consIds};
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -55,14 +55,14 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
 
     sourceFiles = getSourceFiles(r);
 
-    <curAdtFiles, newFiles> = filterFiles(sourceFiles, "<cursor[0]>", newName, twoNameFilter, getTree);
+    <curAdtFiles, newFiles> = filterFiles(sourceFiles, "<cursor[0]>", newName, containsNameCheck, getTree);
 
     consIds = flatMapPerFile(defs, set[str](loc f, set[Define] localDataDefs) {
         localTm = r.getConfig().tmodelForLoc(f);
         return {consId | <Define _:<_, _, _, _, _, defType(AType adtType)>, Define _:<_, str consId, _, constructorId(), _, defType(acons(adtType, _, _))>> <- localDataDefs * localTm.defines};
     });
 
-    consFiles = filterFiles(sourceFiles, consIds, anyNameFilter, getTree);
+    consFiles = filterFiles(sourceFiles, consIds, containsNameCheck, getTree);
 
     return <curAdtFiles + consFiles, curAdtFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -45,7 +45,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] def
     findDataLikeOccurrenceFilesUnchecked(defs, cursor, newName, getTree, r);
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, typeVarId(), _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
+    <{scope.top}, {scope.top}, singleNameFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
 
 public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(set[Define] defs, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
     if (size(defs.id) > 1) {
@@ -53,7 +53,7 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
         return <{}, {}, {}>;
     }
 
-    <curAdtFiles, newFiles> = filterFiles(getSourceFiles(r), allNameSortsFilter("<cursor[0]>", newName), getTree);
+    <curAdtFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
 
     consIds = {consId
         | Define _:<_, _, _, _, loc dataDef, defType(AType adtType)> <- defs
@@ -61,7 +61,7 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
         , Define _:<_, str consId, _, constructorId(), _, defType(acons(adtType, _, _))> <- tm.defines
     };
 
-    consFiles = {*filterFiles(getSourceFiles(r), allNameSortsFilter(consId), getTree) | consId <- consIds};
+    consFiles = {*filterFiles(getSourceFiles(r), consId, singleNameFilter, getTree) | consId <- consIds};
 
     return <curAdtFiles + consFiles, curAdtFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -53,14 +53,16 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
         return <{}, {}, {}>;
     }
 
-    <curAdtFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
+    sourceFiles = getSourceFiles(r);
+
+    <curAdtFiles, newFiles> = filterFiles(sourceFiles, "<cursor[0]>", newName, twoNameFilter, getTree);
 
     consIds = flatMapPerFile(defs, set[str](loc f, set[Define] localDataDefs) {
         localTm = r.getConfig().tmodelForLoc(f);
         return {consId | <Define _:<_, _, _, _, _, defType(AType adtType)>, Define _:<_, str consId, _, constructorId(), _, defType(acons(adtType, _, _))>> <- localDataDefs * localTm.defines};
     });
 
-    consFiles = {*filterFiles(getSourceFiles(r), consId, singleNameFilter, getTree) | consId <- consIds};
+    consFiles = filterFiles(sourceFiles, consIds, anyNameFilter, getTree);
 
     return <curAdtFiles + consFiles, curAdtFiles, newFiles>;
 }

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -46,7 +46,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
 tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable name">;
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, moduleVariableId(), _, defType(_, vis=privateVis())>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    <curUseFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
+    <curUseFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, containsNameCheck, getTree);
     return <{scope.top}, curUseFiles, newFiles>;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -40,13 +40,13 @@ import util::Maybe;
 tuple[type[Tree] as, str desc] asType(variableId()) = <#Name, "variable name">;
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, variableId(), _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
+    <{scope.top}, {scope.top}, singleNameFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
 
 // Global variables
 tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable name">;
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, moduleVariableId(), _, defType(_, vis=privateVis())>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    <curUseFiles, newFiles> = filterFiles(getSourceFiles(r), allNameSortsFilter("<cursor[0]>", newName), getTree);
+    <curUseFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, twoNameFilter, getTree);
     return <{scope.top}, curUseFiles, newFiles>;
 }
 
@@ -54,4 +54,4 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
 tuple[type[Tree] as, str desc] asType(patternVariableId()) = <#Name, "pattern variable name">;
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, patternVariableId(), _, _>}, list[Tree] cursor, str newName, Tree(loc) _, Renamer _) =
-    <{scope.top}, {scope.top}, allNameSortsFilter(newName)(cursor[-1]) ? {scope.top} : {}>;
+    <{scope.top}, {scope.top}, singleNameFilter(newName)(cursor[-1]) ? {scope.top} : {}>;

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Variables.rsc
@@ -46,7 +46,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
 tuple[type[Tree] as, str desc] asType(moduleVariableId()) = <#Name, "variable name">;
 
 tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{<loc scope, _, _, moduleVariableId(), _, defType(_, vis=privateVis())>}, list[Tree] cursor, str newName, Tree(loc) getTree, Renamer r) {
-    <curUseFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, containsNameCheck, getTree);
+    <curUseFiles, newFiles> = filterFiles(getSourceFiles(r), "<cursor[0]>", newName, getTree);
     return <{scope.top}, curUseFiles, newFiles>;
 }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -55,14 +55,15 @@ map[str, num] benchmarks(loc projDir) = benchmark((
       , "[bird] global function": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "collectAnnos", libs = [typepalLib])
       , "[bird] local var": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "imported", libs = [typepalLib])
       , "[bird] module name": run(birdProj(projDir), "src/main/rascal/lang/bird/Checker.rsc", "lang::bird::Checker", libs = [typepalLib])
+      , "[bird] module name": run(birdProj(projDir), "src/main/rascal/lang/bird/Syntax.rsc", "Expr", libs = [typepalLib])
       , "[typepal] local var": run(typepalProj(projDir), "src/analysis/typepal/Solver.rsc", "facts", srcDirs = ["src"])
       , "[typepal] constructor": run(typepalProj(projDir), "src/analysis/typepal/Collector.rsc", "collector", srcDirs = ["src"])
       , "[typepal] global var": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "currentTplVersion", srcDirs = ["src"])
-      , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/m3/AST.rsc", "astNodeSpecification")
-      , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e")
-      , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
-      , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
-      , "[rascal] nonterminal label": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "lhs", newName = "lefthandside")
+      , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/m3/AST.rsc", "astNodeSpecification", libs = [typepalLib])
+      , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e", libs = [typepalLib])
+      , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K", libs = [typepalLib])
+      , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure", libs = [typepalLib])
+    //   , "[rascal] nonterminal label": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "lhs", newName = "lefthandside", libs = [typepalLib])
 ), safeRuns(3, intMedian, realTimeOf));
 
 num(void()) safeRuns(int numRuns, num(list[num]) aggregate, int(void()) measure) = int(void() f) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -58,10 +58,11 @@ map[str, num] benchmarks(loc projDir) = benchmark((
       , "[typepal] local var": run(typepalProj(projDir), "src/analysis/typepal/Solver.rsc", "facts", srcDirs = ["src"])
       , "[typepal] constructor": run(typepalProj(projDir), "src/analysis/typepal/Collector.rsc", "collector", srcDirs = ["src"])
       , "[typepal] global var": run(typepalProj(projDir), "src/analysis/typepal/Version.rsc", "currentTplVersion", srcDirs = ["src"])
-    //   , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/m3/AST.rsc", "astNodeSpecification")
-    //   , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e")
-    //   , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
-    //   , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
+      , "[rascal] function": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/m3/AST.rsc", "astNodeSpecification")
+      , "[rascal] local var": run(rascalProj(projDir), "src/org/rascalmpl/library/analysis/diff/edits/ExecuteTextEdits.rsc", "e")
+      , "[rascal] type param": run(rascalProj(projDir), "src/org/rascalmpl/library/Map.rsc", "K")
+      , "[rascal] grammar constructor": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "transitiveReflexiveClosure")
+      , "[rascal] nonterminal label": run(rascalProj(projDir), "src/org/rascalmpl/library/lang/rascal/syntax/Rascal.rsc", "lhs", newName = "lefthandside")
 ), safeRuns(3, intMedian, realTimeOf));
 
 num(void()) safeRuns(int numRuns, num(list[num]) aggregate, int(void()) measure) = int(void() f) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Benchmark.rsc
@@ -43,7 +43,7 @@ loc birdProj(loc projDir) = projDir + "bird/bird-core"; // removed RASCAL.MF
 public loc typepalLib = |mvn://org.rascalmpl--typepal--0.15.1-SNAPSHOT/|;
 
 void() run(loc proj, str file, str oldName, str newName = "<oldName>2", int occurrence = 0, list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) = void() {
-    println("Renameing \'<oldName>\' to \'<newName>\' in <proj + file>");
+    println("Renaming \'<oldName>\' to \'<newName>\' in <proj + file>");
     <edits, msgs> = testProjectOnDisk(proj, file, oldName, newName = newName, occurrence = occurrence, srcDirs = srcDirs, libs = libs);
     if (errors:{_, *_} := {msg | msg <- msgs, msg is error}) throw errors;
     if (size({r | /r:replace(_, _) := edits}) < 2) throw "Unexpected number of edits: <edits>";

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -144,3 +144,9 @@ test bool escapeVariants() = testRenameOccurrences({
     byText("EscapeImport3", "import a::b::\\Foo;
                       'int baz = a::b::\\Foo::foo;", {0, 1}, skipCursors = {1})
 }, oldName = "a::b::Foo", newName = "a::b::Bar");
+
+@expected{illegalRename}
+test bool moduleExists() = testRenameOccurrences({
+    byText("Foo", "", {0}),
+    byText("foo::Foo", "", {})
+}, oldName = "Foo", newName = "foo::Foo");

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -42,7 +42,9 @@ Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 
         pcfg = pathConfig(
             srcs = [ projectDir + "src/org/rascalmpl/library"
                    , projectDir + "src/org/rascalmpl/compiler"
-                   , projectDir + "test/org/rascalmpl/benchmark"],
+                   , projectDir + "src/org/rascalmpl/tutor"
+                   , projectDir + "test/org/rascalmpl/benchmark"
+                   ],
             bin = projectDir + "target/classes",
             libs = libs
         );

--- a/rascal-lsp/src/main/rascal/util/Util.rsc
+++ b/rascal-lsp/src/main/rascal/util/Util.rsc
@@ -78,7 +78,7 @@ str safeRelativeModuleName(loc path, PathConfig pcfg) {
 @synopsis{
     Try to parse string `name` as reified type `begin` and return whether this succeeded.
 }
-Maybe[Tree] tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
+Maybe[&T] tryParseAs(type[&T <: Tree] begin, str name, bool allowAmbiguity = false) {
     try {
         return just(parse(begin, name, allowAmbiguity = allowAmbiguity));
     } catch ParseError(_): {

--- a/rascal-lsp/src/main/rascal/util/Util.rsc
+++ b/rascal-lsp/src/main/rascal/util/Util.rsc
@@ -95,3 +95,5 @@ str describeTree(amb(alts)) = intercalate("|", [describeTree(alt) | alt <- alts]
 str describeTree(char(int c)) = "char <c>";
 
 list[str] describeTrees(list[Tree] trees) = [describeTree(t) | t <- trees];
+
+set[&T] toSet(tuple[&T, &T] ts) = {ts<0>, ts<1>};


### PR DESCRIPTION
Many performance optimization including:
- Only augment TModel when necessary
- Cache augmented TModels (just like 'normal' TModels)
- Cache results of `TModel(loc)` function (ljust like `TModel(Tree)`)
- Only check parse tree for occurrences if file contents match (string based)

Benchmark results after optimizations. Elapsed times are 3-run median, in seconds

| project | role of name under cursor | optimized | `main` | latest release |
|---------|------------------------------|-----------------------------------------|----|-|
| bird | local var | 11 | 86 | 45 |
| bird | global function | 34 | 321 | 87 |
| bird | formal param | 6 | 3 | 45 |
| bird | nonterminal | 15 | 639 | 38 |
| bird | module name | 6 | 163 | 81 |
| typepal | local var | 9 | 41 | 39 |
| typepal | constructor | 29 | 311 | (configuration error) |
| typepal | global var | 1 | 1 | (configuration error) |
| rascal | function | 3 | - | - |
| rascal | local var | 1 | - | 2 |
| rascal | type param | 3 | - | 2 |
| rascal | nonterminal label | (configuration error) | - | - |
| rascal | grammar constructor | 71 | - | - |