### PR TITLE
Fixed (non-recovery) parse error location reporting in DSLs

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -39,8 +39,10 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticRelatedInformation;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
+import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.parser.gtd.exception.ParseError;
 import org.rascalmpl.values.ValueFactoryFactory;
 import org.rascalmpl.values.parsetrees.ITree;
@@ -87,7 +89,31 @@ public class Diagnostics {
         public Diagnostic instantiate(ColumnMaps columns);
     }
 
-    public static Template generateParseErrorDiagnostic(ParseError e) {
+    public static Template generateParseErrorDiagnostic(Throwable t) {
+        if (t instanceof ParseError) {
+            return generateParseErrorDiagnostic((ParseError) t);
+        }
+
+        if (t instanceof Throw) {
+            IValue e = ((Throw) t).getException();
+            if (e instanceof IConstructor) {
+                IConstructor error = (IConstructor) e;
+                if (error.getName().equals(RuntimeExceptionFactory.ParseError.getName())) {
+                    ISourceLocation loc = (ISourceLocation) error.get(0);
+                    return cm -> new Diagnostic(Locations.toRange(loc, cm), PARSE_ERROR_MESSAGE, DiagnosticSeverity.Error,
+                            PARSER_DIAGNOSTICS_SOURCE);
+                }
+            }
+        }
+
+        logger.error("Parsing crashed", t);
+        return cm -> new Diagnostic(new Range(new Position(0,0), new Position(0,1)),
+                        "Parsing failed: " + t.getMessage(),
+                        DiagnosticSeverity.Error,
+                        "parser");
+    }
+
+    private static Template generateParseErrorDiagnostic(ParseError e) {
         return cm -> new Diagnostic(toRange(e, cm), PARSE_ERROR_MESSAGE, DiagnosticSeverity.Error, PARSER_DIAGNOSTICS_SOURCE);
     }
 
@@ -154,18 +180,6 @@ public class Diagnostics {
 
     private static DiagnosticRelatedInformation related(ColumnMaps cm, ISourceLocation loc, String message) {
         return new DiagnosticRelatedInformation(Locations.toLSPLocation(loc, cm), message);
-    }
-
-    public static Diagnostic translateRascalParseError(IValue e, ColumnMaps cm) {
-        if (e instanceof IConstructor) {
-            IConstructor error = (IConstructor) e;
-            if (error.getName().equals(RuntimeExceptionFactory.ParseError.getName())) {
-                ISourceLocation loc = (ISourceLocation) error.get(0);
-                return new Diagnostic(Locations.toRange(loc, cm), PARSE_ERROR_MESSAGE, DiagnosticSeverity.Error, PARSER_DIAGNOSTICS_SOURCE);
-            }
-        }
-
-        throw new IllegalArgumentException(e.toString());
     }
 
     private static void storeFixCommands(IConstructor d, Diagnostic result) {


### PR DESCRIPTION
When editing a DSL file without error recovery, parse errors where always reported at the start of the file.
Now the actual location of the parse error is used.

Fixes #779 