### PR TITLE
Remove rename test with illegal input program

### DIFF
--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/Functions.rsc
@@ -132,12 +132,10 @@ test bool arityOverload() = testRenameOccurrences({0, 1, 2, 3, 4, 5}, "x = conca
     'str concat(str s1, str s2, str s3) = s1 + concat(s2, s3);
 ", oldName = "concat", newName = "foo");
 
-/* disabling for now
 test bool overloadClash() = testRenameOccurrences({0}, "", decls = "
     'int foo = 0;
     'int foo(int x) = x when x \< 2;
 ");
-*/
 
 test bool crossModuleOverload() = testRenameOccurrences({
     byText("Str", "

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/Functions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/Functions.rsc
@@ -132,11 +132,6 @@ test bool arityOverload() = testRenameOccurrences({0, 1, 2, 3, 4, 5}, "x = conca
     'str concat(str s1, str s2, str s3) = s1 + concat(s2, s3);
 ", oldName = "concat", newName = "foo");
 
-test bool overloadClash() = testRenameOccurrences({0}, "", decls = "
-    'int foo = 0;
-    'int foo(int x) = x when x \< 2;
-");
-
 test bool crossModuleOverload() = testRenameOccurrences({
     byText("Str", "
         'str concat(str s) = s;


### PR DESCRIPTION
@toinehartman could you take a look at why we had this test? It looks like this was never legal rascal, but only now did the type-checker catch this case? Or is there something specific happening here?

(I disabled the test in #794 to finish the PR)