### PR TITLE
Fix module rename signature

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -253,10 +253,10 @@ public class RascalLanguageServices {
         }, VF.tuple(VF.list(), VF.map()), exec, false, client);
     }
 
-    public CompletableFuture<ITuple> getModuleRenames(IList fileRenames, Set<ISourceLocation> workspaceFolders) {
+    public InterruptibleFuture<ITuple> getModuleRenames(IList fileRenames, Set<ISourceLocation> workspaceFolders) {
         var emptyResult = VF.tuple(VF.list(), VF.map());
         if (fileRenames.isEmpty()) {
-            return CompletableFuture.completedFuture(emptyResult);
+            return InterruptibleFuture.completedFuture(emptyResult);
         }
 
         return runEvaluator("Rascal module rename", semanticEvaluator, eval -> {
@@ -265,7 +265,7 @@ public class RascalLanguageServices {
             } catch (Throw e) {
                 throw new RuntimeException(e.getMessage());
             }
-        }, emptyResult, exec, false, client).get();
+        }, emptyResult, exec, false, client);
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -259,13 +259,9 @@ public class RascalLanguageServices {
             return InterruptibleFuture.completedFuture(emptyResult);
         }
 
-        return runEvaluator("Rascal module rename", semanticEvaluator, eval -> {
-            try {
-                return (ITuple) eval.call("rascalRenameModule", fileRenames, workspaceFolders.stream().collect(VF.setWriter()), makePathConfigGetter(eval));
-            } catch (Throw e) {
-                throw new RuntimeException(e.getMessage());
-            }
-        }, emptyResult, exec, false, client);
+        return runEvaluator("Rascal module rename", semanticEvaluator, eval ->
+            (ITuple) eval.call("rascalRenameModule", fileRenames, workspaceFolders.stream().collect(VF.setWriter()), makePathConfigGetter(eval))
+        , emptyResult, exec, false, client);
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -31,7 +31,6 @@ import static org.rascalmpl.vscode.lsp.util.EvaluatorUtil.runEvaluator;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +45,6 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.eclipse.lsp4j.FileRename;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
@@ -255,32 +253,19 @@ public class RascalLanguageServices {
         }, VF.tuple(VF.list(), VF.map()), exec, false, client);
     }
 
-    private ISourceLocation sourceLocationFromUri(String uri) {
-        try {
-            return URIUtil.createFromURI(uri);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public CompletableFuture<ITuple> getModuleRenames(List<FileRename> fileRenames, Set<ISourceLocation> workspaceFolders) {
+    public CompletableFuture<ITuple> getModuleRenames(IList fileRenames, Set<ISourceLocation> workspaceFolders) {
         var emptyResult = VF.tuple(VF.list(), VF.map());
         if (fileRenames.isEmpty()) {
             return CompletableFuture.completedFuture(emptyResult);
         }
 
-        return CompletableFuture.supplyAsync(() -> fileRenames.stream()
-                .map(r -> VF.tuple(sourceLocationFromUri(r.getOldUri()), sourceLocationFromUri(r.getNewUri())))
-                .collect(VF.listWriter())
-            , exec)
-            .thenCompose(renames ->
-                runEvaluator("Rascal module rename", semanticEvaluator, eval -> {
-                    try {
-                        return (ITuple) eval.call("rascalRenameModule", renames, workspaceFolders.stream().collect(VF.setWriter()), makePathConfigGetter(eval));
-                    } catch (Throw e) {
-                        throw new RuntimeException(e.getMessage());
-                    }
-                }, emptyResult, exec, false, client).get());
+        return runEvaluator("Rascal module rename", semanticEvaluator, eval -> {
+            try {
+                return (ITuple) eval.call("rascalRenameModule", fileRenames, workspaceFolders.stream().collect(VF.setWriter()), makePathConfigGetter(eval));
+            } catch (Throw e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        }, emptyResult, exec, false, client).get();
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -521,6 +521,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                     }
                 });
             })
+            .get()
             .exceptionally(e -> {
                 var cause = e.getCause();
                 logger.catching(Level.ERROR, cause);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -104,6 +104,10 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.util.locations.ColumnMaps;
+import org.rascalmpl.util.locations.LineColumnOffsetMap;
+import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
@@ -124,8 +128,6 @@ import org.rascalmpl.vscode.lsp.util.FoldingRanges;
 import org.rascalmpl.vscode.lsp.util.SelectionRanges;
 import org.rascalmpl.vscode.lsp.util.SemanticTokenizer;
 import org.rascalmpl.vscode.lsp.util.Versioned;
-import org.rascalmpl.util.locations.ColumnMaps;
-import org.rascalmpl.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import org.rascalmpl.vscode.lsp.util.locations.impl.TreeSearch;
 
@@ -135,9 +137,12 @@ import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IString;
 import io.usethesource.vallang.IValue;
+import io.usethesource.vallang.IValueFactory;
 
 public class RascalTextDocumentService implements IBaseTextDocumentService, LanguageClientAware {
+    private static final IValueFactory VF = IRascalValueFactory.getInstance();
     private static final Logger logger = LogManager.getLogger(RascalTextDocumentService.class);
+
     private final ExecutorService ownExecuter;
     private @MonotonicNonNull RascalLanguageServices rascalServices;
 
@@ -495,7 +500,11 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             .map(f -> Locations.toLoc(f.getUri()))
             .collect(Collectors.toSet());
 
-        availableRascalServices().getModuleRenames(params.getFiles(), folders)
+        IList renames = params.getFiles().stream()
+            .map(r -> VF.tuple(URIUtil.assumeCorrectLocation(r.getOldUri()), URIUtil.assumeCorrectLocation(r.getNewUri())))
+            .collect(VF.listWriter());
+
+        availableRascalServices().getModuleRenames(renames, folders)
             .thenAccept(res -> {
                 var edits = (IList) res.get(0);
                 var messages = (ISet) res.get(1);


### PR DESCRIPTION
- Return interruptible futures from Rascal services where possible.
- Map LSP types before calling Rascal services.

As commented by @DavyLandman: https://github.com/usethesource/rascal-language-servers/pull/871#discussion_r2522144318