### PR TITLE
Use lastTreeWithoutErrors for calculating code lenses

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -166,11 +166,11 @@ public class TextDocumentState {
                         treeAsync.completeExceptionally(e);
                     } else {
                         var tree = new Versioned<>(version, t, timestamp);
-                        treeAsync.complete(tree);
                         Versioned.replaceIfNewer(last, tree);
                         if (diagnosticsList.isEmpty()) {
                             Versioned.replaceIfNewer(lastWithoutErrors, tree);
                         }
+                        treeAsync.complete(tree);
                     }
 
                     // Complete future to get diagnostics

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -542,6 +542,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 return r;
             })
             .thenApply(Versioned::get)
+            // Replace with the last tree without errors, might be the same as `tree` if the parse succeeded without any error recovery
+            .thenApply(tree -> f.getLastTreeWithoutErrors().get())
             .thenApplyAsync(rascalServices::locateCodeLenses, ownExecuter)
             .thenApply(List::stream)
             .thenApply(res -> res.map(this::makeRunCodeLens))


### PR DESCRIPTION
The "Run in new Rascal terminal" code lens would disappear if you introduced certain parse errors.
With this fix, the code lenses are always calculated based on the last tree without errors
so the code lense will not disappear until the source code parses without errors and there is no longer a main function.

This PR closes #665.