### PR TITLE
parse error message strings

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -195,7 +195,7 @@ public class TextDocumentState {
                     new Range(new Position(0,0), new Position(0,1)),
                     "Parsing failed: " + excp.getMessage(),
                     DiagnosticSeverity.Error,
-                    "Rascal Parser");
+                    "parser");
                 diagnostics.add(columns -> diagnostic);
             }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -38,7 +38,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.rascalmpl.interpreter.NullRascalMonitor;
 import org.rascalmpl.shell.ShellEvaluatorFactory;
-import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.RascalFunctionValueFactory;
 import org.rascalmpl.values.RascalValueFactory;
@@ -49,7 +48,6 @@ import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
-import io.usethesource.vallang.IMap;
 import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.ITuple;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -55,6 +55,7 @@ import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.interpreter.Evaluator;
 import org.rascalmpl.interpreter.env.ModuleEnvironment;
+import org.rascalmpl.interpreter.staticErrors.SyntaxError;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.parser.gtd.exception.ParseError;
@@ -189,6 +190,8 @@ public class RascalLanguageServices {
                 throw RuntimeExceptionFactory.io("Could not open " + t[0] + " for reading");
             } catch (ParseError pe) {
                 throw RuntimeExceptionFactory.parseError(pe.getLocation());
+            } catch (SyntaxError se) {
+                throw RuntimeExceptionFactory.parseError(se.getLocation());
             }
         });
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -64,12 +64,6 @@ public class Diagnostics {
     private static final Logger logger = LogManager.getLogger(Diagnostics.class);
     private static final Map<String, DiagnosticSeverity> severityMap;
 
-    // Note: DiagnosticSeverity.Hint only highlightes a single character!
-    private static final DiagnosticSeverity ERROR_LOCATION_HIGHLIGHT = DiagnosticSeverity.Error;
-    private static final DiagnosticSeverity ERROR_TREE_HIGHLIGHT = null;
-    private static final DiagnosticSeverity PREFIX_HIGHLIGHT = null;
-    private static final DiagnosticSeverity SKIPPED_HIGHLIGHT = null;
-
     static {
         severityMap = new HashMap<>();
         severityMap.put("error", DiagnosticSeverity.Error);
@@ -95,7 +89,7 @@ public class Diagnostics {
     }
 
     public static Template generateParseErrorDiagnostic(ParseError e) {
-        return cm -> new Diagnostic(toRange(e, cm), e.getMessage(), DiagnosticSeverity.Error, "parser");
+        return cm -> new Diagnostic(toRange(e, cm), "Parsing got stuck.", DiagnosticSeverity.Error, "parser");
     }
 
     public static List<Template> generateParseErrorDiagnostics(ITree errorTree) {
@@ -167,7 +161,7 @@ public class Diagnostics {
                 }
 
                 related.add(related(cm, completeErrorTreeLoc,
-                    "Experts: the last grammar rule that was tried was `" + nonterminal + "` = "
+                    "Experts: the last grammar rule that was tried was `" + nonterminal + " = "
                         + prefix.stream()
                         .map(IConstructor.class::cast)
                         .map(x -> SymbolAdapter.toString(x, false))
@@ -177,6 +171,7 @@ public class Diagnostics {
                         .map(IConstructor.class::cast)
                         .map(x -> SymbolAdapter.toString(x, false))
                         .collect(Collectors.joining(" "))
+                        + "`"
                 ));
             }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -147,7 +147,7 @@ public class Diagnostics {
 
             related.add(related(cm, stuckLoc,
                "It is likely something is extra or missing here, or before this position. However, parsing can also have gone back here searching for a solution."));
-            related.add(related(cm, skippedLoc, "Parsing skipped this part to artificially complete a `" + nonterminal + "` and continue parsing. Something is missing or extra before the end of this part"));
+            related.add(related(cm, skippedLoc, "Parsing skipped this part to artificially complete a `" + nonterminal + "` and continue parsing. Something is missing or extra before the end of this part."));
             related.add(related(cm, prefixLoc, "This part of the `" + nonterminal + "` was still recognized until parsing got stuck."));
 
             // TODO: replace by ProductionAdapter calls once they are available with the new RC of Rascal
@@ -159,6 +159,8 @@ public class Diagnostics {
                 IList symbols = ProductionAdapter.getSymbols(prod);
                 IList prefix = symbols.sublist(0, dot);
                 IList postfix = symbols.sublist(dot, symbols.length());
+
+                related.add(related(cm, stuckLoc, "Experts: a `" + nonterminal + "` was the last but probably not the only grammar rule that was tried at this position."));
 
                 if (dot == 0) {
                     related.add(related(cm, stuckLoc, "Experts: no (start of) any alternative of `" + nonterminal + "` could be matched."));


### PR DESCRIPTION
- **reusing the information in an error tree and using the concept of Related Information in LSP diagnostic messages the parse errors were simplified for beginner users, while extra information is provided for expert users**
- **finetuning messages**
- **minor fixes**
