### PR TITLE
Fix "crashed unexpectedly" error notification for parse errors during type check

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -57,6 +57,7 @@ import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
+import org.rascalmpl.parser.gtd.exception.ParseError;
 import org.rascalmpl.types.RascalTypeFactory;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
@@ -197,6 +198,8 @@ public class RascalLanguageServices {
                 return RascalServices.parseRascalModule(resolvedLocation, Prelude.consumeInputStream(reader).toCharArray());
             } catch (IOException e1) {
                 throw RuntimeExceptionFactory.io("Could not open " + t[0] + " for reading");
+            } catch (ParseError pe) {
+                throw RuntimeExceptionFactory.parseError(pe.getLocation());
             }
         });
     }


### PR DESCRIPTION
# WIP

## Before this PR

A "crashed unexpectedly" error notification was shown during a type check when an unopened, imported module would contain a parse error.

![image](https://github.com/user-attachments/assets/3a406240-8cd6-4163-a245-d71778a8ed62)

The exception was thrown during the call of function `getParseTree` on line 70:

https://github.com/usethesource/rascal-language-servers/blob/91a53acf34c68c104c0a98c1b8db5d94a341a293/rascal-lsp/src/main/rascal/lang/rascal/lsp/IDECheckerWrapper.rsc#L68-L77

As the call is wrapped in a `try`/`catch`, the intended behavior seems to be that the exception is caught and the imported module ignored. The reason this doesn't work, though, is that `getParseTree` is defined in Java and throws a `ParseError` instead of a `org.rascal.exceptions.Throw`, so it can't be caught by Rascal's `catch`.

## After this PR

The `ParseError` is rethrown as a `Throw` in the Java implementation of `getParseTree`.

![image](https://github.com/user-attachments/assets/eec4f1d6-7b63-4129-84a6-d1e8c9545a54)
