### PR TITLE
Simplified code and nullable annotations

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -552,10 +552,9 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     }
 
     private CompletableFuture<SemanticTokens> getSemanticTokens(TextDocumentIdentifier doc) {
-        var specialCaseHighlighting = CompletableFuture.completedFuture(false);
         return recoverExceptions(getFile(doc).getCurrentTreeAsync(true)
                 .thenApply(Versioned::get)
-                .thenCombineAsync(specialCaseHighlighting, tokenizer::semanticTokensFull, ownExecuter), SemanticTokens::new)
+                .thenApply(t -> tokenizer.semanticTokensFull(t, false)), SemanticTokens::new)
             .whenComplete((r, e) ->
                 logger.trace("Semantic tokens success, reporting {} tokens back", r == null ? 0 : r.getData().size())
             );

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -112,11 +112,11 @@ public class FileFacts {
                 }),
                 r -> {
                     r.interrupt();
-                    InterruptibleFuture<@Nullable SummaryBridge> summaryCalc = rascal.getSummary(file, confs.lookupConfig(file))
-                        .thenApply(s -> s == null ? null : new SummaryBridge(file, s, cm));
+                    var summaryCalc = rascal.getSummary(file, confs.lookupConfig(file))
+                        .<@Nullable SummaryBridge>thenApply(s -> s == null ? null : new SummaryBridge(file, s, cm));
                     // only run get summary after the typechecker for this file is done running
                     // (we cannot now global running type checkers, that is a different subject)
-                    CompletableFuture<@Nullable SummaryBridge> mergedCalc = typeCheckResults.get().thenCompose(o -> summaryCalc.get());
+                    var mergedCalc = typeCheckResults.get().<@Nullable SummaryBridge>thenCompose(o -> summaryCalc.get());
                     return new InterruptibleFuture<>(mergedCalc, summaryCalc::interrupt);
                 });
         }


### PR DESCRIPTION
After this we're at 40 CF errors, and they are mostly issues with calls from constructors to this.