### PR TITLE
Configure Rascal packager to avoid CI locations in release tpl files

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -180,6 +180,11 @@
             <goals>
               <goal>package</goal>
             </goals>
+            <configuration>
+              <srcs>
+                <src>${project.basedir}/src/main/rascal/library</src>
+              </srcs>
+            </configuration>
           </execution>
           <execution>
             <id>default-tutor</id>

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -187,7 +187,7 @@ function checkDeprecatedFeatures(mfBody: vscode.TextDocument, diagnostics: vscod
         const [key, value] = line.text.split(":");
         if (key && value && key === "Require-Libraries" && value.trim() !== "") {
             diagnostics.push(new vscode.Diagnostic(line.range,
-                "The 'Require-Libraries' option is not supported anymor. Please make sure your dependencies are listed in the pom.xml of the project and remove this line."
+                "The 'Require-Libraries' option is not supported anymore. Please make sure your dependencies are listed in the pom.xml of the project and remove this line."
             ));
         }
     }


### PR DESCRIPTION
This PR ensures that, during a build, CI locations in tpl files are rewritten to `mvn` locations