### PR TITLE
Some experiments to see what rascal-lsp Rascal code could look like with error tree support

### DIFF
--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -109,7 +109,7 @@ Summary picoSummaryService(loc l, start[Program] input, PicoSummarizerMode mode)
     Summary s = summary(l);
 
     // definitions of variables
-    rel[str, loc] defs = {<"<var.id>", var.src> | /IdType var := input, !hasParseErrors(var)};
+    rel[str, loc] defs = {<"<var.id>", var.src> | /IdType var := input, var.id?};
 
     // uses of identifiers
     rel[loc, str] uses = {<id.src, "<id>"> | /Id id := input};

--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -89,7 +89,7 @@ symbol search in the editor.
 }
 list[DocumentSymbol] picoDocumentSymbolService(start[Program] input)
   = [symbol("<input.src>", DocumentSymbolKind::\file(), input.src, children=[
-      *[symbol("<var.id>", \variable(), var.src) | /IdType var := input, !hasParseErrors(var)]
+      *[symbol("<var.id>", \variable(), var.src) | /IdType var := input, var.id?]
   ])];
 
 @synopsis{The analyzer maps pico syntax trees to error messages and references}

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/DocumentSymbols.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/DocumentSymbols.rsc
@@ -45,7 +45,7 @@ list[DocumentSymbol] documentRascalSymbols(start[Module] \mod) {
     top-down-break visit (m) {
         case amb(set[Tree] _): {/* stop here, and do not show this node not its children in the outline */;}
         case (Declaration) `<Tags _> <Visibility _> <Type t> <{Variable ","}+ vars>;`:
-            children += [symbol(clean("<v.name>"), variable(), v@\loc, detail="variable <t> <v>") | v <- vars, !hasParseErrors(v)];
+            children += [symbol(clean("<v.name>"), variable(), v@\loc, detail="variable <t> <v>") | v <- vars, v.name?];
 
         case decl: (Declaration) `<Tags _> <Visibility _> anno <Type t> <Type ot>@<Name name>;`:
             if (!hasParseErrors(decl)) {
@@ -79,7 +79,7 @@ list[DocumentSymbol] documentRascalSymbols(start[Module] \mod) {
         }
 
         case FunctionDeclaration func :
-            if (!hasParseErrors(func)) {
+            if (func.signature? && !hasParseErrors(func.signature)) {
                 children += [symbol("<func.signature.name><func.signature.parameters>", \function(), (func.signature)@\loc, detail="<func.signature.\type>")];
             }
 


### PR DESCRIPTION
Changes are minor. The only real improvement is that a parse error in the function body of a Rascal function no longer removes the function from the outline.