### PR TITLE
Avoid using the common thread pool and give the thread pools a name

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
@@ -118,19 +118,20 @@ public abstract class BaseLanguageServer {
 
     private static final Logger logger = LogManager.getLogger(BaseLanguageServer.class);
 
-    private static Launcher<IBaseLanguageClient> constructLSPClient(Socket client, ActualLanguageServer server)
+    private static Launcher<IBaseLanguageClient> constructLSPClient(Socket client, ActualLanguageServer server, ExecutorService threadPool)
         throws IOException {
         client.setTcpNoDelay(true);
-        return constructLSPClient(client.getInputStream(), client.getOutputStream(), server);
+        return constructLSPClient(client.getInputStream(), client.getOutputStream(), server, threadPool);
     }
 
-    private static Launcher<IBaseLanguageClient> constructLSPClient(InputStream in, OutputStream out, ActualLanguageServer server) {
+    private static Launcher<IBaseLanguageClient> constructLSPClient(InputStream in, OutputStream out, ActualLanguageServer server, ExecutorService threadPool) {
         Launcher<IBaseLanguageClient> clientLauncher = new Launcher.Builder<IBaseLanguageClient>()
             .setLocalService(server)
             .setRemoteInterface(IBaseLanguageClient.class)
             .setInput(in)
             .setOutput(out)
             .configureGson(BaseLanguageServer::configureGson)
+            .setExecutorService(threadPool)
             .create();
 
         server.connect(clientLauncher.getRemoteProxy());
@@ -169,7 +170,7 @@ public abstract class BaseLanguageServer {
             var docService = docServiceProvider.apply(threadPool);
             var wsService = workspaceServiceProvider.apply(threadPool, docService);
             docService.pair(wsService);
-            startLSP(constructLSPClient(capturedIn, capturedOut, new ActualLanguageServer(() -> System.exit(0), docService, wsService)));
+            startLSP(constructLSPClient(capturedIn, capturedOut, new ActualLanguageServer(() -> System.exit(0), threadPool, docService, wsService), threadPool));
         }
         else {
             try (ServerSocket serverSocket = new ServerSocket(portNumber, 0, InetAddress.getByName("127.0.0.1"))) {
@@ -178,7 +179,7 @@ public abstract class BaseLanguageServer {
                     var docService = docServiceProvider.apply(threadPool);
                     var wsService = workspaceServiceProvider.apply(threadPool, docService);
                     docService.pair(wsService);
-                    startLSP(constructLSPClient(serverSocket.accept(), new ActualLanguageServer(() -> {}, docService, wsService)));
+                    startLSP(constructLSPClient(serverSocket.accept(), new ActualLanguageServer(() -> {}, threadPool, docService, wsService), threadPool));
                 }
             } catch (IOException e) {
                 logger.fatal("Failure to start TCP server", e);
@@ -223,10 +224,12 @@ public abstract class BaseLanguageServer {
         private final IBaseTextDocumentService lspDocumentService;
         private final BaseWorkspaceService lspWorkspaceService;
         private final Runnable onExit;
+        private final ExecutorService executor;
         private IDEServicesConfiguration ideServicesConfiguration;
 
-        private ActualLanguageServer(Runnable onExit, IBaseTextDocumentService lspDocumentService, BaseWorkspaceService lspWorkspaceService) {
+        private ActualLanguageServer(Runnable onExit, ExecutorService executor, IBaseTextDocumentService lspDocumentService, BaseWorkspaceService lspWorkspaceService) {
             this.onExit = onExit;
+            this.executor = executor;
             this.lspDocumentService = lspDocumentService;
             this.lspWorkspaceService = lspWorkspaceService;
         }
@@ -264,7 +267,7 @@ public abstract class BaseLanguageServer {
                     logger.catching(e);
                     throw new CompletionException(e);
                 }
-            });
+            }, executor);
         }
 
         private static PathConfig findPathConfig(ISourceLocation path, RascalConfigMode mode, AtomicBoolean isRascal) throws IOException {
@@ -304,42 +307,47 @@ public abstract class BaseLanguageServer {
                     logger.catching(e);
                     throw new CompletionException(e);
                 }
-            });
+            }, executor);
         }
 
         @Override
         public CompletableFuture<Void> sendRegisterLanguage(LanguageParameter lang) {
-            return CompletableFuture.runAsync(() -> lspDocumentService.registerLanguage(lang));
+            return CompletableFuture.runAsync(() -> lspDocumentService.registerLanguage(lang), executor);
         }
         @Override
         public CompletableFuture<Void> sendUnregisterLanguage(LanguageParameter lang) {
-            return CompletableFuture.runAsync(() -> lspDocumentService.unregisterLanguage(lang));
+            return CompletableFuture.runAsync(() -> lspDocumentService.unregisterLanguage(lang), executor);
         }
 
         @Override
         public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-            logger.info("LSP connection started (connected to {} version {})", params.getClientInfo().getName(), params.getClientInfo().getVersion());
