### PR TITLE
Better documentation of error recovery support for DSLs

### DIFF
--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -234,6 +234,11 @@ Register the Pico language and the contributions that supply the IDE with featur
 ((registerLanguage)) is called twice here:
 1. first for fast and cheap contributions
 2. asynchronously for the full monty that loads slower
+
+The `errorRecovery` parameter can be set to `true` to enable error recovery in the parser.
+When enabled, all the contributions in this file will mostly work when parse errors are
+present in the input because the contributions are written to be robust
+in the presence of error trees. See ((util::LanguageServer::LanguageServer)) for more details.
 }
 @benefits{
 * You can run each contribution on an example in the terminal to test it first.

--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -238,7 +238,7 @@ Register the Pico language and the contributions that supply the IDE with featur
 The `errorRecovery` parameter can be set to `true` to enable error recovery in the parser.
 When enabled, all the contributions in this file will mostly work when parse errors are
 present in the input because the contributions are written to be robust
-in the presence of error trees. See ((util::LanguageServer::LanguageServer)) for more details.
+in the presence of error trees. See ((util::LanguageServer)) for more details.
 }
 @benefits{
 * You can run each contribution on an example in the terminal to test it first.

--- a/rascal-lsp/src/main/rascal/library/util/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/util/LanguageServer.rsc
@@ -182,6 +182,11 @@ interpreter lock will make the editor services less responsive.
      syntax highlighting can update their grammars and explicitly opt-out of the
      special case by passing `usesSpecialCaseHighlighting = false` when
      registering the ((parsing)) service.
+   * You can enable error recovery in the parser like by setting `allowRecovery` to `true`: `parser(#start[Program], allowRecovery=true)`.
+With error recovery enabled  "hard" parse errors can still occur but that will be rare. In most cases parsing with error recovery enabled
+will produce a parse tree with error nodes. Syntax highlighting will still work on such trees. Note that any contributions that you add must be
+able to handle such error trees or unexpected things will happen like strange results and crashes. More information on error recovery and error trees
+can be found in ((ParseTree::Production)), ((ParseTree::parser)), and ((util::ParseErrorRecovery)).
 * The ((analysis)) service indexes a file as a ((Summary)), offering precomputed relations for looking up
 hover documentation, definition with uses, references to declarations, implementations of types and compiler errors and warnings.
    * ((analysis)) focuses on their own file, but may reuse cached or stored indices from other files.


### PR DESCRIPTION
This PR add some help for the designer of a DSL on how to enable and support error recovery.
This PR is currently in draft because more documentation is needed.

Closes #771 