### PR TITLE
Configure Dependabot to update GitHub Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
         dependency-type: "development"
         exclude-patterns:
         - "@types/vscode"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
As per the [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#configuring-dependabot-version-updates-for-actions).

Triggered by warnings in our CI run about a deprecated [CodeQL version](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/#users-of-github-com-and-github-enterprise-server-3-20-and-newer).