### PR TITLE
User-interruptible evaluator jobs

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
@@ -51,6 +51,7 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SetTraceParams;
+import org.eclipse.lsp4j.WorkDoneProgressCancelParams;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.messages.Tuple.Two;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -365,6 +366,11 @@ public abstract class BaseLanguageServer {
         @Override
         public void registerVFS(VFSRegister registration) {
             VSCodeVFSClient.buildAndRegister(registration.getPort());
+        }
+
+        @Override
+        public void cancelProgress(WorkDoneProgressCancelParams params) {
+            lspDocumentService.cancelProgress(params.getToken().getLeft());
         }
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -57,4 +57,5 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     boolean isManagingFile(ISourceLocation file);
 
     default void didRenameFiles(RenameFilesParams params, Set<ISourceLocation> workspaceFolders) {}
+    void cancelProgress(String progressId);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -26,7 +26,6 @@
  */
 package org.rascalmpl.vscode.lsp;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -194,6 +193,10 @@ public class LSPIDEServices implements IDEServices {
     @Override
     public void warning(String message, ISourceLocation src) {
         monitor.warning(message, src);
+    }
+
+    public IRascalMonitor getMonitor() {
+        return monitor;
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
@@ -134,10 +134,21 @@ public class RascalLSPMonitor implements IRascalMonitor {
     private final ThreadLocal<LSPProgressBar> activeProgress = new ThreadLocal<>();
     private final Map<String, InterruptibleFuture<? extends Object>> activeFutures = new ConcurrentHashMap<>();
 
+    /**
+     * Register a running {@link InterruptibleFuture}, so it can be interrupted later.
+     * Must be called from the same thread as the corresponding {@link jobStarted}.
+     * @param name The task name, equal to the one used for {@link jobStarted}.
+     * @param future The future doing the work.
+     */
     public void registerActiveFuture(String name, InterruptibleFuture<?> future) {
         activeFutures.put(generateProgressId(name), future);
     }
 
+    /**
+     * Unregister an {@link InterruptibleFuture} that has finished.
+     * Must be called from the same thread as the corresponding {@link jobEnded}.
+     * @param name The task name, equal to the one used for {@link jobEnded}.
+     */
     public void unregisterActiveFuture(String name) {
         activeFutures.remove(generateProgressId(name));
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
@@ -153,10 +153,6 @@ public class RascalLSPMonitor implements IRascalMonitor {
         activeFutures.remove(generateProgressId(name));
     }
 
-    public @Nullable InterruptibleFuture<?> getActiveFuture(String progressId) {
-        return activeFutures.get(progressId);
-    }
-
     @Override
     public void jobStart(String name, int workShare, int totalWork) {
         var progress = this.activeProgress.get();
@@ -234,5 +230,16 @@ public class RascalLSPMonitor implements IRascalMonitor {
     @Override
     public void warning(String message, ISourceLocation src) {
         logger.warn("{} : {}", src, message);
+    }
+
+    /**
+     * Cancel the running {@link InterruptibleFuture} corresponding to a specific progress bar.
+     * @param progressId The identifier of the progress bar.
+     */
+    public void cancelProgress(String progressId) {
+        var future = activeFutures.get(progressId);
+        if (future != null) {
+            future.interrupt();
+        }
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
@@ -132,7 +132,7 @@ public class RascalLSPMonitor implements IRascalMonitor {
     }
 
     private final ThreadLocal<LSPProgressBar> activeProgress = new ThreadLocal<>();
-    private final Map<String, InterruptibleFuture<?>> activeFutures = new ConcurrentHashMap<>();
+    private final Map<String, InterruptibleFuture<? extends Object>> activeFutures = new ConcurrentHashMap<>();
 
     public void registerActiveFuture(String name, InterruptibleFuture<?> future) {
         activeFutures.put(generateProgressId(name), future);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/RascalLSPMonitor.java
@@ -84,7 +84,7 @@ public class RascalLSPMonitor implements IRascalMonitor {
 
             var msg = new WorkDoneProgressBegin();
             msg.setTitle(progressPrefix + rootName);
-            msg.setCancellable(true);
+            msg.setCancellable(activeFutures.containsKey(progressId));
             notifyProgress(msg);
         }
 
@@ -96,7 +96,7 @@ public class RascalLSPMonitor implements IRascalMonitor {
         public void progress(String message) {
             var msg = new WorkDoneProgressReport();
             msg.setMessage(message);
-            msg.setCancellable(true);
+            msg.setCancellable(activeFutures.containsKey(progressId));
             notifyProgress(msg);
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -117,6 +117,8 @@ public interface ILanguageContributions {
      * `references`, and `implementations` as parameter.
      */
     public static interface OnDemandFocusToSetCalculator extends Function<IList, InterruptibleFuture<ISet>> { }
+
+    public void cancelProgress(String progressId);
 }
 
 /*package*/ class EmptySummary {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -464,9 +464,6 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
 
     @Override
     public void cancelProgress(String progressId) {
-        var future = monitor.getActiveFuture(progressId);
-        if (future != null) {
-            future.interrupt();
-        }
+        monitor.cancelProgress(progressId);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -107,6 +107,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private final CompletableFuture<SummaryConfig> builderSummaryConfig;
     private final CompletableFuture<SummaryConfig> ondemandSummaryConfig;
     private final IBaseLanguageClient client;
+    private final RascalLSPMonitor monitor;
 
     public InterpretedLanguageContributions(LanguageParameter lang, IBaseTextDocumentService docService, BaseWorkspaceService workspaceService, IBaseLanguageClient client, ExecutorService exec) {
         this.client = client;
@@ -118,7 +119,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
             var pcfg = new PathConfig().parse(lang.getPathConfig());
             pcfg = EvaluatorUtil.addLSPSources(pcfg, false);
 
-            var monitor = new RascalLSPMonitor(client, LogManager.getLogger(logger.getName() + "[" + lang.getName() + "]"), lang.getName() + ": ");
+            monitor = new RascalLSPMonitor(client, LogManager.getLogger(logger.getName() + "[" + lang.getName() + "]"), lang.getName() + ": ");
 
             this.eval = EvaluatorUtil.makeFutureEvaluator(new LSPContext(exec, docService, workspaceService, client),
                 "evaluator for " + lang.getName(), monitor, pcfg, lang.getMainModule());
@@ -459,5 +460,13 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
                 return EvaluatorUtil.runEvaluator(name, eval, e -> s.call(args), defaultResult, exec, true, client);
             }),
             exec);
+    }
+
+    @Override
+    public void cancelProgress(String progressId) {
+        var future = monitor.getActiveFuture(progressId);
+        if (future != null) {
+            future.interrupt();
+        }
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -369,4 +369,9 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     public CompletableFuture<SummaryConfig> getOndemandSummaryConfig() {
         return ondemandSummaryConfig;
     }
+
+    @Override
+    public void cancelProgress(String progressId) {
+        contributions.forEach(klc -> klc.contrib.cancelProgress(progressId));
+    }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -674,6 +674,8 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
 
     @Override
     public void cancelProgress(String progressId) {
-        throw new UnsupportedOperationException("Unimplemented method 'cancelProgress'");
+        contributions.values().forEach(plex -> {
+            plex.cancelProgress(progressId);
+        });
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -671,4 +671,9 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public TextDocumentState getDocumentState(ISourceLocation file) {
         return files.get(file.top());
     }
+
+    @Override
+    public void cancelProgress(String progressId) {
+        throw new UnsupportedOperationException("Unimplemented method 'cancelProgress'");
+    }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -251,4 +251,9 @@ public class ParserOnlyContribution implements ILanguageContributions {
         return CompletableFuture.completedFuture(SummaryConfig.FALSY);
     }
 
+    @Override
+    public void cancelProgress(String progressId) {
+        // empty, since this contribution does not have any running tasks nor a monitor
+    }
+
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -416,10 +416,7 @@ public class RascalLanguageServices {
     public void cancelProgress(String progressId) {
         var future = monitor.getActiveFuture(progressId);
         if (future != null) {
-            logger.debug("Interrupting future {}", progressId);
             future.interrupt();
-        } else {
-            logger.debug("No future for progress ID {}", progressId);
         }
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -414,9 +414,6 @@ public class RascalLanguageServices {
     }
 
     public void cancelProgress(String progressId) {
-        var future = monitor.getActiveFuture(progressId);
-        if (future != null) {
-            future.interrupt();
-        }
+        monitor.cancelProgress(progressId);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -626,4 +626,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public @MonotonicNonNull FileFacts getFileFacts() {
         return facts;
     }
+
+    @Override
+    public void cancelProgress(String progressId) {
+        this.rascalServices.cancelProgress(progressId);
+    }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
@@ -98,7 +98,8 @@ public class EvaluatorUtil {
 
         future.set(new InterruptibleFuture<>(eval.thenApplyAsync(actualEval -> {
             try {
-                while (future.get() == null) {
+                InterruptibleFuture<T> self;
+                while ((self = future.get()) == null) {
                     // yield until our value has been set
                     Thread.yield();
                 }
@@ -108,7 +109,7 @@ public class EvaluatorUtil {
                     monitor = ((LSPIDEServices) monitor).getMonitor();
                 }
                 if (monitor instanceof RascalLSPMonitor) {
-                    ((RascalLSPMonitor) monitor).registerActiveFuture(task, future.get());
+                    ((RascalLSPMonitor) monitor).registerActiveFuture(task, self);
                 }
 
                 actualEval.jobStart(task);


### PR DESCRIPTION
Allow the developer to interrupt evaluator tasks, for example to cancel long-running typechecker jobs. Cancelling interrupts the Rascal interpreter.

Rascal example:
![afbeelding](https://github.com/user-attachments/assets/9884c18e-0edf-47ea-a3d3-53507bad7982)

Pico example:
![afbeelding](https://github.com/user-attachments/assets/81e8f8b6-9f08-49f9-8424-6976f273c5fa)

Closes #672.