### PR TITLE
Cleanup old diagnostics for deleted files

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.lsp4j.DeleteFilesParams;
 import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
@@ -57,6 +58,7 @@ public interface IBaseTextDocumentService extends TextDocumentService {
 
     boolean isManagingFile(ISourceLocation file);
 
-    default void didRenameFiles(RenameFilesParams params, List<WorkspaceFolder> workspaceFolders) {}
+    void didRenameFiles(RenameFilesParams params, List<WorkspaceFolder> workspaceFolders);
+    void didDeleteFiles(DeleteFilesParams params);
     void cancelProgress(String progressId);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -56,6 +56,7 @@ import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.DeleteFilesParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
@@ -81,6 +82,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PrepareRenameDefaultBehavior;
 import org.eclipse.lsp4j.PrepareRenameParams;
 import org.eclipse.lsp4j.PrepareRenameResult;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameFilesParams;
@@ -294,6 +296,19 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         }
         facts(params.getTextDocument()).close(Locations.toLoc(params.getTextDocument()));
     }
+
+    @Override
+    public void didDeleteFiles(DeleteFilesParams params) {
+        ownExecuter.submit(() -> {
+            // if a file is deleted, and we were tracking it, we remove our diagnostics
+            for (var f : params.getFiles()) {
+                if (registeredExtensions.containsKey(extension(f.getUri()))) {
+                    client.publishDiagnostics(new PublishDiagnosticsParams(f.getUri(), List.of()));
+                }
+            }
+        });
+    }
+
 
     private void triggerAnalyzer(TextDocumentItem doc, Duration delay) {
         triggerAnalyzer(new VersionedTextDocumentIdentifier(doc.getUri(), doc.getVersion()), delay);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricWorkspaceService.java
@@ -26,13 +26,15 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import org.eclipse.lsp4j.FileOperationPattern;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 
 public class ParametricWorkspaceService extends BaseWorkspaceService {
     ParametricWorkspaceService(ExecutorService exec, IBaseTextDocumentService docService) {
-        super(exec, docService);
+        super(exec, docService, List.of(new FileOperationPattern("**/*")));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -52,6 +52,7 @@ import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.DeleteFilesParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
@@ -73,6 +74,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PrepareRenameDefaultBehavior;
 import org.eclipse.lsp4j.PrepareRenameParams;
 import org.eclipse.lsp4j.PrepareRenameResult;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.RenameOptions;
@@ -235,6 +237,16 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             throw new ResponseErrorException(new ResponseError(ResponseErrorCode.InternalError,
                 "Unknown file: " + Locations.toLoc(params.getTextDocument()), params));
         }
+    }
+
+    @Override
+    public void didDeleteFiles(DeleteFilesParams params) {
+        ownExecuter.submit(() -> {
+            // if a file is deleted, we remove our diagnostics
+            for (var f : params.getFiles()) {
+                client.publishDiagnostics(new PublishDiagnosticsParams(f.getUri(), List.of()));
+            }
+        });
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -26,9 +26,11 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.eclipse.lsp4j.FileOperationPattern;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
@@ -37,7 +39,7 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     private @MonotonicNonNull LanguageClient client;
 
     RascalWorkspaceService(ExecutorService exec, IBaseTextDocumentService documentService) {
-        super(exec, documentService);
+        super(exec, documentService, List.of(new FileOperationPattern("**/*.rsc")));
     }
 
     @Override


### PR DESCRIPTION
Fixes #671

I've also reduced the watch scope of rascal to only monitor rascal files, not all files. @toinehartman do you remember why initially it was for all files? is it for a rename of a file from a non `.rsc` extension?