### PR TITLE
Add labels to workspace edits

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -521,7 +521,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                     }
 
                     WorkspaceEdit changes = DocumentChanges.translateDocumentChanges(this, edits);
-                    client.applyEdit(new ApplyWorkspaceEditParams(changes)).thenAccept(editResponse -> {
+                    client.applyEdit(new ApplyWorkspaceEditParams(changes, "Rename files")).thenAccept(editResponse -> {
                         if (!editResponse.isApplied()) {
                             throw new RuntimeException("didRenameFiles resulted in a list of edits but applying them failed"
                                 + (editResponse.getFailureReason() != null ? (": " + editResponse.getFailureReason()) : ""));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -506,7 +506,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 }
 
                 var changes = DocumentChanges.translateDocumentChanges(this, edits);
-                availableClient().applyEdit(new ApplyWorkspaceEditParams(changes)).thenAccept(editResponse -> {
+                availableClient().applyEdit(new ApplyWorkspaceEditParams(changes, "Rename files")).thenAccept(editResponse -> {
                     if (!editResponse.isApplied()) {
                         throw new RuntimeException("Applying module rename failed" + (editResponse.getFailureReason() != null ? (": " + editResponse.getFailureReason()) : ""));
                     }


### PR DESCRIPTION
Add describing labels when applying edits to the workspace. Shown to the user in the undo stack, for example. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_applyEdit