### PR TITLE
Simplified configuration of rascal-maven-plugin

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -158,6 +158,15 @@
         <groupId>org.rascalmpl</groupId>
         <artifactId>rascal-maven-plugin</artifactId>
         <version>0.30.0-RC25</version>
+        <configuration>
+            <errorsAsWarnings>false</errorsAsWarnings>
+            <bin>${project.build.outputDirectory}</bin>
+            <srcs>
+                <src>${project.basedir}/src/main/rascal/library</src>
+            </srcs>
+            <sources>|http://github.com/usethesource/rascal-language-servers/blob/main/rascal-lsp|</sources>
+            <issues>|http://github.com/usethesource/rascal-language-servers/issues|</issues>
+        </configuration>
         <executions>
           <execution>
             <?m2e ignore?>
@@ -166,13 +175,6 @@
             <goals>
               <goal>compile</goal>
             </goals>
-            <configuration>
-                <errorsAsWarnings>false</errorsAsWarnings>
-                <bin>${project.build.outputDirectory}</bin>
-                <srcs>
-                    <src>${project.basedir}/src/main/rascal/library</src>
-                </srcs>
-            </configuration>
           </execution>
           <execution>
             <id>default-package</id>
@@ -180,11 +182,6 @@
             <goals>
               <goal>package</goal>
             </goals>
-            <configuration>
-              <srcs>
-                <src>${project.basedir}/src/main/rascal/library</src>
-              </srcs>
-            </configuration>
           </execution>
           <execution>
             <id>default-tutor</id>
@@ -192,18 +189,6 @@
             <goals>
               <goal>tutor</goal>
             </goals>
-            <configuration>
-              <bin>${project.build.outputDirectory}</bin>
-              <sources>|http://github.com/usethesource/rascal-language-servers/blob/main/rascal-lsp|</sources>
-              <issues>|http://github.com/usethesource/rascal-language-servers/issues|</issues>
-              <srcs>
-                <src>${project.basedir}/src/main/rascal</src>
-              </srcs>
-              <ignores>
-                  <ignore>${project.basedir}/src/main/rascal/lang/rascal</ignore>
-                  <ignore>${project.basedir}/src/main/rascal/framework</ignore>
-              </ignores>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -28,7 +28,7 @@ POSSIBILITY OF SUCH DAMAGE.
 @description{
 The core functionality of this module is built upon these concepts:
 * ((registerLanguage)) for enabling your language services for a given file extension _in the current IDE_.
-* ((Language)) is the data-type for defining a language, with meta-data for starting a new LSP server.
+* ((LanguageServer-Language)) is the data-type for defining a language, with meta-data for starting a new LSP server.
 * A ((LanguageService)) is a specific feature for an IDE. Each service comes with one Rascal function that implements it.
 }
 module demo::lang::pico::LanguageServer
@@ -49,7 +49,7 @@ private Tree (str _input, loc _origin) picoParser(bool allowRecovery) {
 @description{
 Each ((LanguageService)) for pico is implemented as a function.
 Here we group all services such that the LSP server can link them
-with the ((Language)) definition later.
+with the ((LanguageServer-Language)) definition later.
 }
 set[LanguageService] picoLanguageServer(bool allowRecovery) = {
     parsing(picoParser(allowRecovery), usesSpecialCaseHighlighting = false),


### PR DESCRIPTION
* Sources were configured separately for `compile` and `package`
* Tutor configuration still referred to source paths that no longer exist (from before the `lsp`/`library` split)