### PR TITLE
Fixed janky "Run in new Rascal terminal" codelens.

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -323,7 +323,7 @@ public class RascalLanguageServices {
                     }
                 }
             } catch (Exception e) {
-                // We must have encountered an error tree. This exception can be more specific (IndexOutOfBounds) once a Rascal version with a more robust version of "TreeAdapter.getArg()" is released.
+                // We must have encountered an error tree. This exception can be more specific once a Rascal version with a more robust version of "TreeAdapter.getArg()" is released.
                 logger.warn("Failed to process top-level tree, it probably contains a parse error: {}", topLevel, e);
             }
         }


### PR DESCRIPTION
Note that the current solution (catch any exception) is not ideal.
We can replace this with a more specific exception once we fix the `TreeAdapter.getArg` method in Rascal to properly handle error trees.