### PR TITLE
Fix the logic to compute REPL titles

### DIFF
--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -181,21 +181,12 @@ export class RascalExtension implements vscode.Disposable {
                     return "no project";
                 }
                 case 'Module (qualified)': {
-                    const name = startCommand.match(this.qualifiedName);
-                    if (name && name[1]) {
-                        if (name[0] !== '') {
-                            return name[0] + "::" + name[1];
-                        }
-                        return name[1];
-                    }
-                    return "no module";
+                    const [_, qualifiers, name] = startCommand.match(this.qualifiedName) ?? [];
+                    return name ? `${qualifiers ?? ''}${name}` : 'no module';
                 }
                 case 'Module (unqualified)': {
-                    const name = startCommand.match(this.qualifiedName);
-                    if (name && name[1]) {
-                        return name[1];
-                    }
-                    return "no module";
+                    const [_1, _2, name] = startCommand.match(this.qualifiedName) ?? [];
+                    return name ?? "no module";
                 }
                 default:
                     this.log.warn(`Unknown origin format: ${originFormat}`);
@@ -208,7 +199,7 @@ export class RascalExtension implements vscode.Disposable {
         const name1 = '(?:[A-Z_a-z][0-9A-Z_a-z]*)';
         const name2 = '(?:\\\\[A-Z_a-z][\\-0-9A-Z_a-z]*)';
         const name = `(?:${name1}|${name2})`;
-        const qualifiedName = `(?:(?:${name}::)*(${name}))`;
+        const qualifiedName = `((?:${name}::)*)(${name})`;
         return new RegExp(`^import ${qualifiedName};`);
     })(); // Build the regex only once
 


### PR DESCRIPTION
Fixes #751

<img width="400" height="78" alt="image" src="https://github.com/user-attachments/assets/faa039bc-e64b-4b08-b237-ce711c5f4ff7" />

Post-mortem: As part of the move to JLine 3, the command to startup REPLs was changed. Corresponding changes to extract REPL titles from such commands were made in commit d68ecad, but it didn't work exactly as intended.