### PR TITLE
Fix logic of when to clean outdated tpls

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -164,7 +164,7 @@ public class PathConfigs {
         private PathConfig actualBuild(ISourceLocation projectRoot, long newestConfig, @Nullable PathConfig prevPcfg) {
             final var newPcfg = PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.COMPILER, true);
             // Did the path config change?
-            if (newPcfg.equals(prevPcfg)) {
+            if (!newPcfg.equals(prevPcfg)) {
                 try {
                     cleanOutdatedTPLs(newPcfg.getBin(), newestConfig);
                 } catch (IOException e) {


### PR DESCRIPTION
The if condition was the wrong way around. We want to clean when the path config has changed.