### PR TITLE
Replacing eval.eval with eval.call to avoid double clearing of jobs in the LSP monitor

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -241,8 +241,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     private static ISet loadContributions(Evaluator eval, LanguageParameter lang) {
-        return (ISet) eval.eval(eval.getMonitor(), lang.getMainFunction() + "()", URIUtil.rootLocation("lsp"))
-            .getValue();
+        return (ISet) eval.call(eval.getMonitor(), lang.getMainFunction());
     }
 
     @Override


### PR DESCRIPTION
Fixes #775 