-            logger.debug("LSP client capabilities: {}", params.getCapabilities());
-            final InitializeResult initializeResult = new InitializeResult(new ServerCapabilities());
-            lspDocumentService.initializeServerCapabilities(initializeResult.getCapabilities());
-            lspWorkspaceService.initialize(params.getCapabilities(), params.getWorkspaceFolders(), initializeResult.getCapabilities());
-            logger.debug("Initialized LSP connection with capabilities: {}", initializeResult);
-
-            return CompletableFuture.completedFuture(initializeResult);
+            return CompletableFuture.supplyAsync(() -> {
+                logger.info("LSP connection started (connected to {} version {})", params.getClientInfo().getName(), params.getClientInfo().getVersion());
+                logger.debug("LSP client capabilities: {}", params.getCapabilities());
+                final InitializeResult initializeResult = new InitializeResult(new ServerCapabilities());
+                lspDocumentService.initializeServerCapabilities(initializeResult.getCapabilities());
+                lspWorkspaceService.initialize(params.getCapabilities(), params.getWorkspaceFolders(), initializeResult.getCapabilities());
+                logger.debug("Initialized LSP connection with capabilities: {}", initializeResult);
+                return initializeResult;
+            }, executor);
         }
 
         @Override
         @SuppressWarnings("unused") // InitializedParams is an empty interface
         public void initialized(InitializedParams params) {
-            logger.debug("LSP connection initialized");
-            lspWorkspaceService.initialized();
-            lspDocumentService.initialized();
+            executor.submit(() -> {
+                logger.debug("LSP connection initialized");
+                lspWorkspaceService.initialized();
+                lspDocumentService.initialized();
+            });
         }
 
         @Override
         public CompletableFuture<Object> shutdown() {
-            lspDocumentService.shutdown();
-            return CompletableFuture.completedFuture(null);
+            return CompletableFuture.supplyAsync(() -> {
+                lspDocumentService.shutdown();
+                return null;
+            }, executor);
         }
 
         @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IRascalFileSystemServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IRascalFileSystemServices.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.Base64.Encoder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -55,14 +56,15 @@ import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.uri.UnsupportedSchemeException;
 import org.rascalmpl.values.IRascalValueFactory;
