### PR TITLE
Rename refactoring: improve common keyword field support

### DIFF
--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/Rename.rsc
@@ -149,7 +149,7 @@ void rascalCheckCausesDoubleDeclarations(Define cD, str newName, TModel tm, Rena
     }
 
     if (isFieldRole(cD.idRole)) {
-        for (Define dataDef <- findAdditionalDataLikeDefinitions({cD}, tm, r)
+        for (Define dataDef <- findAdditionalDataLikeDefinitions({cD}, tm, r.getConfig().tmodelForLoc)
            , loc nD <- (newNameDefs<idRole, defined>)[{fieldId(), keywordFieldId()}] & (tm.defines<idRole, scope, defined>)[{fieldId(), keywordFieldId()}, dataDef.defined]
         ) {
             r.error(cD.defined, "Cannot rename to \'<newName>\', since this would clash with an existing definition at <nD>.");

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -57,14 +57,14 @@ set[Define] findAdditionalDefinitions(set[Define] cursorDefs, Tree tr, TModel tm
     adtDefs += findAdditionalDefinitions(adtDefs, tr, tm, r);
 
     // Find all fields with the same name in these ADT definitions
-    return getFieldDefinitions(adtDefs, cursorDefs<idRole, id>, r.getConfig().tmodelForLoc);
+    return getFieldDefinitions(adtDefs, cursorDefs.id, r.getConfig().tmodelForLoc);
 }
 
 @synopsis{Collect all definitions for field <fieldName> in ADT/collection/tuple by definition.}
-set[Define] getFieldDefinitions(set[Define] containerDefs, rel[IdRole, str] fields, TModel(loc) getModel)
+set[Define] getFieldDefinitions(set[Define] containerDefs, set[str] fieldNames, TModel(loc) getModel)
     = flatMapPerFile(containerDefs, set[Define](loc f, set[Define] localContainerDefs) {
         localTm = getModel(f);
-        candidateDefs = {*(localTm.defines<idRole, id, scope, defined>[role, name]) | <role, name> <- fields};
+        candidateDefs = {*(localTm.defines<idRole, id, scope, defined>[fieldRoles, name]) | name <- fieldNames};
         return {localTm.definitions[d] | loc d <- candidateDefs[localContainerDefs.defined]};
     });
 
@@ -80,7 +80,7 @@ set[Define] getFieldDefinitions(set[AType] containerTypes, str fieldName, TModel
         }
     }
     // Since we do not know (based on tree) what kind of field role (positional, keyword) we are looking for, select them all
-    return getFieldDefinitions(containerTypeDefs, {<role, fieldName> | role <- fieldRoles}, getModel);
+    return getFieldDefinitions(containerTypeDefs, {fieldName}, getModel);
 }
 
 @synopsis{Collect all definitions for the field <fieldName> in ADT/collection/tuple by tree.}

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Fields.rsc
@@ -69,10 +69,16 @@ set[Define] getFieldDefinitions(set[Define] containerDefs, rel[IdRole, str] fiel
     });
 
 @synopsis{Collect all definitions for the field <fieldName> by ADT/constructor type.}
-set[Define] getFieldDefinitions(set[AType] containerTypes, str fieldName, TModel tm, TModel(loc) getModel) {
+set[Define] getFieldDefinitions(set[AType] containerTypes, str fieldName, TModel tm, set[loc] reachableFromUse, TModel(loc) getModel) {
     rel[AType, IdRole, Define] definesByType = {<d.defInfo.atype, d.idRole, d> | d <- tm.defines, d.defInfo.atype?};
     // Find all type-like definitions (but omit variable definitions etc.)
     set[Define] containerTypeDefs = definesByType[containerTypes, dataOrSyntaxRoles];
+    if (dataId() in containerTypeDefs.idRole) {
+        // Find overloads
+        for (loc modScope <- reachableFromUse) {
+            containerTypeDefs += findAdditionalDataLikeDefinitions(containerTypeDefs, getModel(modScope.top), getModel);
+        }
+    }
     // Since we do not know (based on tree) what kind of field role (positional, keyword) we are looking for, select them all
     return getFieldDefinitions(containerTypeDefs, {<role, fieldName> | role <- fieldRoles}, getModel);
 }
@@ -86,10 +92,10 @@ set[Define] getFieldDefinitions(Tree container, str fieldName, TModel tm, TModel
             set[Define] containerDefs = {fileTm.definitions[d] | loc d <- localContainerDefs, fileTm.definitions[d]?};
             // Find the type of the container. For a constructor value, the type is its ADT type.
             set[AType] containerDefTypes = {acons(AType adt, _, _) := di.atype ? adt : di.atype | DefInfo di <- containerDefs.defInfo};
-            return getFieldDefinitions(containerDefTypes, fieldName, fileTm, getModel);
+            return getFieldDefinitions(containerDefTypes, fieldName, fileTm, rascalGetReflexiveModulePaths(tm).to, getModel);
         });
     } else if (just(AType containerType) := getFact(tm, container.src)) {
-        return getFieldDefinitions({containerType}, fieldName, tm, getModel) ;
+        return getFieldDefinitions({containerType}, fieldName, tm, rascalGetReflexiveModulePaths(tm).to, getModel) ;
     }
 
     return {};

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Grammars.rsc
@@ -47,7 +47,7 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] def
     when role in syntaxRoles;
 
 set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, IdRole role, _, _>, *_}, Tree tr, TModel tm, Renamer r) =
