### PR TITLE
Fix exception logging

### DIFF
--- a/package-and-run.sh
+++ b/package-and-run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+./package.sh
+
+TMPDIR=$(mktemp --directory)
+VSIX_LATEST=$(ls -t1 **/*.vsix | head -1)
+CODE_COMMAND="code --extensions-dir ${TMPDIR}/extensions --user-data-dir ${TMPDIR}/data"
+
+${CODE_COMMAND} --install-extension "${VSIX_LATEST}" --force
+${CODE_COMMAND} --new-window "$1"

--- a/package-and-run.sh
+++ b/package-and-run.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
+set -x
 
 ./package.sh
 
 TMPDIR=$(mktemp --directory)
+# shellcheck disable=SC2012
 VSIX_LATEST=$(ls -t1 **/*.vsix | head -1)
-CODE_COMMAND="code --extensions-dir ${TMPDIR}/extensions --user-data-dir ${TMPDIR}/data"
+CODE_COMMAND="code --extensions-dir $TMPDIR/ext --user-data-dir $TMPDIR/data"
 
-${CODE_COMMAND} --install-extension "${VSIX_LATEST}" --force
-${CODE_COMMAND} --new-window "$1"
+mkdir -p "$TMPDIR"/{ext,data}
+
+$CODE_COMMAND --install-extension "$VSIX_LATEST" --force
+$CODE_COMMAND --new-window "${1:-}" # optionally pass a workspace/folder/file to open

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -188,6 +188,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
 
     @Override
     public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
+        logger.debug("workspace/executeCommand: {}", params);
         if (params.getCommand().startsWith(RASCAL_META_COMMAND) || params.getCommand().startsWith(RASCAL_COMMAND)) {
             String languageName = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
             String command = ((JsonPrimitive) params.getArguments().get(1)).getAsString();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -585,7 +585,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .thenApplyAsync(rascalServices::locateCodeLenses, ownExecuter)
             .thenApply(List::stream)
             .thenApply(res -> res.map(this::makeRunCodeLens))
-            .thenApply(s -> s.collect(Collectors.toList())), Collections::emptyList)
+            .thenApply(s -> s.collect(Collectors.toList())), () -> null)
             ;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -591,7 +591,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     @Override
     public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
-        logger.debug("codeAction: {}", params);
+        logger.debug("textDocument/codeAction: {}", params);
 
         var range = Locations.toRascalRange(params.getTextDocument(), params.getRange(), columns);
         var loc = Locations.toLoc(params.getTextDocument());

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -379,7 +379,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .map(f -> Locations.toLoc(f.getUri()))
             .collect(Collectors.toSet());
 
-        return recoverExceptions(file.getCurrentTreeAsync()
+        return file.getCurrentTreeAsync()
             .thenApply(Versioned::get)
             .handle((t, r) -> (t == null ? file.getLastTreeWithoutErrors().get() : t))
             .thenCompose(tr -> {
@@ -391,7 +391,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .thenApply(t -> {
                 showMessages((ISet) t.get(1));
                 return DocumentChanges.translateDocumentChanges(this, (IList) t.get(0));
-            }), () -> null);
+            });
     }
 
     private void showMessages(ISet messages) {

--- a/rascal-lsp/src/main/resources/JsonLogTemplate.json
+++ b/rascal-lsp/src/main/resources/JsonLogTemplate.json
@@ -16,5 +16,12 @@
     },
     "message": {
         "$resolver": "message"
+    },
+    "exception": {
+        "$resolver": "exception",
+        "field": "stackTrace",
+        "stackTrace": {
+          "stringified": true
+        }
     }
 }

