### PR TITLE
Clearing column maps based on LSP events

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -344,8 +344,8 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     private TextDocumentState updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
         columns.clear(file.getLocation());
+        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
         return file;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -345,6 +345,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
         handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
+        columns.clear(file.getLocation());
         return file;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -273,6 +273,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
         handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
+        columns.clear(file.getLocation());
         return file;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -272,8 +272,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     private TextDocumentState updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
         columns.clear(file.getLocation());
+        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
         return file;
     }
 


### PR DESCRIPTION
This is a partial fix for #764 since some files might be changed outside of VS Code, but we're still opening column maps for them.

I think this combined with the watches added in https://github.com/usethesource/rascal/pull/2435 will be the full fix for issue #764 