### PR TITLE
Added missing overload in TerminalIDEClient

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEClient.java
@@ -154,6 +154,11 @@ public class TerminalIDEClient implements IDEServices {
     }
 
     @Override
+    public void applyFileSystemEdits(IList edits) {
+        applyDocumentsEdits(edits);
+    }
+
+    @Override
     public void jobStart(String name, int workShare, int totalWork) {
         monitor.jobStart(name, workShare, totalWork);
     }


### PR DESCRIPTION
An overload for `applyFileSystemEdits` was missing.

Closes #840 