### PR TITLE
Group Dependabot version updates for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      version-updates:
+        patterns:
+        - "*"


### PR DESCRIPTION
To prevent this from happening: 
#884 
#885 
#886 
#887 
#888
#889 

Note: this configuration does not apply to security updates, so we can address those individually.