### PR TITLE
The file extension of a doc uri is now done more robustly

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -28,6 +28,7 @@ package org.rascalmpl.vscode.lsp.parametric;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -606,7 +607,8 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         throw new UnsupportedOperationException("Rascal Parametric LSP has no support for this file: " + doc);
     }
 
-    private static String extension(String file) {
+    private static String extension(String doc) {
+        String file = URI.create(doc).getPath();
         int index = file.lastIndexOf(".");
         if (index != -1) {
             return file.substring(index + 1);


### PR DESCRIPTION
When opening a diff pane in VSCode for a file written in a DSL produced errors because the code that determined the file extension did not take into account that the document uri could contain query parameters.
By first parsing the document uri as an URI object and then using the "path" part to determine the file extension solves this problem.

This closes #746 