### PR TITLE
Design LSP rename API

### DIFF
--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -52,7 +52,9 @@ set[LanguageService] picoLanguageServer() = {
     execution(picoExecutionService),
     inlayHint(picoInlayHintService),
     definition(picoDefinitionService),
-    codeAction(picoCodeActionService)
+    codeAction(picoCodeActionService),
+    prepareRename(picoRenamePreparingService),
+    rename(picoRenamingService)
 };
 
 @synopsis{This set of contributions runs slower but provides more detail.}
@@ -176,6 +178,15 @@ value picoExecutionService(removeDecl(start[Program] program, IdType toBeRemoved
     applyDocumentsEdits([changed(program@\loc.top, [replace(toBeRemoved@\loc, "")])]);
     return ("result": true);
 }
+
+loc picoRenamePreparingService(Focus _:[Id id, *_]) = id.src;
+
+tuple[list[DocumentEdit], set[Message]] picoRenamingService(Focus focus, str newName) = <[changed(focus[0].src.top, [
+    replace(id.src, newName)
+    | cursor := focus[0]
+    , /Id id := focus[-1]
+    , id := cursor
+])], {}>;
 
 @synopsis{The main function registers the Pico language with the IDE}
 @description{

--- a/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/demo/lang/pico/LanguageServer.rsc
@@ -53,8 +53,7 @@ set[LanguageService] picoLanguageServer() = {
     inlayHint(picoInlayHintService),
     definition(picoDefinitionService),
     codeAction(picoCodeActionService),
-    prepareRename(picoRenamePreparingService),
-    rename(picoRenamingService)
+    rename(picoRenamingService, prepareRenameService = picoRenamePreparingService)
 };
 
 @synopsis{This set of contributions runs slower but provides more detail.}

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -274,7 +274,7 @@ data LanguageService
     | codeAction    (list[CodeAction] (Focus _focus) codeActionService)
     | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService
         , loc (Focus _focus) prepareRenameService = defaultPrepareRenameService)
-    | didRenameFiles(tuple[list[DocumentEdit], set[Message]] (lrel[loc old, loc new] fileRenames) didRenameFilesService)
+    | didRenameFiles(tuple[list[DocumentEdit], set[Message]] (list[DocumentEdit] fileRenames) didRenameFilesService)
     ;
 
 loc defaultPrepareRenameService(Focus _:[Tree tr, *_]) = tr.src when tr.src?;

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -209,7 +209,7 @@ hover documentation, definition with uses, references to declarations, implement
 * The ((execution)) service executes the commands registered by ((lenses)) and ((inlayHinter))s.
 * The ((actions)) service discovers places in the editor to add "code actions" (little hints in the margin next to where the action is relevant) and connects ((CodeAction))s to execute when the users selects the action from a menu.
 * The ((util::LanguageServer::rename)) service renames an identifier by collecting the edits required to rename all occurrences of that identifier. It might fail and report why in diagnostics.
-   * The optional ((prepareRename)) service argument discovers places in the editor where a ((util::LanguageServer::rename)) is possible. If renameing the location is not supported, it should throw an exception.
+   * The optional `prepareRename` service argument discovers places in the editor where a ((util::LanguageServer::rename)) is possible. If renameing the location is not supported, it should throw an exception.
 * The ((didRenameFiles)) service collects ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed). The IDE applies the edits after moving the files. It might fail and report why in diagnostics.
 
 Many services receive a ((Focus)) parameter. The focus lists the syntactical constructs under the current cursor, from the current

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -209,7 +209,7 @@ hover documentation, definition with uses, references to declarations, implement
 * The ((actions)) service discovers places in the editor to add "code actions" (little hints in the margin next to where the action is relevant) and connects ((CodeAction))s to execute when the users selects the action from a menu.
 * The ((prepareRename)) service discovers places in the editor where a ((util::LanguageServer::rename)) is possible.
 * The ((util::LanguageServer::rename)) service renames an identifier by collecting the edits required to rename all occurrences of that identifier. It might fail and report why in diagnostics.
-* The ((willRenameFiles)) service collects ((DocumentEdit))s corresponding to renaming files (e.g. to rename a class when the class file will be renamed). The IDE applies the edits before moving the files.
+* The ((willRenameFiles)) service collects ((DocumentEdit))s corresponding to renaming files (e.g. to rename a class when the class file will be renamed). The IDE applies the edits before moving the files. It might fail and report why in diagnostics. Failure aborts the renaming.
 * The ((didRenameFiles)) service collects and applies ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed).
 
 Many services receive a ((Focus)) parameter. The focus lists the syntactical constructs under the current cursor, from the current
