### PR TITLE
editor and webview fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,25 +1,34 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
 
 extra_flags=''
+lint=0
 
 clean="clean"
-while getopts 'fd' flag; do
+while getopts 'lfd' flag; do
   case "${flag}" in
     f) extra_flags='-Drascal.compile.skip -Drascal.tutor.skip -DskipTests' ;;
+    l) lint=1 ;;
     d) clean='' ;;
     *) printf "incorrect param, valid params:
     Use -f to skip rascal-compile and tests
-    Use -d to skip cleaning the target folder"
+    Use -d to skip cleaning the target folder
+    Use -l to skip linting
+
+"
         exit 1 ;;
   esac
 done
 
 rm -f rascal-lsp/target/*.jar
 
-(cd rascal-lsp && mvn -B checkstyle:checkstyle  checkstyle:check )
+if (( $lint == 1 )); then
+   (cd rascal-lsp && mvn -B checkstyle:checkstyle  checkstyle:check )
+fi
 (cd rascal-lsp && mvn $clean package -Drascal.monitor.batch $extra_flags )
-(cd rascal-vscode-extension && npm run lint )
+if (( $lint == 1 )); then
+   (cd rascal-vscode-extension && npm run lint )
+fi
 (cd rascal-vscode-extension && npm run lsp4j:package )
 

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,8 @@ done
 
 rm -f rascal-lsp/target/*.jar
 
+(cd rascal-lsp && mvn -B checkstyle:checkstyle  checkstyle:check )
 (cd rascal-lsp && mvn $clean package -Drascal.monitor.batch $extra_flags )
+(cd rascal-vscode-extension && npm run lint )
 (cd rascal-vscode-extension && npm run lsp4j:package )
 

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.41.0-RC67-SNAPSHOT</version>
+      <version>0.41.0-RC67</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.41.0-RC66</version>
+      <version>0.41.0-RC67-SNAPSHOT</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseLanguageClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseLanguageClient.java
@@ -43,7 +43,7 @@ public interface IBaseLanguageClient extends LanguageClient {
     void receiveUnregisterLanguage(LanguageParameter lang);
 
     @JsonNotification("rascal/editDocument")
-	void editDocument(EditorParameter params);
+    void editDocument(EditorParameter params);
 
     /**
      * Notification sent to the vscode client to start a debugging session on the given debug adapter port

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseLanguageClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseLanguageClient.java
@@ -29,6 +29,7 @@ package org.rascalmpl.vscode.lsp;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.BrowseParameter;
+import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.EditorParameter;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 
 public interface IBaseLanguageClient extends LanguageClient {
@@ -40,6 +41,9 @@ public interface IBaseLanguageClient extends LanguageClient {
 
     @JsonNotification("rascal/receiveUnregisterLanguage")
     void receiveUnregisterLanguage(LanguageParameter lang);
+
+    @JsonNotification("rascal/editDocument")
+	void editDocument(EditorParameter params);
 
     /**
      * Notification sent to the vscode client to start a debugging session on the given debug adapter port

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -38,12 +38,13 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4j.ShowDocumentParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.rascalmpl.debug.IRascalMonitor;
 import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.BrowseParameter;
+import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.EditorParameter;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.util.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.DocumentChanges;
@@ -89,16 +90,15 @@ public class LSPIDEServices implements IDEServices {
     }
 
     @Override
-    public void edit(ISourceLocation path) {
+    public void edit(ISourceLocation path, int viewColumn) {
         ISourceLocation physical = Locations.toClientLocation(path);
-        ShowDocumentParams params = new ShowDocumentParams(physical.getURI().toASCIIString());
-        params.setTakeFocus(true);
 
+        Range range = null;
         if (physical.hasOffsetLength()) {
-            params.setSelection(Locations.toRange(physical, docService.getColumnMap(physical)));
+            range = Locations.toRange(physical, docService.getColumnMap(physical));
         }
 
-        languageClient.showDocument(params);
+        languageClient.editDocument(new EditorParameter(path.getURI().toASCIIString(), range, viewColumn));
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.library.util.ParseErrorRecovery;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -36,22 +36,14 @@ import java.util.function.BiFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.library.util.ParseErrorRecovery;
-import org.rascalmpl.parser.gtd.exception.ParseError;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.util.Diagnostics;
-import org.rascalmpl.vscode.lsp.util.Diagnostics.Template;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValue;
-import io.usethesource.vallang.IConstructor;
 
 /**
  * TextDocumentState encapsulates the current contents of every open file editor,
@@ -63,6 +55,7 @@ import io.usethesource.vallang.IConstructor;
  * and ParametricTextDocumentService.
  */
 public class TextDocumentState {
+    @SuppressWarnings("unused")
     private static final Logger logger = LogManager.getLogger(TextDocumentState.class);
     private static final ParseErrorRecovery RECOVERY = new ParseErrorRecovery(IRascalValueFactory.getInstance());
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -124,7 +124,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
         this.exec = exec;
 
         try {
-            var pcfg = new PathConfig().parse(lang.getPathConfig());
+            var pcfg = PathConfig.parse(lang.getPathConfig());
             pcfg = EvaluatorUtil.addLSPSources(pcfg, false);
 
             monitor = new RascalLSPMonitor(client, LogManager.getLogger(logger.getName() + "[" + lang.getName() + "]"), lang.getName() + ": ");

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/ITerminalIDEServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/ITerminalIDEServer.java
@@ -38,8 +38,7 @@ import java.util.Base64.Encoder;
 import java.util.concurrent.CompletableFuture;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.eclipse.lsp4j.ShowDocumentParams;
-import org.eclipse.lsp4j.ShowDocumentResult;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.rascalmpl.values.IRascalValueFactory;
@@ -67,7 +66,7 @@ public interface ITerminalIDEServer {
     }
 
     @JsonRequest
-    default CompletableFuture<ShowDocumentResult> edit(ShowDocumentParams edit)  {
+    default CompletableFuture<Void> edit(EditorParameter edit)  {
         throw new UnsupportedOperationException();
     }
 
@@ -230,6 +229,30 @@ public interface ITerminalIDEServer {
         @Override
         public String toString() {
             return "editParameter: " + module;
+        }
+    }
+
+    public static class EditorParameter {
+        private String uri;
+        private int viewColumn;
+        private Range range;
+
+        public EditorParameter(String uri, Range range, int viewColumn) {
+            this.uri = uri;
+            this.range = range;
+            this.viewColumn = viewColumn;
+        }
+
+        public Range getRange() {
+            return range;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public int getViewColumn() {
+            return viewColumn;
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
@@ -35,7 +35,7 @@ import java.net.URI;
 import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.lsp4j.ShowDocumentParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.jline.terminal.Terminal;
 import org.rascalmpl.debug.IRascalMonitor;
@@ -44,6 +44,7 @@ import org.rascalmpl.library.Prelude;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.BrowseParameter;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.DocumentEditsParameter;
+import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.EditorParameter;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.LanguageParameter;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.RegisterDiagnosticsParameters;
 import org.rascalmpl.vscode.lsp.terminal.ITerminalIDEServer.RegisterLocationsParameters;
@@ -100,16 +101,15 @@ public class TerminalIDEClient implements IDEServices {
     }
 
     @Override
-    public void edit(ISourceLocation path) {
+    public void edit(ISourceLocation path, int viewColumn) {
         ISourceLocation physical = Locations.toClientLocation(path);
-        ShowDocumentParams params = new ShowDocumentParams(physical.getURI().toASCIIString());
-        params.setTakeFocus(true);
 
+        Range range = null;
         if (physical.hasOffsetLength()) {
-            params.setSelection(Locations.toRange(physical, columns));
+            range = Locations.toRange(physical, columns);
         }
 
-        server.edit(params);
+        server.edit(new EditorParameter(physical.getURI().toASCIIString(), range, viewColumn));
     }
 
     private String getContents(ISourceLocation file) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEServer.java
@@ -38,8 +38,6 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4j.ShowDocumentParams;
-import org.eclipse.lsp4j.ShowDocumentResult;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.rascalmpl.uri.LogicalMapResolver;
 import org.rascalmpl.uri.URIResolverRegistry;
@@ -79,9 +77,9 @@ public class TerminalIDEServer implements ITerminalIDEServer {
     }
 
     @Override
-    public CompletableFuture<ShowDocumentResult> edit(ShowDocumentParams edit) {
+    public CompletableFuture<Void> edit(EditorParameter edit) {
         logger.trace("edit({})", edit);
-        return languageClient.showDocument(edit);
+        return CompletableFuture.runAsync(() -> languageClient.editDocument(edit));
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -220,10 +220,6 @@ public class Diagnostics {
         return result;
     }
 
-    private static Range toRange(ITree t, ColumnMaps cm) {
-        return toRange(TreeAdapter.getLocation(t), cm);
-    }
-
     private static Range toRange(ParseError pe, ColumnMaps cm) {
         return toRange(pe.getLocation(), cm);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
@@ -194,7 +194,7 @@ public class EvaluatorUtil {
 
     private enum ErrorHandlingOption {
         // The order in which these values are declared is the order in which they will appear in the VS Code tooltip
-        REPORT_ON_GITHUB("Report on GitHub"),
+        REPORT_ON_GITHUB("Report on GitHub with usethesource/rascal-language-servers"),
         COPY_STACK_TRACE("Copy stack trace to clipboard"),
         IGNORE("Ignore");
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
@@ -194,7 +194,7 @@ public class EvaluatorUtil {
 
     private enum ErrorHandlingOption {
         // The order in which these values are declared is the order in which they will appear in the VS Code tooltip
-        REPORT_ON_GITHUB("Report on GitHub with usethesource/rascal-language-servers"),
+        REPORT_ON_GITHUB("Report on Rascal GitHub"),
         COPY_STACK_TRACE("Copy stack trace to clipboard"),
         IGNORE("Ignore");
 

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -14,7 +14,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.13.0-opendag",
+  "version": "0.13.0-head",
   "engines": {
     "vscode": "^1.90.0",
     "node": ">=20.9.0"

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -14,7 +14,7 @@
     "color": "#ffffff",
     "theme": "light"
   },
-  "version": "0.13.0-head",
+  "version": "0.13.0-opendag",
   "engines": {
     "vscode": "^1.90.0",
     "node": ">=20.9.0"

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -64,7 +64,7 @@ export async function activateLanguageClient(
 
 
     client.onNotification("rascal/editDocument", (e:EditorParameter) => {
-        openEditor(e.uri, e.range, e.viewColumn)
+        openEditor(e.uri, e.range, e.viewColumn);
     });
 
     const schemesReply = client.sendRequest<string[]>("rascal/filesystem/schemes");
@@ -112,24 +112,24 @@ async function showContentPanel(url: string, title:string, viewColumn:integer): 
 }
 
 async function openEditor(uriString: string, range:vscode.Range, viewColumn: integer) {
-        const uri = vscode.Uri.parse(uriString);
+    const uri = vscode.Uri.parse(uriString);
 
-        const doc = await vscode.workspace.openTextDocument(uri);
+    const doc = await vscode.workspace.openTextDocument(uri);
 
-        // Show it in an editor
-        const editor = await vscode.window.showTextDocument(doc, {
-             // make sure it's not a preview, otherwise it will dissappear with the next focus change:
-            preview: false,
-            // put it where we want: if another editor is open for the same URI _and_ the same viewColumn, that one will be reused:
-            viewColumn: viewColumn,
-            // will let this editor take focus:
-            preserveFocus: false,
-            // don't use the `selection` field here because we can not control scrolling behavior from that with editors which are already open
-        });
+    // Show it in an editor
+    const editor = await vscode.window.showTextDocument(doc, {
+        // make sure it's not a preview, otherwise it will dissappear with the next focus change:
+        preview: false,
+        // put it where we want: if another editor is open for the same URI _and_ the same viewColumn, that one will be reused:
+        viewColumn: viewColumn,
+        // will let this editor take focus:
+        preserveFocus: false,
+        // don't use the `selection` field here because we can not control scrolling behavior from that with editors which are already open
+    });
 
-        // set the primary selection and move it into view (but don't scroll unless necessary)
-        editor.selection = new vscode.Selection(range.start, range.end);
-        editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    // set the primary selection and move it into view (but don't scroll unless necessary)
+    editor.selection = new vscode.Selection(range.start, range.end);
+    editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
 }
 
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -57,8 +57,14 @@ export async function activateLanguageClient(
     client.sendNotification("rascal/vfs/register", {
         port: vfsServer.port
     });
+
     client.onNotification("rascal/showContent", (bp:BrowseParameter) => {
         showContentPanel(bp.uri, bp.title, bp.viewColumn);
+    });
+
+
+    client.onNotification("rascal/editDocument", (e:EditorParameter) => {
+        openEditor(e.uri, e.range, e.viewColumn)
     });
 
     const schemesReply = client.sendRequest<string[]>("rascal/filesystem/schemes");
@@ -105,6 +111,27 @@ async function showContentPanel(url: string, title:string, viewColumn:integer): 
     contentPanels.set(id, panel);
 }
 
+async function openEditor(uriString: string, range:vscode.Range, viewColumn: integer) {
+        const uri = vscode.Uri.parse(uriString);
+
+        const doc = await vscode.workspace.openTextDocument(uri);
+
+        // Show it in an editor
+        const editor = await vscode.window.showTextDocument(doc, {
+             // make sure it's not a preview, otherwise it will dissappear with the next focus change:
+            preview: false,
+            // put it where we want: if another editor is open for the same URI _and_ the same viewColumn, that one will be reused:
+            viewColumn: viewColumn,
+            // will let this editor take focus:
+            preserveFocus: false,
+            // don't use the `selection` field here because we can not control scrolling behavior from that with editors which are already open
+        });
+
+        // set the primary selection and move it into view (but don't scroll unless necessary)
+        editor.selection = new vscode.Selection(range.start, range.end);
+        editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+}
+
 
 function loadURLintoPanel(panel:vscode.WebviewPanel, url:string): void {
     panel.webview.html = `
@@ -122,7 +149,7 @@ function loadURLintoPanel(panel:vscode.WebviewPanel, url:string): void {
                 sandbox="allow-scripts allow-forms allow-same-origin allow-pointer-lock allow-downloads allow-top-navigation"
                 style="display: block; margin: 0px; overflow: hidden; position: absolute; width: 100%; height: 100%; visibility: visible;"
             >
-            Loading ${url}...
+            Loading ${url} at ${new Date().toLocaleTimeString()}
             </iframe>
             </body>
             </html>`;
@@ -134,6 +161,13 @@ interface BrowseParameter {
     title: string;
     viewColumn:integer;
 }
+
+interface EditorParameter {
+    uri: string;
+    viewColumn: integer;
+    range: vscode.Range;
+}
+
 
 async function buildRascalServerOptions(jarPath: string, isParametricServer: boolean, dedicated: boolean, lspArg: string | undefined, logger: vscode.LogOutputChannel): Promise<ServerOptions> {
     const classpath = buildCompilerJVMPath(jarPath);

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -95,6 +95,7 @@ async function showContentPanel(url: string, title:string, viewColumn:integer): 
         },
         {
             enableScripts: true,
+            retainContextWhenHidden: true, /* otherwise the whole page reloads every time we loose focus */
         }
     );
 

--- a/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
@@ -26,13 +26,12 @@
  */
 import * as vscode from 'vscode';
 
-import { BaseLanguageClient } from 'vscode-languageclient';
+import { BaseLanguageClient, integer } from 'vscode-languageclient';
 import { VSCodeUriResolverServer } from '../fs/VSCodeURIResolver';
 import { activateLanguageClient } from './RascalLSPConnection';
 import { LanguageParameter, ParameterizedLanguageServer } from './ParameterizedLanguageServer';
 import { RascalDebugClient } from '../dap/RascalDebugClient';
 import { RASCAL_LANGUAGE_ID } from '../Identifiers';
-
 
 export class RascalLanguageServer implements vscode.Disposable {
     public readonly rascalClient: Promise<BaseLanguageClient>;
@@ -76,6 +75,5 @@ export class RascalLanguageServer implements vscode.Disposable {
     dispose() {
         this.rascalClient.then(c => c.dispose());
     }
-
 }
 

--- a/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
@@ -26,7 +26,7 @@
  */
 import * as vscode from 'vscode';
 
-import { BaseLanguageClient, integer } from 'vscode-languageclient';
+import { BaseLanguageClient } from 'vscode-languageclient';
 import { VSCodeUriResolverServer } from '../fs/VSCodeURIResolver';
 import { activateLanguageClient } from './RascalLSPConnection';
 import { LanguageParameter, ParameterizedLanguageServer } from './ParameterizedLanguageServer';


### PR DESCRIPTION
* [x] adds viewColumn to showDocument by creating a new method editDocument that does have that parameter
   - makes sure the editor is not a preview document
   - makes sure to take the focus
   - interprets the viewColumn parameter the same as the webview creator
* [x] fixes webview creation
   - breaks a funny cache where due to an equal html document (with a nested iframe that is not equal) a webview 
     would never be updated
   - make sure the webviews don't take focus unnecessarily, such that people working in an editor can continue 
     typing

This is based on https://github.com/usethesource/rascal/pull/2453 and have to wait for an RC to be able to merge this.
