### PR TITLE
Refactored the handling of error trees to avoid null trees and extracting common patterns

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -63,7 +63,7 @@ public class TextDocumentState {
     private final BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser;
     private final ISourceLocation location;
 
-    private final AtomicReference<@MonotonicNonNull Versioned<Update>> current;
+    private final AtomicReference<Versioned<Update>> current;
     private final AtomicReference<@MonotonicNonNull Versioned<ITree>> lastWithoutErrors;
     private final AtomicReference<@MonotonicNonNull Versioned<ITree>> last;
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -152,7 +152,7 @@ public class TextDocumentState {
 
         return result.handle((t, e) -> {
             if (t == null) {
-                throw new RuntimeException("We've never seen a parse tree without errors for: " + getLocation());
+                throw new IllegalStateException("No previous parse tree without errors for: " + getLocation());
             }
             return t;
         });

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -95,7 +95,7 @@ public class TextDocumentState {
         return unpackCurrent().getContent();
     }
 
-    public CompletableFuture<Versioned<ITree>> getCurrentTreeAsync() {
+    private CompletableFuture<Versioned<ITree>> getCurrentTreeAsync() {
         return unpackCurrent().getTreeAsync();
     }
 
@@ -107,13 +107,57 @@ public class TextDocumentState {
         return current.get().get();
     }
 
-    public @MonotonicNonNull Versioned<ITree> getLastTree() {
-        return last.get();
-    }
-
     public @MonotonicNonNull Versioned<ITree> getLastTreeWithoutErrors() {
         return lastWithoutErrors.get();
     }
+
+    /**
+     * Wait for the current content to get parsed and get the parse tree from it.
+     * @param allowRecoveredErrors if false parse trees with recovered errors complete the future exceptionally
+     * @return the current parse tree
+     */
+    public CompletableFuture<Versioned<ITree>> getCurrentTreeAsync(boolean allowRecoveredErrors) {
+        if (allowRecoveredErrors) {
+            return getCurrentTreeAsync();
+        }
+        return getCurrentTreeAsync().thenApply(t -> {
+            var withoutErrors = lastWithoutErrors.get();
+            // side-effect of a succesfull parse without any recovered errors is that
+            // `getLastTreeWithoutErrors` is updated to the same tree
+            if (withoutErrors == null || withoutErrors.get() != t.get()) {
+                throw new IllegalStateException("File has parse errors");
+            }
+            return t;
+        });
+    }
+
+    /**
+     * Wait for current tree to parse. Then return the last tree that matches the allowRecoveredErrors conditation.
+     * @param allowRecoveredErrors if false, the result will not contain a tree with recovered errors.
+     * @return the last parse tree, or an exception if non existed.
+     */
+    public CompletableFuture<Versioned<ITree>> getLastTreeAsync(boolean allowRecoveredErrors) {
+        var result = getCurrentTreeAsync()
+            .handle((t, e) -> {
+                if (t == null) {
+                    return last.get();
+                }
+                return t;
+            });
+        if (!allowRecoveredErrors) {
+            // if a parse is done, always overwrite it with the
+            // last tree that did not have any errors, also not recovered errors
+            result = result.thenApply(t -> lastWithoutErrors.get());
+        }
+
+        return result.handle((t, e) -> {
+            if (t == null) {
+                throw new RuntimeException("We've never seen a parse tree without errors for: " + getLocation());
+            }
+            return t;
+        });
+    }
+
 
     /**
      * An update of a text document, characterized in terms of its
@@ -125,8 +169,8 @@ public class TextDocumentState {
         private final int version;
         private final String content;
         private final long timestamp;
-        private final CompletableFuture<Versioned<ITree>> treeAsync;
-        private final CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync;
+        private final CompletableFuture<@Nullable Versioned<ITree>> treeAsync;
+        private final CompletableFuture<@Nullable Versioned<List<Diagnostics.Template>>> diagnosticsAsync;
 
         public Update(int version, String content, long timestamp) {
             this.version = version;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -52,7 +52,7 @@ public interface ILanguageContributions {
     public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input);
     public InterruptibleFuture<IList> documentSymbol(ITree input);
     public InterruptibleFuture<IList> codeLens(ITree input);
-    public InterruptibleFuture<IList> inlayHint(@Nullable ITree input);
+    public InterruptibleFuture<IList> inlayHint(ITree input);
     public InterruptibleFuture<@Nullable IValue> execution(String command);
     public InterruptibleFuture<ISet> hover(IList focus);
     public InterruptibleFuture<ISet> definition(IList focus);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,7 +126,6 @@ import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import org.rascalmpl.vscode.lsp.util.locations.impl.TreeSearch;
-
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.ISet;
@@ -310,9 +308,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         documentSymbol(DocumentSymbolParams params) {
         logger.debug("textDocument/documentSymbol: {}", params.getTextDocument());
         TextDocumentState file = getFile(params.getTextDocument());
-        return recoverExceptions(file.getCurrentTreeAsync()
+        return recoverExceptions(file.getLastTreeAsync(true)
             .thenApply(Versioned::get)
-            .handle((t, r) -> (t == null ? (file.getLastTree().get()) : t))
             .thenCompose(tr -> rascalServices.getDocumentSymbols(tr).get())
             .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, columns.get(file.getLocation())))
             );
@@ -358,9 +355,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         logger.debug("textDocument/prepareRename: {} at {}", params.getTextDocument(), params.getPosition());
         TextDocumentState file = getFile(params.getTextDocument());
 
-        return recoverExceptions(file.getCurrentTreeAsync()
+        return recoverExceptions(file.getCurrentTreeAsync(false)
             .thenApply(Versioned::get)
-            .handle((t, r) -> (t == null ? file.getLastTreeWithoutErrors().get() : t))
             .thenApply(tr -> {
                 Position rascalCursorPos = Locations.toRascalPosition(file.getLocation(), params.getPosition(), columns);
                 IList focus = TreeSearch.computeFocusList(tr, rascalCursorPos.getLine(), rascalCursorPos.getCharacter());
@@ -380,9 +376,14 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .map(f -> Locations.toLoc(f.getUri()))
             .collect(Collectors.toSet());
 
-        return file.getCurrentTreeAsync()
+        return file.getCurrentTreeAsync(false)
             .thenApply(Versioned::get)
-            .handle((t, r) -> (t == null ? file.getLastTreeWithoutErrors().get() : t))
+            .handle((t, e) -> {
+                if (e != null) {
+                    throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed, "We cannot rename in a file with parse errors.", null));
+                }
+                return t;
+            })
             .thenCompose(tr -> {
                 Position rascalCursorPos = Locations.toRascalPosition(file.getLocation(), params.getPosition(), columns);
                 var focus = TreeSearch.computeFocusList(tr, rascalCursorPos.getLine(), rascalCursorPos.getCharacter());
@@ -447,7 +448,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
         logger.debug("textDocument/foldingRange: {}", params.getTextDocument());
         TextDocumentState file = getFile(params.getTextDocument());
-        return recoverExceptions(file.getCurrentTreeAsync().thenApply(Versioned::get).thenApplyAsync(FoldingRanges::getFoldingRanges))
+        return recoverExceptions(file.getCurrentTreeAsync(true).thenApply(Versioned::get).thenApplyAsync(FoldingRanges::getFoldingRanges))
             .whenComplete((r, e) ->
                 logger.trace("Folding regions success, reporting {} regions back", r == null ? 0 : r.size())
             );
@@ -514,7 +515,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     private CompletableFuture<SemanticTokens> getSemanticTokens(TextDocumentIdentifier doc) {
         var specialCaseHighlighting = CompletableFuture.completedFuture(false);
-        return recoverExceptions(getFile(doc).getCurrentTreeAsync()
+        return recoverExceptions(getFile(doc).getCurrentTreeAsync(true)
                 .thenApply(Versioned::get)
                 .thenCombineAsync(specialCaseHighlighting, tokenizer::semanticTokensFull, ownExecuter), SemanticTokens::new)
             .whenComplete((r, e) ->
@@ -545,9 +546,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public CompletableFuture<List<SelectionRange>> selectionRange(SelectionRangeParams params) {
         logger.debug("textDocument/selectionRange: {}", params);
         TextDocumentState file = getFile(params.getTextDocument());
-        return recoverExceptions(file.getCurrentTreeAsync()
+        return recoverExceptions(file.getCurrentTreeAsync(true)
             .thenApply(Versioned::get)
-            .handle((t, r) -> (t == null ? file.getLastTreeWithoutErrors().get() : t))
             .thenApply(tr -> params.getPositions().stream()
                 .map(p -> Locations.toRascalPosition(file.getLocation(), p, columns))
                 .map(p -> TreeSearch.computeFocusList(tr, p.getLine(), p.getCharacter()))
@@ -569,19 +569,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     @Override
     public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
         TextDocumentState f = getFile(params.getTextDocument());
-        return recoverExceptions(f.getCurrentTreeAsync()
-            .handle((r, e) -> {
-                // fallback to tree if a parsing error occurred.
-                if (r == null) {
-                    r = f.getLastTreeWithoutErrors();
-                }
-                if (r == null) {
-                    throw new RuntimeException(e);
-                }
-                return r;
-            })
-            // Replace with the last tree without errors, might be the same as `tree` if the parse succeeded without any error recovery
-            .thenApply(tree -> f.getLastTreeWithoutErrors())
+        return recoverExceptions(f.getLastTreeAsync(false)
             .thenApply(Versioned::get)
             .thenApplyAsync(rascalServices::locateCodeLenses, ownExecuter)
             .thenApply(List::stream)
@@ -608,7 +596,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         // based on the cursor position in the file and the current parse tree
         CompletableFuture<Stream<IValue>> codeActions = recoverExceptions(
             getFile(params.getTextDocument())
-                .getCurrentTreeAsync()
+                .getCurrentTreeAsync(true)
                 .thenApply(Versioned::get)
                 .thenCompose((ITree tree) -> computeCodeActions(range.getStart().getLine(), range.getStart().getCharacter(), tree, facts.getPathConfig(loc)))
                 .thenApply(IList::stream)

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/ITerminalIDEServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/ITerminalIDEServer.java
@@ -353,7 +353,7 @@ public interface ITerminalIDEServer {
             return mainModule;
         }
 
-        public @MonotonicNonNull ParserSpecification getPrecompiledParser() {
+        public @Nullable ParserSpecification getPrecompiledParser() {
             return precompiledParser;
         }
 


### PR DESCRIPTION
After finding some strange handling of error recovery, @toinehartman and I sat together and refactored it into some more user-friendly functions on `TextDocumentState`.