@@ -274,7 +274,7 @@ data LanguageService
     | codeAction    (list[CodeAction] (Focus _focus) codeActionService)
     | prepareRename (loc (Focus _focus) prepareRenameService)
     | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService)
-    | willRenameFiles(list[DocumentEdit](map[loc old, loc new] fileRenames) willRenameFilesService)
+    | willRenameFiles(tuple[list[DocumentEdit], set[Message]] (map[loc old, loc new] fileRenames) willRenameFilesService)
     | didRenameFiles(void(map[loc old, loc new] fileRenames) didRenameFilesService)
     ;
 

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -207,6 +207,10 @@ hover documentation, definition with uses, references to declarations, implement
 * The ((inlayHint)) service discovers plances to add "inlays" (little views embedded in the editor on the same line). Unlike ((lenses)) inlays do not offer command execution.
 * The ((execution)) service executes the commands registered by ((lenses)) and ((inlayHinter))s.
 * The ((actions)) service discovers places in the editor to add "code actions" (little hints in the margin next to where the action is relevant) and connects ((CodeAction))s to execute when the users selects the action from a menu.
+* The ((prepareRename)) service discovers places in the editor where a ((util::LanguageServer::rename)) is possible.
+* The ((util::LanguageServer::rename)) service renames an identifier by collecting the edits required to rename all occurrences of that identifier. It might fail and report why in diagnostics.
+* The ((willRenameFiles)) service collects ((DocumentEdit))s corresponding to renaming files (e.g. to rename a class when the class file will be renamed). The IDE applies the edits before moving the files.
+* The ((didRenameFiles)) service collects and applies ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed).
 
 Many services receive a ((Focus)) parameter. The focus lists the syntactical constructs under the current cursor, from the current
 leaf all the way up to the root of the tree. This list helps to create functionality that is syntax-directed, and always relevant to the
@@ -268,6 +272,10 @@ data LanguageService
     | references    (set[loc] (Focus _focus) referencesService)
     | implementation(set[loc] (Focus _focus) implementationService)
     | codeAction    (list[CodeAction] (Focus _focus) codeActionService)
+    | prepareRename (loc (Focus _focus) prepareRenameService)
+    | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService)
+    | willRenameFiles(list[DocumentEdit](map[loc old, loc new] fileRenames) willRenameFilesService)
+    | didRenameFiles(void(map[loc old, loc new] fileRenames) didRenameFilesService)
     ;
 
 @deprecated{Backward compatible with ((parsing)).}

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -209,8 +209,7 @@ hover documentation, definition with uses, references to declarations, implement
 * The ((actions)) service discovers places in the editor to add "code actions" (little hints in the margin next to where the action is relevant) and connects ((CodeAction))s to execute when the users selects the action from a menu.
 * The ((prepareRename)) service discovers places in the editor where a ((util::LanguageServer::rename)) is possible.
 * The ((util::LanguageServer::rename)) service renames an identifier by collecting the edits required to rename all occurrences of that identifier. It might fail and report why in diagnostics.
-* The ((willRenameFiles)) service collects ((DocumentEdit))s corresponding to renaming files (e.g. to rename a class when the class file will be renamed). The IDE applies the edits before moving the files. It might fail and report why in diagnostics. Failure aborts the renaming.
-* The ((didRenameFiles)) service collects ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed). The IDE applies the edits before moving the files. It might fail and report why in diagnostics.
+* The ((didRenameFiles)) service collects ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed). The IDE applies the edits after moving the files. It might fail and report why in diagnostics.
 
 Many services receive a ((Focus)) parameter. The focus lists the syntactical constructs under the current cursor, from the current
 leaf all the way up to the root of the tree. This list helps to create functionality that is syntax-directed, and always relevant to the
@@ -247,7 +246,6 @@ typical programming language concepts. Since these are all just `rel[loc, loc]` 
    * ((definition)) points the other way around, from a use to the declaration, but only if a value is associated there explicitly or implicitly.
    * ((implementation)) points from abstract declarations (interfaces, classes, function signatures) to more concrete realizations of those declarations.
 * `providesDocumentation` is deprecated. Use `providesHovers` instead.
