### PR TITLE
Always ask the checker to check the requested module, even if its not changed

### DIFF
--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -111,7 +111,7 @@ map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module]
     step("Checking module <l>", 1);
     pcfg = getPathConfig(initialProject);
     checkOutdatedPathConfig(pcfg);
-    msgs += check(calculateOutdated(modulesPerProject[initialProject] + l, pcfg), rascalCompilerConfig(pcfg));
+    msgs += check(calculateOutdated(modulesPerProject[initialProject], pcfg) + [l], rascalCompilerConfig(pcfg));
     return filterAndFix(msgs, workspaceFolders);
 }, totalWork=3);
 


### PR DESCRIPTION
While the current behavior --to really mirror maven/java-watch semantics-- it is correct, it doesn't follow the contract for the rascal user that you trigger the typechecker by saving the module.

This becomes apparent with downstream errors that you might miss.