-    findAdditionalDataLikeDefinitions(cursorDefs, tm, r)
+    findAdditionalDataLikeDefinitions(cursorDefs, tm, r.getConfig().tmodelForLoc)
     when role in syntaxRoles;
 
 void renameDefinitionUnchecked(Define d: <_, _, _, nonterminalId(), _, _>, loc _, str _, Renamer _) {

--- a/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/lsp/refactor/rename/Types.rsc
@@ -68,9 +68,9 @@ public tuple[set[loc], set[loc], set[loc]] findDataLikeOccurrenceFilesUnchecked(
 }
 
 set[Define] findAdditionalDefinitions(set[Define] cursorDefs:{<_, _, _, dataId(), _, _>, *_}, Tree tr, TModel tm, Renamer r) =
-    findAdditionalDataLikeDefinitions(cursorDefs, tm, r);
+    findAdditionalDataLikeDefinitions(cursorDefs, tm, r.getConfig().tmodelForLoc);
 
-public set[Define] findAdditionalDataLikeDefinitions(set[Define] defs, TModel tm, Renamer r) {
+public set[Define] findAdditionalDataLikeDefinitions(set[Define] defs, TModel tm, TModel(loc) getModel) {
     reachable = rascalGetReflexiveModulePaths(tm).to;
     reachableCursorDefs = {d.defined | Define d <- defs, any(loc modScope <- reachable, isContainedInScope(d.defined, modScope, tm))};
 
@@ -79,7 +79,7 @@ public set[Define] findAdditionalDataLikeDefinitions(set[Define] defs, TModel tm
     return {fileTm.definitions[overload]
         | loc modScope <- reachable
         , loc f := modScope.top
-        , fileTm := r.getConfig().tmodelForLoc(f)
+        , fileTm := getModel(f)
         , definitions := (d.defined: d | d <- fileTm.defines) + tm.definitions
         , loc overload <- (fileTm.defines<idRole, defined>)[dataOrSyntaxRoles]
         , rascalMayOverloadSameName(reachableCursorDefs + overload, definitions)

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -145,6 +145,32 @@ test bool commonKeywordFieldImported() = testRenameOccurrences({
   ", {0})
 });
 
+test bool commonKeywordFieldsMerged() = testRenameOccurrences({
+    byText("Foo", "data D(int foo = 1) = d();", {0})
+  , byText("Baz", "data D(int foo = 0, int baz = 0);", {0})
+  , byText("Bar",
+        "import Foo;
+        'import Baz;
+        'D oneTwo = d(foo=1, baz=2);
+  ", {0})
+});
+
+test bool commonKeywordFieldsMergedMixedRole() = testRenameOccurrences({
+    byText("Foo", "data D = d(int foo = 1);", {0})
+  , byText("Baz", "data D(int foo = 0, int baz = 0);", {0})
+  , byText("Bar",
+        "import Foo;
+        'import Baz;
+        'D oneTwo = d(foo=1, baz=2);
+  ", {0})
+  , byText("Qux",
+        "import Foo;
+        'import Baz;
+        'D three = d(foo=3);
+
+  ", {0})
+});
+
 test bool sameNameFields() = testRenameOccurrences({0, 2, 3}, "
     'D x = d(8);
     'int i = x.foo;

--- a/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
+++ b/rascal-lsp/src/main/rascal/lang/rascal/tests/rename/Fields.rsc
@@ -126,6 +126,25 @@ test bool commonKeywordFieldsSameType() = testRenameOccurrences({0, 1},
     decls = "data D (set[loc] foo = {}, set[loc] baz = {})= d();"
 );
 
+test bool commonKeywordFieldExtended() = testRenameOccurrences({
+    byText("Foo", "data D = d();", {})
+  , byText("Bar",
+        "import Foo;
+        'data D(int foo = 0, int baz = 0);
+        'D oneTwo = d(foo=1, baz=2);
+  ", {0, 1})
+});
+
+test bool commonKeywordFieldImported() = testRenameOccurrences({
+    byText("Foo", "data D = d();", {})
+  , byText("Baz", "data D(int foo = 0, int baz = 0);", {0})
+  , byText("Bar",
+        "import Foo;
+        'import Baz;
+        'D oneTwo = d(foo=1, baz=2);
+  ", {0})
+});
+
 test bool sameNameFields() = testRenameOccurrences({0, 2, 3}, "
     'D x = d(8);
     'int i = x.foo;


### PR DESCRIPTION

```
map[str, num]: ("[rascal] function":2355,"[bird] module name":5968,"[typepal] local var":8162,"[rascal] local var":213,"[rascal] type param":2526,"[typepal] constructor":102634,"[bird] nonterminal":9818,"[bird] local var":6883,"[bird] global function":309767,"[bird] formal param":3130,"[typepal] global var":272,"[rascal] grammar constructor":36398,"[bird] nonterminal name":8446)
```