### PR TITLE
Remove TPLs when outdated based on path config instead of POM/MF timestamps

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -31,11 +31,9 @@ import java.io.IOException;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -43,7 +41,6 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.library.util.PathConfig.RascalConfigMode;
 import org.rascalmpl.uri.URIResolverRegistry;
@@ -91,15 +88,9 @@ public class PathConfigs {
             if (reg.exists(manifest)) {
                 updater.watchFile(projectRoot, manifest);
             }
-            var configSources = registerMavenWatches(reg, projectRoot);
-            configSources.add(manifest);
+            registerMavenWatches(reg, projectRoot);
 
-            long newestConfig = configSources.stream()
-                .mapToLong(PathConfigs::safeLastModified)
-                .max()
-                .getAsLong(); // safe, since the set has at least one element
-
-            var result = updater.actualBuild(projectRoot, newestConfig, null);
+            var result = updater.actualBuild(projectRoot);
             logger.debug("New path config: {}", result);
             return result;
         }
@@ -151,9 +142,8 @@ public class PathConfigs {
                         // right before we calculate the path config,
                         // we clear it from the list, as the path config calculation
                         // can take some time
-                        final var changed = changedRoots.remove(root);
-                        // pass the last modified time stamp that we just removed
-                        currentPathConfigs.compute(root, (k, prevPcfg) -> actualBuild(k, changed, prevPcfg));
+                        changedRoots.remove(root);
+                        currentPathConfigs.replace(root, actualBuild(root));
                     }
                 } catch (Exception e) {
                     logger.error("Unexpected error while building PathConfigs", e) ;
@@ -161,61 +151,23 @@ public class PathConfigs {
             }
         }
 
-        private PathConfig actualBuild(ISourceLocation projectRoot, long newestConfig, @Nullable PathConfig prevPcfg) {
-            final var newPcfg = PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.COMPILER, true);
-            // Did the path config change?
-            if (!newPcfg.equals(prevPcfg)) {
-                try {
-                    cleanOutdatedTPLs(newPcfg.getBin(), newestConfig);
-                } catch (IOException e) {
-                    logger.debug("Cannot clean outdated TPLs in {}. The directory might have been removed in the meantime.", newPcfg.getBin());
-                }
-            }
-            return newPcfg;
-        }
-
-        /**
-         * Over-approximation of outdated TPLs, which serves to clean the workspace after an update.
-         * @param newPcfg The new path config of the project.
-         * @throws IOException When listing the entries of the directory fails, e.g. the directory does not exist or the URI scheme is unsupported.
-         */
-        private void cleanOutdatedTPLs(ISourceLocation dir, long olderThan) throws IOException {
-            if (!reg.isDirectory(dir)) {
-                return;
-            }
-            for (var l : reg.list(dir)) {
-                if (reg.isDirectory(dir)) {
-                    cleanOutdatedTPLs(l, olderThan);
-                } else {
-                    try {
-                        if (reg.isFile(l) && "tpl".equals(URIUtil.getExtension(l)) && safeLastModified(l) < olderThan) {
-                            logger.trace("Deleting outdated TPL {}", l);
-                            reg.remove(l, false);
-                        }
-                    } catch (IOException e) {
-                        logger.debug("Cannot remove TPL at {}", l, e);
-                    }
-                }
-            }
+        private PathConfig actualBuild(ISourceLocation projectRoot) {
+            return PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.COMPILER, true);
         }
 
     }
 
-    private Set<ISourceLocation> registerMavenWatches(URIResolverRegistry reg, ISourceLocation projectRoot) throws IOException {
-        final Set<ISourceLocation> poms = new HashSet<>();
+    private void registerMavenWatches(URIResolverRegistry reg, ISourceLocation projectRoot) throws IOException {
         var mainPom = URIUtil.getChildLocation(projectRoot, "pom.xml");
         if (reg.exists(mainPom)) {
             updater.watchFile(projectRoot, mainPom);
-            poms.add(mainPom);
             if (hasParentSection(reg, mainPom)) {
                 var parentPom = URIUtil.getChildLocation(URIUtil.getParentLocation(projectRoot), "pom.xml");
                 if (!mainPom.equals(parentPom) && reg.exists(parentPom)) {
                     updater.watchFile(projectRoot, parentPom);
-                    poms.add(parentPom);
                 }
             }
         }
-        return poms;
     }
 
     private static final Pattern detectParent = Pattern.compile("<\\s*parent\\s*>");

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -125,13 +125,22 @@ loc pathConfigFile(PathConfig pcfg) = pcfg.bin + "rascal.pathconfig";
 
 void checkOutdatedPathConfig(PathConfig pcfg) {
     pcfgFile = pathConfigFile(pcfg);
-    if (!exists(pcfgFile) || tplInputsChanged(pcfg, readBinaryValueFile(#PathConfig, pcfgFile))) {
-        // We do not know the previous path config, or it changed
-        // Be safe and remove TPLs
-        for (loc f <- find(pcfg.bin, "tpl")) {
-            remove(f);
+    jobWarning("Checking path config", pcfgFile);
+    try {
+        if (!exists(pcfgFile) || tplInputsChanged(pcfg, readBinaryValueFile(#PathConfig, pcfgFile))) {
+            // We do not know the previous path config, or it changed
+            // Be safe and remove TPLs
+            for (loc f <- find(pcfg.bin, "tpl")) {
+                try {
+                    remove(f);
+                } catch IO(_): {
+                    jobWarning("Cannot remove TPL", f);
+                }
+            }
+            writeBinaryValueFile(pcfgFile, pcfg);
         }
-        writeBinaryValueFile(pcfgFile, pcfg);
+    } catch IO(str msg): {
+        jobWarning(msg, pcfg.bin);
     }
 }
 

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -125,7 +125,6 @@ loc pathConfigFile(PathConfig pcfg) = pcfg.bin + "rascal.pathconfig";
 
 void checkOutdatedPathConfig(PathConfig pcfg) {
     pcfgFile = pathConfigFile(pcfg);
-    jobWarning("Checking path config", pcfgFile);
     try {
         if (!exists(pcfgFile) || tplInputsChanged(pcfg, readBinaryValueFile(#PathConfig, pcfgFile))) {
             // We do not know the previous path config, or it changed

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -128,7 +128,9 @@ void checkOutdatedPathConfig(PathConfig pcfg) {
     if (!exists(pcfgFile) || tplInputsChanged(pcfg, readBinaryValueFile(#PathConfig, pcfgFile))) {
         // We do not know the previous path config, or it changed
         // Be safe and remove TPLs
-        removeAllTPLs(pcfg);
+        for (loc f <- find(pcfg.bin, "tpl")) {
+            remove(f);
+        }
         writeBinaryValueFile(pcfgFile, pcfg);
     }
 }
@@ -137,13 +139,6 @@ bool tplInputsChanged(PathConfig old, PathConfig new)
     = old.srcs != new.srcs
     || old.libs != new.libs
     ;
-
-void removeAllTPLs(PathConfig pcfg) {
-    for (loc f <- find(pcfg.bin, "tpl")) {
-        println("Removing <f>");
-        remove(f);
-    }
-}
 
 loc locateRascalModule(str fqn, PathConfig pcfg, PathConfig(loc file) getPathConfig, set[loc] workspaceFolders) {
     fileName = makeFileName(fqn);


### PR DESCRIPTION
Closes #788.