### PR TITLE
Abort type-check when dependencies have parse errors.

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -167,7 +167,8 @@ public class RascalLanguageServices {
         return e.getFunctionValueFactory().function(getParseTreeType, (t, u) -> {
             ISourceLocation resolvedLocation = Locations.toClientLocation((ISourceLocation) t[0]);
             try {
-                var tree = rascalTextDocumentService.getFile(resolvedLocation).getCurrentTreeAsync(false).get();
+                // although we cannot type-check modules with errors, we prefer to get the errors here instead of retrying the parse and still failing after this try-block
+                var tree = rascalTextDocumentService.getFile(resolvedLocation).getCurrentTreeAsync(true).get();
                 if (tree != null) {
                     return tree.get();
                 }

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -85,7 +85,7 @@ map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module]
                         ml = locateRascalModule(modName, getPathConfig(currentProject), getPathConfig, workspaceFolders);
                         if (ml.extension == "rsc", mlpt := getParseTree(ml), mlpt.src.top notin checkedForImports) {
                             if (hasParseErrors(mlpt)) {
-                                return (l: {error("Cannot typecheck this module, since a dependency has parse error(s).", openFileHeader.src,
+                                return (l: {error("Cannot typecheck this module, since dependency `<modName>` has parse error(s).", openFileHeader.src,
                                     causes=[error("Has a parse error around this position.", e.src) | Tree e <- findBestParseErrors(mlpt)])
                                 });
                             }
@@ -94,7 +94,7 @@ map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module]
                             dependencies += <currentProject, inferProjectRoot(mlpt.src.top)>;
                         }
                     } catch ParseError(loc err): {
-                        return (l: {error("Cannot typecheck this module, since a dependency has parse error(s).", openFileHeader.src, causes=[error("Has parse error(s).", err)])});
+                        return (l: {error("Cannot typecheck this module, since dependency `<modName>` has parse error(s).", openFileHeader.src, causes=[error("Has parse error(s).", err)])});
                     } catch e: {
                         println("Exception while building dependency graph at <currentSrc>: <e>");
                         ;// Continue

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -85,8 +85,8 @@ map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module]
                         ml = locateRascalModule(modName, getPathConfig(currentProject), getPathConfig, workspaceFolders);
                         if (ml.extension == "rsc", mlpt := getParseTree(ml), mlpt.src.top notin checkedForImports) {
                             if (hasParseErrors(mlpt)) {
-                                return (l: {error("Cannot typecheck this module.", openFileHeader.src,
-                                    causes=[error("Parse error", e.src) | Tree e <- findBestParseErrors(mlpt)])
+                                return (l: {error("Cannot typecheck this module, since a dependency has parse error(s).", openFileHeader.src,
+                                    causes=[error("Has a parse error around this position.", e.src) | Tree e <- findBestParseErrors(mlpt)])
                                 });
                             }
                             checkForImports += mlpt;
@@ -94,7 +94,7 @@ map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module]
                             dependencies += <currentProject, inferProjectRoot(mlpt.src.top)>;
                         }
                     } catch ParseError(loc err): {
-                        return (l: {error("Cannot typecheck this module.", openFileHeader.src, causes=[error("<modName> has parse error(s).", err)])});
+                        return (l: {error("Cannot typecheck this module, since a dependency has parse error(s).", openFileHeader.src, causes=[error("Has parse error(s).", err)])});
                     } catch e: {
                         println("Exception while building dependency graph at <currentSrc>: <e>");
                         ;// Continue

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -80,7 +80,7 @@ map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module]
                     try {
                         ml = locateRascalModule(modName, getPathConfig(currentProject), getPathConfig, workspaceFolders);
                         if (ml.extension == "rsc", mlpt := getParseTree(ml), mlpt.src.top notin checkedForImports) {
-                            if (printlnExp("Transitive dependency <ml> has parse error(s): ", hasParseErrors(mlpt))) {
+                            if (hasParseErrors(mlpt)) {
                                 return {<l, error("Cannot typecheck this module, since <modName> has parse error(s) (<tree.src.top>).", openFileHeader.src)>};
                             }
                             checkForImports += mlpt;

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -37,7 +37,6 @@ import analysis::graphs::Graph;
 import util::FileSystem;
 import util::Monitor;
 import util::ParseErrorRecovery;
-import util::Reflective;
 
 import lang::rascal::\syntax::Rascal;
 import lang::rascalcore::check::Checker;

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -54,11 +54,12 @@ import lang::rascalcore::check::ModuleLocations;
 }
 map[loc, set[Message]] checkFile(loc l, set[loc] workspaceFolders, start[Module](loc file) getParseTree, PathConfig(loc file) getPathConfig)
     = job("Rascal check", map[loc, set[Message]](void(str, int) step) {
-    start[Module] openFile;
+    openFile = (start[Module]) `module Placeholder`;
     try {
+        // Note: check further down parses again, possibly leading to a different tree if the contents changed in the meantime
         openFile = getParseTree(l);
     } catch ParseError(loc err): {
-        return (l: {error("Cannot typecheck this module, since it has parse error(s).", err)});
+        return ();
     }
     if (hasParseErrors(openFile)) {
         // We cannot typecheck this file, since it has type errors. Do not return any errors, since the parse triggered by the IDE will take care of that.


### PR DESCRIPTION
**Recovered parse error**
_Shows 1 cause per disambiguated error tree_
<img width="865" height="1013" alt="afbeelding" src="https://github.com/user-attachments/assets/69fce87c-fd76-465c-9351-2ce77eae947d" />

**Fatal parse error**
_Shows 1 cause for the file with an error_
<img width="865" height="1013" alt="afbeelding" src="https://github.com/user-attachments/assets/c7f19143-61ae-457b-8775-c16594139dc5" />

Closes #832 