+import org.rascalmpl.vscode.lsp.util.NamedThreadPool;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
-
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValueFactory;
 
 public interface IRascalFileSystemServices {
     static final URIResolverRegistry reg = URIResolverRegistry.getInstance();
     static final Logger IRascalFileSystemServices__logger = LogManager.getLogger(IDEServicesThread.class);
+    static final ExecutorService executor = NamedThreadPool.cachedDaemon("rascal-vfs", 4);
 
     @JsonRequest("rascal/filesystem/resolveLocation")
     default CompletableFuture<SourceLocation> resolveLocation(SourceLocation loc) {
@@ -81,7 +83,7 @@ public interface IRascalFileSystemServices {
                 IRascalFileSystemServices__logger.warn("Could not resolve location {}", loc, e);
                 return loc;
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/watch")
@@ -100,7 +102,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException | RuntimeException e) {
                 throw new VSCodeFSError(e);
             }
-        });
+        }, executor);
     }
 
     static FileChangeEvent convertChangeEvent(ISourceLocationChanged changed) throws IOException {
@@ -161,7 +163,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException | RuntimeException e) {
                 throw new VSCodeFSError(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/readDirectory")
@@ -177,7 +179,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException | RuntimeException e) {
                 throw new VSCodeFSError(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/createDirectory")
@@ -188,7 +190,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException | RuntimeException e) {
                 throw new VSCodeFSError(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/readFile")
@@ -218,7 +220,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException | RuntimeException e) {
                 throw new VSCodeFSError(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/writeFile")
@@ -249,7 +251,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException | RuntimeException e) {
                 throw new VSCodeFSError(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/delete")
@@ -261,7 +263,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException e) {
                 throw new CompletionException(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/rename")
@@ -274,7 +276,7 @@ public interface IRascalFileSystemServices {
             } catch (IOException | URISyntaxException e) {
                 throw new CompletionException(e);
             }
-        });
+        }, executor);
     }
 
     @JsonRequest("rascal/filesystem/schemes")

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricLanguageServer.java
@@ -26,11 +26,10 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
-import java.util.concurrent.Executors;
 
 import org.rascalmpl.vscode.lsp.BaseLanguageServer;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
-
+import org.rascalmpl.vscode.lsp.util.NamedThreadPool;
 import com.google.gson.GsonBuilder;
 
 public class ParametricLanguageServer extends BaseLanguageServer {
@@ -43,7 +42,7 @@ public class ParametricLanguageServer extends BaseLanguageServer {
             dedicatedLanguage = null;
         }
 
-        startLanguageServer(Executors.newCachedThreadPool()
+        startLanguageServer(NamedThreadPool.cached("parametric", 8)
             , threadPool -> new ParametricTextDocumentService(threadPool, dedicatedLanguage)
             , ParametricWorkspaceService::new
             , 9999

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -839,7 +839,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                 var location = lang.getPrecompiledParser().getParserLocation();
                 if (URIResolverRegistry.getInstance().exists(location)) {
                     logger.debug("Got precompiled definition: {}", lang.getPrecompiledParser());
-                    multiplexer.addContributor(buildContributionKey(lang) + "$parser", new ParserOnlyContribution(lang.getName(), lang.getPrecompiledParser()));
+                    multiplexer.addContributor(buildContributionKey(lang) + "$parser", new ParserOnlyContribution(lang.getName(), lang.getPrecompiledParser(), ownExecuter));
                 }
                 else {
                     logger.error("Defined precompiled parser ({}) does not exist", lang.getPrecompiledParser());

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -633,7 +633,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     }
 
     private CompletableFuture<IList> computeCodeActions(final int startLine, final int startColumn, ITree tree, PathConfig pcfg) {
-        return CompletableFuture.<IList>supplyAsync(() -> TreeSearch.computeFocusList(tree, startLine, startColumn))
+        return CompletableFuture.<IList>supplyAsync(() -> TreeSearch.computeFocusList(tree, startLine, startColumn), ownExecuter)
             .thenCompose(focus -> focus.isEmpty()
                 ? CompletableFuture.completedFuture(focus /* an empty list */)
                 : rascalServices.codeActions(focus, pcfg).get());

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/impl/VSCodeVFSClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/impl/VSCodeVFSClient.java
@@ -37,18 +37,18 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.rascalmpl.uri.ISourceLocationWatcher;
+import org.rascalmpl.vscode.lsp.IRascalFileSystemServices;
 import org.rascalmpl.vscode.lsp.uri.jsonrpc.VSCodeUriResolverClient;
 import org.rascalmpl.vscode.lsp.uri.jsonrpc.VSCodeUriResolverServer;
 import org.rascalmpl.vscode.lsp.uri.jsonrpc.VSCodeVFS;
 import org.rascalmpl.vscode.lsp.uri.jsonrpc.messages.ISourceLocationChanged;
 import org.rascalmpl.vscode.lsp.uri.jsonrpc.messages.WatchRequest;
-import engineering.swat.watch.DaemonThreadPool;
+import org.rascalmpl.vscode.lsp.util.NamedThreadPool;
 import io.usethesource.vallang.ISourceLocation;
 
 public class VSCodeVFSClient implements VSCodeUriResolverClient, AutoCloseable {
@@ -155,7 +155,7 @@ public class VSCodeVFSClient implements VSCodeUriResolverClient, AutoCloseable {
 
 
 
-    private static final ExecutorService exec = DaemonThreadPool.buildConstrainedCached("FallbackResolver watcher thread-pool", 4);
+    private static final ExecutorService exec = NamedThreadPool.cachedDaemon("FallbackResolver-watcher", 4);
 
     /**
     * The watch api in rascal uses closures identity to keep track of watches.
@@ -213,7 +213,7 @@ public class VSCodeVFSClient implements VSCodeUriResolverClient, AutoCloseable {
                 .setLocalService(newClient)
                 .setInput(socket.getInputStream())
                 .setOutput(socket.getOutputStream())
-                .setExecutorService(Executors.newCachedThreadPool())
+                .setExecutorService(IRascalFileSystemServices.executor)
                 .create();
 
             clientLauncher.startListening();


### PR DESCRIPTION
This PR introduces:

- nicely named threads (this helps with the log reading)
- all work is always done on our threads, and not on the common forkjoin pool, which shouldn't only be used for scheduling
- threads are cleaned up after a time not used, as to avoid old threads hanging around for longer than needed.