--- a/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
+++ b/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
@@ -83,7 +83,7 @@ class LogMessage {
  */
 export class JsonParserOutputChannel implements vscode.LogOutputChannel {
     readonly name: string;
-    readonly logLevel: vscode.LogLevel;
+    logLevel: vscode.LogLevel;
 
     private readonly logChannel: vscode.LogOutputChannel;
     private client?: LanguageClient = undefined;
@@ -107,6 +107,7 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
     }
 
     private didChangeLogLevel(level: vscode.LogLevel) {
+        this.logLevel = level;
         // since vscode.LogLevel is a subset of LogLevel, and the same order, we can convert easily
         const newLevel = Object.values(LogLevel)[level];
         if (!this.client) {

--- a/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
+++ b/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
@@ -172,21 +172,16 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
         return date.getTime();
     }
 
-    private formatException(log: LogMessage): string {
-        if (!log.exception || log.exception === "") {
-            return "";
-        }
-        return log.exception;
-    }
-
     private formatMessage(log: LogMessage) {
-        return `[${log.threadName}] ${log.loggerName} ${log.message} ${this.formatException(log)}(@${this.formatServerTime(log.timestamp)} ms)`;
+        return `[${log.threadName}] ${log.loggerName} ${log.message} ${log.exception ? log.exception : ""}(@${this.formatServerTime(log.timestamp)} ms)`;
     }
 
+    // This is called from the server side, a.k.a. with JSON payloads (possibly multiple, one per line)
     append(payload: string): void {
         this.printPayloads(payload);
     }
 
+    // This is called from the client with straight info messages
     appendLine(payload: string): void {
         this.logChannel.appendLine(payload);
     }

--- a/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
+++ b/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
@@ -81,8 +81,9 @@ class LogMessage {
  *
  * Received messages that are not JSON or not in the expected format are printed as-is.
  */
-export class JsonParserOutputChannel implements vscode.OutputChannel {
+export class JsonParserOutputChannel implements vscode.LogOutputChannel {
     readonly name: string;
+    readonly logLevel: vscode.LogLevel;
 
     private readonly logChannel: vscode.LogOutputChannel;
     private client?: LanguageClient = undefined;
@@ -90,12 +91,12 @@ export class JsonParserOutputChannel implements vscode.OutputChannel {
     private readonly disposables: Array<vscode.Disposable> = [];
 
     constructor(name: string) {
+        this.name = name;
         this.logChannel = vscode.window.createOutputChannel(name, {log: true});
+        this.logLevel = this.logChannel.logLevel;
         this.disposables.push(this.logChannel);
 
         this.logChannel.onDidChangeLogLevel(this.didChangeLogLevel, this, this.disposables);
-
-        this.name = name;
     }
 
     setClient(client: LanguageClient) {
@@ -113,10 +114,6 @@ export class JsonParserOutputChannel implements vscode.OutputChannel {
             return;
         }
         this.client.sendNotification("rascal/logLevel", newLevel);
-    }
-
-    getLogChannel() {
-        return this.logChannel;
     }
 
     private printLogOutput(loglevel: LogLevel, message: string) {
@@ -191,7 +188,7 @@ export class JsonParserOutputChannel implements vscode.OutputChannel {
     }
 
     appendLine(payload: string): void {
-        this.printPayloads(payload);
+        this.logChannel.appendLine(payload);
     }
 
     show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
@@ -205,13 +202,40 @@ export class JsonParserOutputChannel implements vscode.OutputChannel {
     replace(value: string): void {
         this.logChannel.replace(value);
     }
+
     clear(): void {
         this.logChannel.clear();
     }
+
     hide(): void {
         this.logChannel.hide();
     }
+
     dispose(): void {
         vscode.Disposable.from(...this.disposables).dispose();
+    }
+
+    onDidChangeLogLevel(listener: (e: vscode.LogLevel) => unknown, thisArgs?: unknown, disposables?: vscode.Disposable[]): vscode.Disposable {
+        return this.logChannel.onDidChangeLogLevel(listener, thisArgs, disposables);
+    }
+
+    trace(message: string, ...args: unknown[]): void {
+        this.logChannel.trace(message, args);
+    }
+
+    debug(message: string, ...args: unknown[]): void {
+        this.logChannel.debug(message, args);
+    }
+
+    info(message: string, ...args: unknown[]): void {
+        this.logChannel.info(message, args);
+    }
+
+    warn(message: string, ...args: unknown[]): void {
+        this.logChannel.warn(message, args);
+    }
+
+    error(error: string | Error, ...args: unknown[]): void {
+        this.logChannel.error(error, args);
     }
 }

--- a/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
+++ b/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
@@ -43,13 +43,13 @@ enum LogLevel {
 }
 
 class LogMessage {
-    constructor(
+    private constructor(
         public readonly timestamp: Date,
         public readonly level: LogLevel,
-        public readonly message: string,
         public readonly threadName: string,
         public readonly loggerName: string,
-        public readonly exception: string) {}
+        public readonly message?: string,
+        public readonly exception?: string) {}
 
     static is(json: object): json is LogMessage {
         const log = json as LogMessage;

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -41,7 +41,7 @@ export async function activateLanguageClient(
     : Promise<LanguageClient> {
     const logger = new JsonParserOutputChannel(title);
     const serverOptions: ServerOptions = deployMode
-        ? await buildRascalServerOptions(jarPath, isParametricServer, dedicated, lspArg, logger.getLogChannel())
+        ? await buildRascalServerOptions(jarPath, isParametricServer, dedicated, lspArg, logger)
         : () => connectToRascalLanguageServerSocket(devPort) // we assume a server is running in debug mode
             .then((socket) => <StreamInfo> { writer: socket, reader: socket});
 
@@ -65,7 +65,7 @@ export async function activateLanguageClient(
 
     schemesReply.then( schemes => {
         vfsServer.ignoreSchemes(schemes);
-        new RascalFileSystemProvider(client, logger.getLogChannel()).tryRegisterSchemes(schemes);
+        new RascalFileSystemProvider(client, logger).tryRegisterSchemes(schemes);
     });
 
     return client;


### PR DESCRIPTION
Closes #724
Closes #745  
Closes #753

Should work nicely with this change in the upcoming `10.x` release of `vscode-languageclient` as well: https://github.com/microsoft/vscode-languageserver-node/pull/1630