### PR TITLE
Use fully qualified name in runMain

### DIFF
--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -95,7 +95,7 @@ export class RascalExtension implements vscode.Disposable {
                 if (!text.document.uri || !moduleName) {
                     return;
                 }
-                this.startTerminal(text.document.uri, `import ${moduleName};\nmain();\n`);
+                this.startTerminal(text.document.uri, `import ${moduleName};\n${moduleName}::main();\n`);
             })
         );
     }


### PR DESCRIPTION
The 'Run main in new terminal' code lens might run another `main()` in scope (for example from an imported module), which causes unexpected behaviour. This PR modifies the action to use the fully qualified function name instead.