### PR TITLE
Properly handle modules outside workspace.

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -204,12 +204,13 @@ bool(Tree) anyNameFilter(set[str] names) {
     return bool(Tree tr) {
         visit (tr) {
             case (Name) `<Name n>`: for (n <- escNames) return true;
-            case (Nonterminal) `<Nonterminal n>`: for (nt1 <- escNonterminals, n := nt1) return true;
-            case (NonterminalLabel) `<NonterminalLabel n>`: for (ntl1 <- escNonterminalLabels, n := ntl1) return true;
+            case (Nonterminal) `<Nonterminal n>`: for (n <- escNonterminals) return true;
+            case (NonterminalLabel) `<NonterminalLabel n>`: for (n <- escNonterminalLabels) return true;
             case (QualifiedName) `<QualifiedName n>`: {
-                if (n.names[0].src == n.src) { // skip unqualified names
-                    for (qn <- qualifiedNames, qn := n || qn := [QualifiedName] normalizeEscaping("<n>")) return true;
-                }
+                if (n.names[0].src != n.src // skip unqualified names
+                  , qn <- qualifiedNames
+                  , qn := n || qn := [QualifiedName] normalizeEscaping("<n>"))
+                    return true;
             }
         }
 

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Modules.rsc
@@ -116,6 +116,13 @@ test bool externalImport() = testRenameOccurrences({
     ", {0})
 }, oldName = "Foo", newName = "Bar");
 
+@expected{illegalRename}
+test bool stdlibImport() = testRenameOccurrences({
+    byText("Main", "
+        'import IO;
+    ", {0})
+}, oldName = "IO", newName = "InOut");
+
 test bool simpleEscapedModule() = testRenameOccurrences({
     byText("Foo", "int foo = 8;", {0}, newName = "Bar"),
     byText("Main", "import \\Foo;
@@ -123,7 +130,7 @@ test bool simpleEscapedModule() = testRenameOccurrences({
 }, oldName = "Foo", newName = "Bar");
 
 test bool newEscapedModuleName() = testRenameOccurrences({
-    byText("Foo", "int foo = 8;", {0}, newName = "Foo")
+    byText("Foo", "int foo = 8;", {}, newName = "Foo")
 }, oldName = "Foo", newName = "\\Foo");
 
 test bool autoEscapeModuleName() = testRenameOccurrences({


### PR DESCRIPTION
Before, `relativize` would fail on any module that was not in a source directory of any project. Now, we throw a proper error.
Additionally, simplify some more patterns.