### PR TITLE
Turn PathConfig messages into diagnostics

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -37,6 +37,7 @@
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <log4j2.version>2.25.1</log4j2.version>
     <lsp4j.version>0.24.0</lsp4j.version>
+    <mockito.version>5.20.0</mockito.version>
     <sonar.organization>usethesource</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
   </properties>
@@ -107,6 +108,12 @@
       <groupId>org.eclipse.lsp4j</groupId>
       <artifactId>org.eclipse.lsp4j.debug</artifactId>
       <version>${lsp4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -56,6 +56,7 @@ import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.rascalmpl.uri.URIUtil;
 
 import com.google.gson.JsonPrimitive;
 
@@ -153,7 +154,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         if (removed != null) {
             workspaceFolders.removeAll(removed);
             for (WorkspaceFolder folder : removed) {
-                documentService.projectRemoved(folder.getName(), folder.getUri());
+                documentService.projectRemoved(folder.getName(), URIUtil.assumeCorrectLocation(folder.getUri()));
             }
         }
 
@@ -161,7 +162,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         if (added != null) {
             workspaceFolders.addAll(added);
             for (WorkspaceFolder folder : added) {
-                documentService.projectAdded(folder.getName(), folder.getUri());
+                documentService.projectAdded(folder.getName(), URIUtil.assumeCorrectLocation(folder.getUri()));
             }
         }
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -152,10 +152,17 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         var removed = params.getEvent().getRemoved();
         if (removed != null) {
             workspaceFolders.removeAll(removed);
+            for (WorkspaceFolder folder : removed) {
+                documentService.projectRemoved(folder.getName(), folder.getUri());
+            }
         }
+
         var added = params.getEvent().getAdded();
         if (added != null) {
             workspaceFolders.addAll(added);
+            for (WorkspaceFolder folder : added) {
+                documentService.projectAdded(folder.getName(), folder.getUri());
+            }
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -54,6 +54,10 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     void initialized();
     void registerLanguage(LanguageParameter lang);
     void unregisterLanguage(LanguageParameter lang);
+
+    void projectAdded(String name, String uri);
+    void projectRemoved(String name, String uri);
+
     CompletableFuture<IValue> executeCommand(String languageName, String command);
     LineColumnOffsetMap getColumnMap(ISourceLocation file);
     ColumnMaps getColumnMaps();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -55,8 +55,8 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     void registerLanguage(LanguageParameter lang);
     void unregisterLanguage(LanguageParameter lang);
 
-    void projectAdded(String name, String uri);
-    void projectRemoved(String name, String uri);
+    void projectAdded(String name, ISourceLocation projectRoot);
+    void projectRemoved(String name, ISourceLocation projectRoot);
 
     CompletableFuture<@Nullable IValue> executeCommand(String languageName, String command);
     LineColumnOffsetMap getColumnMap(ISourceLocation file);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -887,11 +887,11 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     @Override
-    public void projectAdded(String name, String uri) {
+    public void projectAdded(String name, ISourceLocation projectRoot) {
     }
 
     @Override
-    public void projectRemoved(String name, String uri) {
+    public void projectRemoved(String name, ISourceLocation projectRoot) {
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -888,10 +888,12 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
 
     @Override
     public void projectAdded(String name, ISourceLocation projectRoot) {
+        // No need to do anything
     }
 
     @Override
     public void projectRemoved(String name, ISourceLocation projectRoot) {
+        // No need to do anything
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -877,6 +877,14 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     @Override
+    public void projectAdded(String name, String uri) {
+    }
+
+    @Override
+    public void projectRemoved(String name, String uri) {
+    }
+
+    @Override
     public CompletableFuture<IValue> executeCommand(String languageName, String command) {
         ILanguageContributions contribs = contributions.get(languageName);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -213,8 +213,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public void connect(LanguageClient client) {
         this.client = client;
         this.rascalServices = new RascalLanguageServices(this, workspaceService, (IBaseLanguageClient) client, ownExecuter);
-        this.facts = new FileFacts(ownExecuter, rascalServices, columns);
-        facts.setClient(client);
+        this.facts = new FileFacts(ownExecuter, rascalServices, client, columns);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -572,12 +572,12 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     }
 
     @Override
-    public void projectAdded(String name, String uri) {
+    public void projectAdded(String name, ISourceLocation projectRoot) {
     }
 
     @Override
-    public void projectRemoved(String name, String uri) {
-        facts.projectRemoved(URIUtil.assumeCorrectLocation(uri));
+    public void projectRemoved(String name, ISourceLocation projectRoot) {
+        facts.projectRemoved(projectRoot);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -103,6 +103,7 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
@@ -563,6 +564,15 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     @Override
     public void unregisterLanguage(LanguageParameter lang) {
         throw new UnsupportedOperationException("registering language is a feature of the language parametric server, not of the Rascal server");
+    }
+
+    @Override
+    public void projectAdded(String name, String uri) {
+    }
+
+    @Override
+    public void projectRemoved(String name, String uri) {
+        facts.projectRemoved(URIUtil.assumeCorrectLocation(uri));
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -102,7 +102,6 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
-import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
@@ -573,6 +572,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     @Override
     public void projectAdded(String name, ISourceLocation projectRoot) {
+        // No need to do anything
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -69,6 +69,10 @@ public class FileFacts {
         this.confs = new PathConfigs(exec, new PathConfigDiagnostics(client, cm));
     }
 
+    public void projectRemoved(ISourceLocation projectLocation) {
+        confs.expungePathConfig(projectLocation);
+    }
+
     public void invalidate(ISourceLocation file) {
         getFile(file).invalidate();
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -61,15 +61,12 @@ public class FileFacts {
     private final ColumnMaps cm;
     private final PathConfigs confs;
 
-    public FileFacts(Executor exec, RascalLanguageServices rascal, ColumnMaps cm) {
+    public FileFacts(Executor exec, RascalLanguageServices rascal, LanguageClient client, ColumnMaps cm) {
         this.exec = exec;
         this.rascal = rascal;
-        this.cm = cm;
-        this.confs = new PathConfigs();
-    }
-
-    public void setClient(LanguageClient client) {
         this.client = client;
+        this.cm = cm;
+        this.confs = new PathConfigs(new PathConfigDiagnostics(client, cm));
     }
 
     public void invalidate(ISourceLocation file) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -35,7 +35,6 @@ import java.util.concurrent.Executor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
@@ -56,7 +55,7 @@ public class FileFacts {
     private static final Logger logger = LogManager.getLogger(FileFacts.class);
     private final Executor exec;
     private final RascalLanguageServices rascal;
-    private volatile @MonotonicNonNull LanguageClient client;
+    private final LanguageClient client;
     private final Map<ISourceLocation, FileFact> files = new ConcurrentHashMap<>();
     private final ColumnMaps cm;
     private final PathConfigs confs;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -66,7 +66,7 @@ public class FileFacts {
         this.rascal = rascal;
         this.client = client;
         this.cm = cm;
-        this.confs = new PathConfigs(new PathConfigDiagnostics(client, cm));
+        this.confs = new PathConfigs(exec, new PathConfigDiagnostics(client, cm));
     }
 
     public void invalidate(ISourceLocation file) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -46,6 +46,11 @@ import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.ISourceLocation;
 
+/*
+ * This class updates VSCode diagnostics based on PathConfig messages.
+ * Messages are tracked by project and by file. So changes in one project will not affect
+ * messages genrated by other projects, even if files with messages belong to multiple projects.
+ */
 /*package*/ class PathConfigDiagnostics {
     private final LanguageClient client;
     private final ColumnMaps cm;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -55,11 +56,7 @@ import io.usethesource.vallang.ISourceLocation;
     private final LanguageClient client;
     private final ColumnMaps cm;
 
-    // For each file, keep track of the list of diagnostics per project.
-    private final Map<ISourceLocation, Map<ISourceLocation, List<Diagnostic>>> projectDiagsPerFile = new HashMap<>();
-
-    // For each project, keep track of the set of files that currently have diagnostics for that project
-    private final Map<ISourceLocation, Set<ISourceLocation>> filesWithDiagsPerProject = new HashMap<>();
+    private final Map<ISourceLocation, Map<ISourceLocation, List<Diagnostic>>> perFileProjectDiagnostics = new LinkedHashMap<>();
 
     /*package*/ PathConfigDiagnostics(LanguageClient client, ColumnMaps cm) {
         this.client = client;
@@ -71,60 +68,78 @@ import io.usethesource.vallang.ISourceLocation;
         publishDiagnostics(project, Diagnostics.translateMessages(messages, cm));
     }
 
-    private void publishDiagnostics(ISourceLocation project, Map<ISourceLocation, List<Diagnostic>> diagnostics) {
-        Set<ISourceLocation> filesToRepublish = new HashSet<>();
-
-        // Do the actual manipulation of the internal datastructures in a synchronized block
-        // so their coherence is guaranteed.
-        synchronized(this) {
-            // Publish diagnostics, but only for files for which diagnostics have changed
-            for (var entry : diagnostics.entrySet()) {
-                ISourceLocation file = entry.getKey().top();
-                List<Diagnostic> newDiagnostics = entry.getValue();
-
-                Map<ISourceLocation, List<Diagnostic>> diagsPerProject = projectDiagsPerFile.computeIfAbsent(file, (f) -> new LinkedHashMap<>());
-                @Nullable List<Diagnostic> publishedDiags = diagsPerProject.get(project);
-
-                // Only publish diagnostics for a file if the diagnostics for that file have changed in the current project
-                if (!newDiagnostics.equals(publishedDiags)) {
-                    // The diagnostics for this file related to the current project have changed.
-                    // We need to re-publish all diagnostics for this file (including the ones from other projects)
-                    diagsPerProject.put(project, newDiagnostics);
-                    filesToRepublish.add(file);
-                }
-            }
-
-            // Now we have published the diagnostics of all files that occur in the list of new messages
-            // Time to remove diagnostics from files that our project previously published diagnostics for but no longer have diagnostics
-            Set<ISourceLocation> newFiles = diagnostics.keySet().stream().map(ISourceLocation::top).collect(Collectors.toSet());
-            Set<ISourceLocation> filesWithoutDiags = new HashSet<>(filesWithDiagsPerProject.getOrDefault(project, Collections.emptySet()));
-            filesWithoutDiags.removeAll(newFiles);
-
-            for (ISourceLocation file : filesWithoutDiags) {
-                // File no longer has diagnostics associated with it in our project
-                projectDiagsPerFile.get(file).remove(project);
-                filesToRepublish.add(file);
-            }
-            filesWithDiagsPerProject.put(project, newFiles);
-        }
-
-        publishFileDiagnostics(filesToRepublish);
-    }
-
     public void clearDiagnostics(ISourceLocation project) {
         publishDiagnostics(project, Collections.emptyMap());
     }
 
-    private void publishFileDiagnostics(Set<ISourceLocation> files) {
-        for (ISourceLocation file : files) {
-            List<Diagnostic> fileDiagnostics = new ArrayList<>();
-            synchronized (this) {
-                // Iterate over all files and gather the diagnostics for all projects that have diagnostics for this file
-                for (List<Diagnostic> diags :  projectDiagsPerFile.getOrDefault(file, Collections.emptyMap()).values()) {
-                    fileDiagnostics.addAll(diags);
-                }
-            }
-            client.publishDiagnostics(new PublishDiagnosticsParams(file.getURI().toString(), fileDiagnostics));
+    private void publishDiagnostics(ISourceLocation project, Map<ISourceLocation, List<Diagnostic>> diagnostics) {
+        for (PublishDiagnosticsParams params : updateDiagnostics(project, diagnostics)) {
+            client.publishDiagnostics(params);
         }
     }
+
+    synchronized private List<PublishDiagnosticsParams> updateDiagnostics(ISourceLocation project, Map<ISourceLocation, List<Diagnostic>> diagnostics) {
+        // Assume all files that currently have diagnostics for our project need to be republished unless proven otherwise
+        List<ISourceLocation> filesToRepublish = new ArrayList<>();
+        for (var entry : diagnostics.entrySet()) {
+            ISourceLocation file = entry.getKey().top();
+            List<Diagnostic> newDiagnostics = entry.getValue();
+
+            // Determine which files get new diagnostics
+            updateFileDiagnostics(project, file, newDiagnostics, filesToRepublish);
+        }
+
+        // Cleanup diagnostics for files that no longer have diagnostics for our project
+        cleanFilesWithoutDiagnostics(project, diagnostics, filesToRepublish);
+
+        // Now gather the diagnostics for all files that need it.
+        return gatherPublishList(filesToRepublish);
+    }
+
+    // Update the diagnostics of a single file. Return `true` if the diagnostics have changed, false otherwise
+    private void updateFileDiagnostics(ISourceLocation project, ISourceLocation file, List<Diagnostic> diagnostics, List<ISourceLocation> filesToRepublish) {
+        Map<ISourceLocation, List<Diagnostic>> publishedDiagsPerProject = perFileProjectDiagnostics.computeIfAbsent(file, (f) -> new LinkedHashMap<>());
+        List<Diagnostic> publishedForOurProject = publishedDiagsPerProject.get(project);
+        if (publishedForOurProject == null || !publishedForOurProject.equals(diagnostics)) {
+            publishedDiagsPerProject.put(project, diagnostics);
+            filesToRepublish.add(file);
+        }
+    }
+
+    private void cleanFilesWithoutDiagnostics(ISourceLocation project, Map<ISourceLocation, List<Diagnostic>> diagnostics, List<ISourceLocation> filesToRepublish) {
+        // Build the set of project files from the diagnostic source locations so we can quickly check if a file has new diagnostics
+        Set<ISourceLocation> diagnosticFiles = new HashSet<>();
+        for (ISourceLocation loc : diagnostics.keySet()) {
+            diagnosticFiles.add(loc.top());
+        }
+
+        // Remove our project diagnostics from files that have them but are not in the new list of diagnostics
+        perFileProjectDiagnostics.entrySet().removeIf(entry -> {
+            ISourceLocation file = entry.getKey();
+            Map<ISourceLocation, List<Diagnostic>> projectDiagnostics = entry.getValue();
+            if (!diagnosticFiles.contains(file) && projectDiagnostics.remove(project) != null) {
+                filesToRepublish.add(file);
+                if (projectDiagnostics.isEmpty()) {
+                    // Remove entry for this file when no more projects with diagnostics for this file are left
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    private List<PublishDiagnosticsParams> gatherPublishList(List<ISourceLocation> filesToRepublish) {
+        List<PublishDiagnosticsParams> publishList = new ArrayList<>(filesToRepublish.size());
+        for (ISourceLocation file : filesToRepublish) {
+            List<Diagnostic> fileDiagnostics = new ArrayList<>();
+            // Iterate over all files and gather the diagnostics for all projects that have diagnostics for this file
+            for (List<Diagnostic> diags : perFileProjectDiagnostics.getOrDefault(file, Collections.emptyMap()).values()) {
+                fileDiagnostics.addAll(diags);
+            }
+            publishList.add(new PublishDiagnosticsParams(file.getURI().toString(), fileDiagnostics));
+        }
+        return publishList;
+    }
+
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -78,7 +78,7 @@ import io.usethesource.vallang.ISourceLocation;
         }
     }
 
-    synchronized private List<PublishDiagnosticsParams> updateDiagnostics(ISourceLocation project, Map<ISourceLocation, List<Diagnostic>> diagnostics) {
+    private synchronized List<PublishDiagnosticsParams> updateDiagnostics(ISourceLocation project, Map<ISourceLocation, List<Diagnostic>> diagnostics) {
         // Assume all files that currently have diagnostics for our project need to be republished unless proven otherwise
         List<ISourceLocation> filesToRepublish = new ArrayList<>();
         for (var entry : diagnostics.entrySet()) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.vscode.lsp.rascal.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.rascalmpl.vscode.lsp.util.Diagnostics;
+import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
+
+import io.usethesource.vallang.IList;
+import io.usethesource.vallang.ISourceLocation;
+
+/*package*/ class PathConfigDiagnostics {
+    private final LanguageClient client;
+    private final ColumnMaps cm;
+    private final Map<ISourceLocation, Map<ISourceLocation, List<Diagnostic>>> publishedProjectDiagsPerFile = new HashMap<>();
+
+    /*package*/ PathConfigDiagnostics(LanguageClient client, ColumnMaps cm) {
+        this.client = client;
+        this.cm = cm;
+    }
+
+    public void publishDiagnostics(ISourceLocation projectRoot, IList messages) {
+        // Gather messages per file
+        Map<ISourceLocation, List<Diagnostic>> diagnosticsPerFile = Diagnostics.translateMessages(messages, cm);
+
+        // Publish diagnostics, but only for files for which diagnostics have changed
+        for (var entry : diagnosticsPerFile.entrySet()) {
+            ISourceLocation file = entry.getKey();
+            List<Diagnostic> newDiagnostics = entry.getValue();
+
+            Map<ISourceLocation, List<Diagnostic>> fileDiagsPerProject = publishedProjectDiagsPerFile.computeIfAbsent(file, (f) -> new HashMap<>());
+            @Nullable List<Diagnostic> publishedDiags = fileDiagsPerProject.get(file);
+
+            // Only publish diagnostics for a file if the diagnostics for that file have changed in the current project
+            if (!newDiagnostics.equals(publishedDiags)) {
+                // The diagnostics for this file related to the current project have changed.
+                // We need to re-publish all diagnostics for this file from all projects
+                fileDiagsPerProject.put(file, newDiagnostics);
+                List<Diagnostic> fileDiagnostics = new ArrayList<>();
+                for (Map<ISourceLocation, List<Diagnostic>> diagsPerFile : publishedProjectDiagsPerFile.values()) {
+                    fileDiagnostics.addAll(diagsPerFile.getOrDefault(file, Collections.emptyList()));
+                }
+
+                client.publishDiagnostics(new PublishDiagnosticsParams(file.getURI().toString(), fileDiagnostics));
+            }
+        }
+    }
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -29,8 +29,12 @@ package org.rascalmpl.vscode.lsp.rascal.model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.Diagnostic;
@@ -46,36 +50,52 @@ import io.usethesource.vallang.ISourceLocation;
     private final LanguageClient client;
     private final ColumnMaps cm;
     private final Map<ISourceLocation, Map<ISourceLocation, List<Diagnostic>>> publishedProjectDiagsPerFile = new HashMap<>();
+    private final Map<ISourceLocation, Set<ISourceLocation>> filesWithDiagsPerProject = new HashMap<>();
 
     /*package*/ PathConfigDiagnostics(LanguageClient client, ColumnMaps cm) {
         this.client = client;
         this.cm = cm;
     }
 
-    public void publishDiagnostics(ISourceLocation projectRoot, IList messages) {
+    public void publishDiagnostics(ISourceLocation project, IList messages) {
         // Gather messages per file
         Map<ISourceLocation, List<Diagnostic>> diagnosticsPerFile = Diagnostics.translateMessages(messages, cm);
 
         // Publish diagnostics, but only for files for which diagnostics have changed
         for (var entry : diagnosticsPerFile.entrySet()) {
-            ISourceLocation file = entry.getKey();
+            ISourceLocation file = entry.getKey().top();
             List<Diagnostic> newDiagnostics = entry.getValue();
 
-            Map<ISourceLocation, List<Diagnostic>> fileDiagsPerProject = publishedProjectDiagsPerFile.computeIfAbsent(file, (f) -> new HashMap<>());
+            Map<ISourceLocation, List<Diagnostic>> fileDiagsPerProject = publishedProjectDiagsPerFile.computeIfAbsent(file, (f) -> new LinkedHashMap<>());
             @Nullable List<Diagnostic> publishedDiags = fileDiagsPerProject.get(file);
 
             // Only publish diagnostics for a file if the diagnostics for that file have changed in the current project
             if (!newDiagnostics.equals(publishedDiags)) {
                 // The diagnostics for this file related to the current project have changed.
-                // We need to re-publish all diagnostics for this file from all projects
-                fileDiagsPerProject.put(file, newDiagnostics);
-                List<Diagnostic> fileDiagnostics = new ArrayList<>();
-                for (Map<ISourceLocation, List<Diagnostic>> diagsPerFile : publishedProjectDiagsPerFile.values()) {
-                    fileDiagnostics.addAll(diagsPerFile.getOrDefault(file, Collections.emptyList()));
-                }
-
-                client.publishDiagnostics(new PublishDiagnosticsParams(file.getURI().toString(), fileDiagnostics));
+                // We need to re-publish all diagnostics for this file (including the ones from other projects)
+                fileDiagsPerProject.put(project, newDiagnostics);
+                publishFileDiagnostics(file);
             }
         }
+
+        // Now we have published the diagnostics of all files that occur in the list of new messages
+        // Time to remove diagnostics from files that our project previously published diagnostics for but no longer have diagnostics
+        Set<ISourceLocation> newFiles = diagnosticsPerFile.keySet().stream().map(file -> file.top()).collect(Collectors.toSet());
+        Set<ISourceLocation> filesWithoutDiags = new HashSet<>(filesWithDiagsPerProject.getOrDefault(project, Collections.emptySet()));
+        filesWithoutDiags.removeAll(newFiles);
+
+        for (ISourceLocation file : filesWithoutDiags) {
+            publishedProjectDiagsPerFile.get(file).remove(project); // File no longer has diagnostics associated with it in our project
+            publishFileDiagnostics(file);
+        }
+        filesWithDiagsPerProject.put(project, newFiles);
+    }
+
+    private void publishFileDiagnostics(ISourceLocation file) {
+        List<Diagnostic> fileDiagnostics = new ArrayList<>();
+        for (List<Diagnostic> diags :  publishedProjectDiagsPerFile.getOrDefault(file, Collections.emptyMap()).values()) {
+            fileDiagnostics.addAll(diags);
+        }
+        client.publishDiagnostics(new PublishDiagnosticsParams(file.getURI().toString(), fileDiagnostics));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -91,6 +91,16 @@ import io.usethesource.vallang.ISourceLocation;
         filesWithDiagsPerProject.put(project, newFiles);
     }
 
+    public void clearDiagnostics(ISourceLocation project) {
+        Set<ISourceLocation> affectedFiles = filesWithDiagsPerProject.remove(project);
+        if (affectedFiles != null) {
+            for (ISourceLocation file : affectedFiles) {
+                publishedProjectDiagsPerFile.get(file).remove(project);
+                publishFileDiagnostics(file);
+            }
+        }
+    }
+
     private void publishFileDiagnostics(ISourceLocation file) {
         List<Diagnostic> fileDiagnostics = new ArrayList<>();
         for (List<Diagnostic> diags :  publishedProjectDiagsPerFile.getOrDefault(file, Collections.emptyMap()).values()) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -49,7 +49,7 @@ import io.usethesource.vallang.ISourceLocation;
 /*
  * This class updates VSCode diagnostics based on PathConfig messages.
  * Messages are tracked by project and by file. So changes in one project will not affect
- * messages genrated by other projects, even if files with messages belong to multiple projects.
+ * messages genrated by other projects, even if files have messages belonging to different projects.
  */
 /*package*/ class PathConfigDiagnostics {
     private final LanguageClient client;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -95,7 +95,7 @@ import io.usethesource.vallang.ISourceLocation;
 
     // Update the diagnostics of a single file. Add any files that need republishing to the `filesToRepublish` set
     private void updateFileDiagnostics(ISourceLocation project, ISourceLocation file, List<Diagnostic> diagnostics, Set<ISourceLocation> filesToRepublish) {
-        Map<ISourceLocation, List<Diagnostic>> publishedDiagsPerProject = perFileProjectDiagnostics.computeIfAbsent(file, (f) -> new LinkedHashMap<>());
+        Map<ISourceLocation, List<Diagnostic>> publishedDiagsPerProject = perFileProjectDiagnostics.computeIfAbsent(file, f -> new LinkedHashMap<>());
         List<Diagnostic> publishedForOurProject = publishedDiagsPerProject.get(project);
         if (publishedForOurProject == null || !publishedForOurProject.equals(diagnostics)) {
             publishedDiagsPerProject.put(project, diagnostics);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -85,7 +85,7 @@ public class PathConfigs {
         try {
             updater.unregisterProject(project);
         } catch (IOException e) {
-            logger.warn("Unregistration of meta files for project " + project + " failed.", e);
+            logger.warn("Unregistration of meta files for project {} failed.", project, e);
         }
         currentPathConfigs.remove(projectRoot);
     }
@@ -159,7 +159,7 @@ public class PathConfigs {
                 changedRoots.put(projectRoot, safeLastModified(sourceFile));
             reg.watch(sourceFile, false, callback);
 
-            var watchList = projectWatches.computeIfAbsent(projectRoot, (root) -> new CopyOnWriteArrayList<>());
+            var watchList = projectWatches.computeIfAbsent(projectRoot, root -> new CopyOnWriteArrayList<>());
             watchList.add(new WatchRegistration(sourceFile, callback));
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -77,6 +77,12 @@ public class PathConfigs {
         this.executor = executor;
     }
 
+    public void expungePathConfig(ISourceLocation project) {
+        var projectRoot = inferProjectRoot(project);
+        // TODO: remove file watches and active messages from updater
+        currentPathConfigs.remove(projectRoot);
+    }
+
     public PathConfig lookupConfig(ISourceLocation forFile) {
         ISourceLocation projectRoot = translatedRoots.get(forFile);
         return currentPathConfigs.computeIfAbsent(projectRoot, this::buildPathConfig);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -147,8 +147,10 @@ public class PathConfigs {
         // the thread will clear them if the time is longer than the timeout
         private final Map<ISourceLocation, Long> changedRoots = new ConcurrentHashMap<>();
 
-        // Watch a single file. We keep track of the watch registrations so we can unwatch
-        // these files when the project is closed.
+        /**
+         *  Watch a single file. We keep track of the watch registrations so we can unwatch
+         * these files when the project is closed.
+         */
         public void watchFile(ISourceLocation projectRoot, ISourceLocation sourceFile) throws IOException {
             if (!isAlive() && !isInterrupted()) {
                 start();
@@ -192,8 +194,7 @@ public class PathConfigs {
                         // we clear it from the list, as the path config calculation
                         // can take some time
                         changedRoots.remove(root);
-                        var pathConfig = actualBuild(root);
-                        currentPathConfigs.replace(root, pathConfig);
+                        currentPathConfigs.replace(root, actualBuild(root));
                     }
                 } catch (Exception e) {
                     logger.error("Unexpected error while building PathConfigs", e) ;

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.rascalmpl.vscode.lsp.rascal.model;
 
 import org.eclipse.lsp4j.Diagnostic;

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
@@ -81,7 +81,7 @@ public class PathConfigDiagnosticsTest {
     }
 
     @Before
-    public void before() throws URISyntaxException {
+    public void before() {
         mockedClient = mock(LanguageClient.class);
         columnMaps = new ColumnMaps(this::getContents);
         sut = new PathConfigDiagnostics(mockedClient, columnMaps);

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
@@ -1,0 +1,137 @@
+package org.rascalmpl.vscode.lsp.rascal.model;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.rascalmpl.library.Messages;
+import org.rascalmpl.library.Prelude;
+import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.values.IRascalValueFactory;
+import org.rascalmpl.vscode.lsp.util.locations.ColumnMaps;
+
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.ISourceLocation;
+
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+public class PathConfigDiagnosticsTest {
+    private static final IRascalValueFactory VF = IRascalValueFactory.getInstance();
+
+    private static final String PROJECT_A = "project-a";
+    private static final String PROJECT_B = "project-b";
+    private static final String POM_A = "project-a/pom.xml";
+    private static final String POM_B = "project-b/pom.xml";
+
+    private static final String MSG1 = "Hello World 1!";
+    private static final String MSG2 = "Hello World 2!";
+
+    private LanguageClient mockedClient;
+    private PathConfigDiagnostics sut;
+    private ColumnMaps columnMaps;
+
+    private final ISourceLocation projectA;
+    private final ISourceLocation projectB;
+
+    private final String pomAUrl;
+    private final String pomBUrl;
+
+    public PathConfigDiagnosticsTest() {
+        projectA = resourceLocation(PROJECT_A);
+        projectB = resourceLocation(PROJECT_B);
+
+        pomAUrl = resourceLocation(POM_A).getURI().toString();
+        pomBUrl = resourceLocation(POM_B).getURI().toString();
+    }
+
+    @Before
+    public void before() throws URISyntaxException {
+        mockedClient = mock(LanguageClient.class);
+        columnMaps = new ColumnMaps(this::getContents);
+        sut = new PathConfigDiagnostics(mockedClient, columnMaps);
+    }
+
+    private String resourceUrl(String res) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return classLoader.getResource(res).toString();
+    }
+
+    private ISourceLocation resourceLocation(String res) {
+        try {
+            return URIUtil.createFromURI(resourceUrl(res));
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ISourceLocation resourceLocation(String res, int line, int col) {
+        ISourceLocation loc = resourceLocation(res);
+        int offset = columnMaps.get(loc).calculateInverseOffsetLength(line, col, line, col).getLeft();
+        return VF.sourceLocation(loc, offset, 1, line, line, col, col);
+    }
+
+    private String getContents(ISourceLocation file) {
+        try (Reader src = URIResolverRegistry.getInstance().getCharacterReader(file)) {
+            return Prelude.consumeInputStream(src);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private IConstructor msg(String file, String msg, int line, int col) {
+        return Messages.info(msg, resourceLocation(file, line, col));
+    }
+
+    private Diagnostic diag(int line, int col, String msg) {
+        var diagnostic = new Diagnostic(new Range(new Position(line, col), new Position(line, col)), msg);
+        diagnostic.setSeverity(DiagnosticSeverity.Information);
+        return diagnostic;
+    }
+
+    private PublishDiagnosticsParams params(String url, Diagnostic... diags) {
+        return new PublishDiagnosticsParams(url, Arrays.asList(diags));
+    }
+
+    @Test
+    public void testPublishFresh() {
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1)));
+    }
+
+    @Test
+    public void testPublishMultiProject() {
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        // Expect the diagnostics for project A
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1)));
+
+        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)));
+        // Expect the diagnostics for both projects
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1), diag(4, 7, MSG2)));
+    }
+
+    @Test
+    public void testDeleteOursButRetainTheirs() {
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1)));
+
+        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)));
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1), diag(4, 7, MSG2)));
+
+        reset(mockedClient);
+        System.err.println("BEFORE CALL");
+        sut.publishDiagnostics(projectA, VF.list());
+        System.out.println(mockingDetails(mockedClient).getInvocations());
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(4, 7, MSG2)));
+    }
+
+}

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
@@ -128,9 +128,17 @@ public class PathConfigDiagnosticsTest {
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1), diag(4, 7, MSG2)));
 
         reset(mockedClient);
-        System.err.println("BEFORE CALL");
         sut.publishDiagnostics(projectA, VF.list());
-        System.out.println(mockingDetails(mockedClient).getInvocations());
+        verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(4, 7, MSG2)));
+    }
+
+    @Test
+    public void testClearDiagnostics() {
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)));
+
+        reset(mockedClient);
+        sut.clearDiagnostics(projectA);
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(4, 7, MSG2)));
     }
 

--- a/rascal-lsp/src/test/resources/project-a/pom.xml
+++ b/rascal-lsp/src/test/resources/project-a/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>project</groupId>
+    <artifactId>a</artifactId>
+    <version>1.0</version>
+</project>

--- a/rascal-lsp/src/test/resources/project-b/pom.xml
+++ b/rascal-lsp/src/test/resources/project-b/pom.xml
@@ -1,0 +1,8 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>project</groupId>
+  <artifactId>b</artifactId>
+  <version>1.0</version>
+</project>

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -28,9 +28,8 @@
 import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { TextEditor, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { TextEditor, ViewSection, VSBrowser, WebDriver, Workbench, until } from 'vscode-extension-tester';
 import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
-
 
 const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile];
 
@@ -251,5 +250,15 @@ describe('IDE', function () {
 
         await ide.triggerTypeChecker(importerEditor, {waitForFinish : true});
         await ide.hasErrorSquiggly(importerEditor);
+    });
+
+    it("errors in manifest detected", async() => {
+        const editor = await ide.openModule(TestWorkspace.manifest);
+        await editor.setTextAtLine(2, "Project-Name: foobar");
+        await editor.save();
+        const element = await ide.hasErrorSquiggly(editor);
+        await editor.setTextAtLine(2, "Project-Name: test-project");
+        await editor.save();
+        await driver.wait(until.stalenessOf(element), Delays.verySlow, "Error did not disapear");
     });
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -31,7 +31,7 @@ import * as path from 'path';
 import { TextEditor, ViewSection, VSBrowser, WebDriver, Workbench, until } from 'vscode-extension-tester';
 import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
 
-const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile];
+const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile, TestWorkspace.manifest];
 
 describe('IDE', function () {
     let browser: VSBrowser;

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -62,6 +62,7 @@ export class TestWorkspace {
     public static readonly libCallFileTpl = path.join(target(this.testProject),'$LibCall.tpl');
     public static readonly libFile = path.join(src(this.libProject), 'Lib.rsc');
     public static readonly libFileTpl = path.join(target(this.libProject),'$Lib.tpl');
+    public static readonly manifest = path.join(this.testProject, "META-INF", "RASCAL.MF");
 
     public static readonly importerFile = path.join(src(this.testProject), 'Importer.rsc');
     public static readonly importeeFile = path.join(src(this.testProject), 'Importee.rsc');

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -100,7 +100,6 @@ export class RascalMFValidator implements vscode.Disposable {
                 checkMissingLastLine(mfBody, diagnostics);
                 checkIncorrectProjectName(mfBody, diagnostics);
                 checkPickySeparator(mfBody, diagnostics);
-                checkDeprecatedFeatures(mfBody, diagnostics);
                 this.diagnostics.set(file, diagnostics);
             }
         }
@@ -144,13 +143,6 @@ function checkIncorrectProjectName(mfBody: vscode.TextDocument, diagnostics: vsc
                 l, offset,
                 l, offset + prName.length
             );
-            const expectedName = calculateProjectName(mfBody.uri);
-            if (prName !== expectedName) {
-                const diag = new vscode.Diagnostic(targetRange,
-                    `Can not handle project names that are not equal to the directory name (${expectedName})`, vscode.DiagnosticSeverity.Error);
-                diag.code = FixKind.fixProjectName;
-                diagnostics.push(diag);
-            }
             if (INVALID_PROJECT_NAME.test(prName)) {
                 const diag = new vscode.Diagnostic(targetRange,
                     "Can not handle project name (" + prName + ") that is not all lowercase, digits, or dashes, i.e. in " + INVALID_PROJECT_NAME, vscode.DiagnosticSeverity.Error);
@@ -179,19 +171,6 @@ function checkPickySeparator(mfBody: vscode.TextDocument, diagnostics: vscode.Di
             diagnostics.push(diag);
         }
     }
-}
-
-function checkDeprecatedFeatures(mfBody: vscode.TextDocument, diagnostics: vscode.Diagnostic[]) {
-    for (let l = 0; l < mfBody.lineCount; l++) {
-        const line = mfBody.lineAt(l);
-        const [key, value] = line.text.split(":");
-        if (key && value && key === "Require-Libraries" && value.trim() !== "") {
-            diagnostics.push(new vscode.Diagnostic(line.range,
-                "The 'Require-Libraries' option is not supported anymore. Please make sure your dependencies are listed in the pom.xml of the project and remove this line."
-            ));
-        }
-    }
-
 }
 
 export function buildMFChildPath(uri: vscode.Uri) {


### PR DESCRIPTION
During PathConfig building messages about pom.xml and RASCAL.MF might be generated.
This PR translates these messages into lsp diagnostics and keeps them synchronized when files are saved or projects are closed.