-* ((willRenameFiles)) is tricky to use, since it requires a fast and reliable response. Since the Rascal evaluator running this service might be locked doing some else first, this cannot be guaranteed. If this causes issues, consider implementing ((didRenameFiles)) instead.
 }
 data LanguageService
     = parsing(Tree (str _input, loc _origin) parsingService
@@ -275,7 +273,6 @@ data LanguageService
     | codeAction    (list[CodeAction] (Focus _focus) codeActionService)
     | prepareRename (loc (Focus _focus) prepareRenameService)
     | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService)
-    | willRenameFiles(tuple[list[DocumentEdit], set[Message]] (lrel[loc old, loc new] fileRenames) willRenameFilesService)
     | didRenameFiles(tuple[list[DocumentEdit], set[Message]] (lrel[loc old, loc new] fileRenames) didRenameFilesService)
     ;
 

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -210,7 +210,7 @@ hover documentation, definition with uses, references to declarations, implement
 * The ((prepareRename)) service discovers places in the editor where a ((util::LanguageServer::rename)) is possible.
 * The ((util::LanguageServer::rename)) service renames an identifier by collecting the edits required to rename all occurrences of that identifier. It might fail and report why in diagnostics.
 * The ((willRenameFiles)) service collects ((DocumentEdit))s corresponding to renaming files (e.g. to rename a class when the class file will be renamed). The IDE applies the edits before moving the files. It might fail and report why in diagnostics. Failure aborts the renaming.
-* The ((didRenameFiles)) service collects and applies ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed).
+* The ((didRenameFiles)) service collects ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed). The IDE applies the edits before moving the files. It might fail and report why in diagnostics.
 
 Many services receive a ((Focus)) parameter. The focus lists the syntactical constructs under the current cursor, from the current
 leaf all the way up to the root of the tree. This list helps to create functionality that is syntax-directed, and always relevant to the
@@ -247,6 +247,7 @@ typical programming language concepts. Since these are all just `rel[loc, loc]` 
    * ((definition)) points the other way around, from a use to the declaration, but only if a value is associated there explicitly or implicitly.
    * ((implementation)) points from abstract declarations (interfaces, classes, function signatures) to more concrete realizations of those declarations.
 * `providesDocumentation` is deprecated. Use `providesHovers` instead.
+* ((willRenameFiles)) is tricky to use, since it requires a fast and reliable response. Since the Rascal evaluator running this service might be locked doing some else first, this cannot be guaranteed. If this causes issues, consider implementing ((didRenameFiles)) instead.
 }
 data LanguageService
     = parsing(Tree (str _input, loc _origin) parsingService
@@ -274,8 +275,8 @@ data LanguageService
     | codeAction    (list[CodeAction] (Focus _focus) codeActionService)
     | prepareRename (loc (Focus _focus) prepareRenameService)
     | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService)
-    | willRenameFiles(tuple[list[DocumentEdit], set[Message]] (map[loc old, loc new] fileRenames) willRenameFilesService)
-    | didRenameFiles(void(map[loc old, loc new] fileRenames) didRenameFilesService)
+    | willRenameFiles(tuple[list[DocumentEdit], set[Message]] (lrel[loc old, loc new] fileRenames) willRenameFilesService)
+    | didRenameFiles(tuple[list[DocumentEdit], set[Message]] (lrel[loc old, loc new] fileRenames) didRenameFilesService)
     ;
 
 @deprecated{Backward compatible with ((parsing)).}

--- a/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/util/LanguageServer.rsc
@@ -44,6 +44,7 @@ import analysis::diff::edits::TextEdits;
 import IO;
 import ParseTree;
 import Message;
+import Exception;
 
 @synopsis{Definition of a language server by its meta-data.}
 @description{
@@ -207,8 +208,8 @@ hover documentation, definition with uses, references to declarations, implement
 * The ((inlayHint)) service discovers plances to add "inlays" (little views embedded in the editor on the same line). Unlike ((lenses)) inlays do not offer command execution.
 * The ((execution)) service executes the commands registered by ((lenses)) and ((inlayHinter))s.
 * The ((actions)) service discovers places in the editor to add "code actions" (little hints in the margin next to where the action is relevant) and connects ((CodeAction))s to execute when the users selects the action from a menu.
-* The ((prepareRename)) service discovers places in the editor where a ((util::LanguageServer::rename)) is possible.
 * The ((util::LanguageServer::rename)) service renames an identifier by collecting the edits required to rename all occurrences of that identifier. It might fail and report why in diagnostics.
+   * The optional ((prepareRename)) service argument discovers places in the editor where a ((util::LanguageServer::rename)) is possible. If renameing the location is not supported, it should throw an exception.
 * The ((didRenameFiles)) service collects ((DocumentEdit))s corresponding to renamed files (e.g. to rename a class when the class file was renamed). The IDE applies the edits after moving the files. It might fail and report why in diagnostics.
 
 Many services receive a ((Focus)) parameter. The focus lists the syntactical constructs under the current cursor, from the current
@@ -271,10 +272,13 @@ data LanguageService
     | references    (set[loc] (Focus _focus) referencesService)
     | implementation(set[loc] (Focus _focus) implementationService)
     | codeAction    (list[CodeAction] (Focus _focus) codeActionService)
-    | prepareRename (loc (Focus _focus) prepareRenameService)
-    | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService)
+    | rename        (tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService
+        , loc (Focus _focus) prepareRenameService = defaultPrepareRenameService)
     | didRenameFiles(tuple[list[DocumentEdit], set[Message]] (lrel[loc old, loc new] fileRenames) didRenameFilesService)
     ;
