### PR TITLE
Fix duplicate jobEnd on interrupt (#775).

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
@@ -128,7 +128,9 @@ public class EvaluatorUtil {
                         actualEval.endAllJobs();
                         return interruptedResult;
                     } finally {
-                        actualEval.jobEnd(task, jobSuccess);
+                        if (jobSuccess) {
+                            actualEval.jobEnd(task, jobSuccess);
+                        }
                         if (monitor instanceof RascalLSPMonitor) {
                             ((RascalLSPMonitor) monitor).unregisterActiveFuture(task);
                         }


### PR DESCRIPTION
Fix a "Got a jobEnd while we never started something" in the case of interrupts.

Another case of #775.
Related to #776.