+
+loc defaultPrepareRenameService(Focus _:[Tree tr, *_]) = tr.src when tr.src?;
+default loc defaultPrepareRenameService(Focus focus) { throw IllegalArgument(focus, "Element under cursor does not have source location"); }
 
 @deprecated{Backward compatible with ((parsing)).}
 @synopsis{Construct a `parsing` ((LanguageService))}


### PR DESCRIPTION
# Design: support renaming in DSL LSPs

The renaming functionality consists of multiple LSP endpoints.

- Language features
  * Prepare rename
  * Rename
- Workspace features
  * Will rename files
  * Did rename files

## Language features

### Prepare rename
[*Prepare rename*](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareRename) selects, given a cursor position, the range in the file that should be renamed. It defaults to using word boundaries, but the user might want to override this behaviour, for example:
- When renaming qualified names like `foo::bar`. By default, VS Code would select `foo` or `bar`, but one might want to rename the complete thing.
- When renaming certain names is not supported, and this can be quickly determined (i.e. based on the parse tree). For example, the language allows renaming local variables, but not function calls.

In the Rascal LSP API, this can be modeled by the following function.
```rascal
loc (Focus _focus) prepareRenameService;
```
Unsupported renames show return `null` (in Java). The DSL can throw a specific exception or a string here, that we catch and handle in Java.

### Rename
[*Rename*](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename) takes a position in the document and a new name, and renames occurrences of the name at that position to the new name. It does so by compiling a list of proposed edits, that the VS Code will then apply. Besides the edits, a rename might also result in diagnostic messages. These serve to signal issues with the renaming, for example when renaming an identifier would result in duplicate definitions. In cases where the DSL is type-checked using *typepal*, a basic renaming can be quickly obtained by using the [rename framework](https://github.com/usethesource/typepal/pull/14/files#diff-331b6ee7eb6cff5a20ed758324cb50852cd52a0ef2e6c39028bbee40a9bc6963). Therefore, it would be advantageous if this endpoint integrates well with that.

In the Rascal LSP API, this can be modeled by the following function:
```rascal
tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService;
```

We group the `prepareRename` and `rename` services together under a single constructor, since they are practically married. For `prepareRename`, we can provide a sensible default.

```rascal
import Exception;

data LanguageService
  = rename(tuple[list[DocumentEdit], set[Message]] (Focus _focus, str newName) renameService
        , loc (Focus _focus) prepareRenameService = defaultPrepareRenameService)
  ;

loc defaultPrepareRenameService(Focus _:[Tree tr, *_]) = tr.src when tr.src?;
default loc defaultPrepareRenameService(Focus focus) { throw IllegalArgument(focus, "Element under cursor does not have source location"); }
```

## Workspace features
### Will/Did rename files
The *[Will](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles)/[Did rename files](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles)* endpoints are called by VS Code before/after files are renamed from the VS Code explorer. They allow the extension to change code references to those file names to match the renaming.

- *Will rename files* is a request, and needs to return a collection of edits (or error in some way - `null` in Java). Since this is very sensitive to evaluator locks, we cannot guarantee it will ever succeed. Therefore, we omit it, until there is a very clear use-case for it.
- *Did rename files* is a notification; the IDE does not wait for it to return and it is itself responsible for applying the edits to the workspace (e.g. via `analysis::diff::edits::ExecuteTextEdits`). We model the API so that the implementor must return edits, which we then apply from the Java wrapper.

```rascal
data LanguageService
  = didRenameFiles(void(map[loc old, loc new] fileRenames) didRenameFilesService)
  ;
```
