### PR TITLE
Fix opaque URI roundtrip

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IRascalFileSystemServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IRascalFileSystemServices.java
@@ -349,14 +349,14 @@ public interface IRascalFileSystemServices {
         public static SourceLocation fromRascalLocation(ISourceLocation loc) {
             if (loc.hasOffsetLength()) {
                 if (loc.hasLineColumn()) {
-                    return new SourceLocation(loc.getURI().toString(), loc.getOffset(), loc.getLength(), loc.getBeginLine(), loc.getBeginColumn(), loc.getEndLine(), loc.getEndColumn());
+                    return new SourceLocation(Locations.toUri(loc), loc.getOffset(), loc.getLength(), loc.getBeginLine(), loc.getBeginColumn(), loc.getEndLine(), loc.getEndColumn());
                 }
                 else {
-                    return new SourceLocation(loc.getURI().toString(), loc.getOffset(), loc.getLength());
+                    return new SourceLocation(Locations.toUri(loc), loc.getOffset(), loc.getLength());
                 }
             }
             else {
-                return new SourceLocation(loc.getURI().toString());
+                return new SourceLocation(Locations.toUri(loc));
             }
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -151,7 +151,7 @@ public class LSPIDEServices implements IDEServices {
         Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(messages, docService.getColumnMaps());
 
         for (Entry<ISourceLocation, List<Diagnostic>> entry : translated.entrySet()) {
-            String uri = entry.getKey().getURI().toString();
+            String uri = Locations.toUri(entry.getKey());
             languageClient.publishDiagnostics(new PublishDiagnosticsParams(uri, entry.getValue()));
         }
     }
@@ -160,7 +160,7 @@ public class LSPIDEServices implements IDEServices {
     public void unregisterDiagnostics(IList resources) {
         for (IValue elem : resources) {
             ISourceLocation loc = (ISourceLocation) elem;
-            languageClient.publishDiagnostics(new PublishDiagnosticsParams(loc.getURI().toString(), Collections.emptyList()));
+            languageClient.publishDiagnostics(new PublishDiagnosticsParams(Locations.toUri(loc), Collections.emptyList()));
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
@@ -52,6 +52,7 @@ import org.rascalmpl.vscode.lsp.parametric.ILanguageContributions;
 import org.rascalmpl.vscode.lsp.parametric.model.ParametricSummary.SummaryLookup;
 import org.rascalmpl.vscode.lsp.util.Lists;
 import org.rascalmpl.vscode.lsp.util.Versioned;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import org.rascalmpl.util.locations.ColumnMaps;
 
 import io.usethesource.vallang.ISourceLocation;
@@ -339,8 +340,9 @@ public class ParametricFileFacts {
                 "Sending {} diagnostic(s) for {} (parser: v{}; analyzer: v{}; builder: v{})",
                 diagnostics.size(), file, fromParser.version(), fromAnalyzer.version(), fromBuilder.version());
 
+            var uri = Locations.toUri(file);
             client.publishDiagnostics(new PublishDiagnosticsParams(
-                file.getURI().toString(),
+                uri,
                 diagnostics));
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
@@ -340,9 +340,8 @@ public class ParametricFileFacts {
                 "Sending {} diagnostic(s) for {} (parser: v{}; analyzer: v{}; builder: v{})",
                 diagnostics.size(), file, fromParser.version(), fromAnalyzer.version(), fromBuilder.version());
 
-            var uri = Locations.toUri(file);
             client.publishDiagnostics(new PublishDiagnosticsParams(
-                uri,
+                Locations.toUri(file),
                 diagnostics));
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -136,9 +136,8 @@ public class FileFacts {
                 return;
             }
             logger.trace("Sending diagnostics for: {}", file);
-            var uri = Locations.toUri(file);
             client.publishDiagnostics(new PublishDiagnosticsParams(
-                uri,
+                Locations.toUri(file),
                 Lists.union(typeCheckerMessages, parseMessages)));
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -136,8 +136,9 @@ public class FileFacts {
                 return;
             }
             logger.trace("Sending diagnostics for: {}", file);
+            var uri = Locations.toUri(file);
             client.publishDiagnostics(new PublishDiagnosticsParams(
-                file.getURI().toString(),
+                uri,
                 Lists.union(typeCheckerMessages, parseMessages)));
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -38,6 +38,7 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.vscode.lsp.util.Diagnostics;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import org.rascalmpl.util.locations.ColumnMaps;
 
 import io.usethesource.vallang.IList;
@@ -134,7 +135,7 @@ import io.usethesource.vallang.ISourceLocation;
             for (List<Diagnostic> diags : perFileProjectDiagnostics.getOrDefault(file, Collections.emptyMap()).values()) {
                 fileDiagnostics.addAll(diags);
             }
-            publishList.add(new PublishDiagnosticsParams(file.getURI().toString(), fileDiagnostics));
+            publishList.add(new PublishDiagnosticsParams(Locations.toUri(file), fileDiagnostics));
         }
         return publishList;
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/TerminalIDEServer.java
@@ -152,7 +152,7 @@ public class TerminalIDEServer implements ITerminalIDEServer {
         Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(param.getMessages(), docService.getColumnMaps());
 
         for (Entry<ISourceLocation, List<Diagnostic>> entry : translated.entrySet()) {
-            String uri = entry.getKey().getURI().toString();
+            String uri = Locations.toUri(entry.getKey());
             languageClient.publishDiagnostics(new PublishDiagnosticsParams(uri, entry.getValue()));
         }
     }
@@ -161,7 +161,7 @@ public class TerminalIDEServer implements ITerminalIDEServer {
     public void unregisterDiagnostics(UnRegisterDiagnosticsParameters param) {
         for (IValue elem : param.getLocations()) {
             ISourceLocation loc = Locations.toPhysicalIfPossible((ISourceLocation) elem);
-            languageClient.publishDiagnostics(new PublishDiagnosticsParams(loc.getURI().toString(), Collections.emptyList()));
+            languageClient.publishDiagnostics(new PublishDiagnosticsParams(Locations.toUri(loc), Collections.emptyList()));
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/messages/ISourceLocationRequest.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/messages/ISourceLocationRequest.java
@@ -28,6 +28,8 @@ package org.rascalmpl.vscode.lsp.uri.jsonrpc.messages;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
+
 import io.usethesource.vallang.ISourceLocation;
 
 public class ISourceLocationRequest {
@@ -42,7 +44,7 @@ public class ISourceLocationRequest {
     }
 
     public ISourceLocationRequest(ISourceLocation loc) {
-        this(loc.getURI().toString());
+        this(Locations.toUri(loc));
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/messages/RenameRequest.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/messages/RenameRequest.java
@@ -29,6 +29,8 @@ package org.rascalmpl.vscode.lsp.uri.jsonrpc.messages;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
+
 import io.usethesource.vallang.ISourceLocation;
 
 public class RenameRequest {
@@ -49,8 +51,8 @@ public class RenameRequest {
     }
 
     public RenameRequest(ISourceLocation from, ISourceLocation to, boolean overwrite) {
-        this.from = from.getURI().toString();
-        this.to = to.getURI().toString();
+        this.from = Locations.toUri(from);
+        this.to = Locations.toUri(to);
         this.overwrite = overwrite;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/CallHierarchy.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/CallHierarchy.java
@@ -97,7 +97,7 @@ public class CallHierarchy {
         var selection = (ISourceLocation) cons.get(CallHierarchyFields.SELECTION);
         var selectionRange = Locations.toRange(selection, columns);
 
-        var ci = new CallHierarchyItem(name, kind, def.top().getURI().toString(), definitionRange, selectionRange);
+        var ci = new CallHierarchyItem(name, kind, Locations.toUri(def.top()), definitionRange, selectionRange);
         var kws = cons.asWithKeywordParameters();
         if (kws.hasParameter(CallHierarchyFields.TAGS)) {
             ci.setTags(DocumentSymbols.symbolTagsToLSP((ISet) kws.getParameter(CallHierarchyFields.TAGS)));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentChanges.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/DocumentChanges.java
@@ -161,6 +161,6 @@ public class DocumentChanges {
     }
 
     private static String getFileURI(IConstructor edit, String label) {
-        return Locations.toClientLocation((ISourceLocation) edit.get(label)).getURI().toString();
+        return Locations.toUri(Locations.toClientLocation((ISourceLocation) edit.get(label)));
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -56,7 +56,7 @@ public class Locations {
     // Synthetic scheme to (un)wrap an opaque URI as/from an absolute URI.
     // Can only contain alphanumeric characters or "+", "-", ".", and should start with an alpha
     // https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
-    private static final String OPAQUE_SCHEME = "opaque---";
+    private static final String OPAQUE_SCHEME = "opaque-lsp-";
 
     public static ISourceLocation toClientLocation(ISourceLocation loc) {
         loc = LSPOpenFileResolver.stripLspPrefix(loc);
@@ -134,9 +134,12 @@ public class Locations {
         try {
             var u = new URI(uri);
             if (u.isOpaque()) {
-                // Rascal does not support opaque URIs
-                // Wrap as a hierarchical URI with all the original information, so we can get the original URI back later.
-                // Note: since an absolute URI requires an absolute path, prefix the scheme-specific part with "/"
+                // Rascal does not support opaque URIs, so we wrap those as hierarchical URIs.
+                // - Replace the scheme by a unique, recognizable scheme.
+                // - Put the original opaque scheme in the authority (which opaque URIs do not have).
+                // - A hierarchical URI requires an absolute path; prefix the scheme-specific part with "/".
+                // - Opaque URIs do not have a query, so we leave that unset.
+                // - Clone the (optional) fragment.
                 uri = new URI(OPAQUE_SCHEME, u.getScheme(), "/" + u.getSchemeSpecificPart(), null, u.getFragment()).toString();
             }
             return URIUtil.createFromURI(uri);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -163,11 +163,11 @@ public class Locations {
     }
 
     public static Location toLSPLocation(ISourceLocation sloc, ColumnMaps cm) {
-        return new Location(sloc.getURI().toString(), toRange(sloc, cm));
+        return new Location(Locations.toUri(sloc), toRange(sloc, cm));
     }
 
     public static Location toLSPLocation(ISourceLocation sloc, LineColumnOffsetMap map) {
-        return new Location(sloc.getURI().toString(), toRange(sloc, map));
+        return new Location(Locations.toUri(sloc), toRange(sloc, map));
     }
 
     public static Range toRange(ISourceLocation sloc, ColumnMaps cm) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -137,7 +137,10 @@ public class Locations {
                 // Rascal does not support opaque URIs
                 // Wrap as a hierarchical URI with all the original information, so we can get the original URI back later.
                 // Since the scheme cannot contain "/", we can use that as a separator in the new URI.
-                return URIUtil.createFromURI(String.format("%s:///%s/%s", OPAQUE_SCHEME, u.getScheme(), u.getRawSchemeSpecificPart()));
+                var fragmentPart = u.getRawFragment() == null
+                    ? ""
+                    : "#" + u.getRawFragment();
+                return URIUtil.createFromURI(String.format("%s:///%s/%s%s", OPAQUE_SCHEME, u.getScheme(), u.getRawSchemeSpecificPart(), fragmentPart));
             }
             return URIUtil.createFromURI(uri);
         } catch (URISyntaxException e) {

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
@@ -130,7 +130,7 @@ public class LocationsTest {
                 fail("Mapped invalid URI " + uri + " to " + loc + ", but should have failed");
             } catch (RuntimeException e) {
                 if (!(e.getCause() instanceof URISyntaxException)) {
-                    fail("Expected excepted caused by URISyntaxException, but got " + e.getCause());
+                    fail("Expected exception caused by URISyntaxException, but got " + e.getCause());
                 }
             }
         }

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
@@ -126,7 +126,7 @@ public class LocationsTest {
         for (var uri : new String[] {"file:///foo/bar baz.txt"}) {
             try {
                 var loc = Locations.toLoc(uri);
-                fail(String.format("Mapped invalid URI %s to %s, but should have failed", uri, loc));
+                fail("Mapped invalid URI " + uri + " to " + loc + ", but should have failed");
             } catch (RuntimeException e) {
                 if (!(e.getCause() instanceof URISyntaxException)) {
                     fail("Expected excepted caused by URISyntaxException, but got " + e.getCause());

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
@@ -117,6 +117,7 @@ public class LocationsTest {
         roundtripUri("file:///foo/bar");
         roundtripUri("file:///foo/bar%20baz.txt");
         roundtripUri("unknown:///foo/bar");
+        roundtripUri("untitled://foo/bar");
         roundtripUri("untitled:///foo/bar");
         roundtripUri("memory:///foo/bar");
     }

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
@@ -139,8 +139,9 @@ public class LocationsTest {
     public void roundtripOpaqueUris() {
         // New, unsaved file from VS Code
         roundtripUri("untitled:Untitled-1");
-        roundtripUri("untitled:foo/bar/Untitled-1");
-        roundtripUri("untitled:Untitled%201");
+        roundtripUri("untitled:foo/bar/Untitled-1"); // separators in scheme-specific part
+        roundtripUri("untitled:Untitled%201"); // encoded characters
+        roundtripUri("untitled:Untitled-1#header1"); // with fragment
 
         // Examples from Java documentation (https://docs.oracle.com/javase/8/docs/api/java/net/URI.html)
         roundtripUri("mailto:java-net@java.sun.com");

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/LocationsTest.java
@@ -27,7 +27,9 @@
 package engineering.swat.rascal.lsp.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import java.net.URISyntaxException;
 import org.junit.Test;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.IRascalValueFactory;
@@ -102,5 +104,47 @@ public class LocationsTest {
         var in = VF.sourceLocation(fileName, 19, 115, 2, 6, 0, 1); // the structure
         var out = Locations.setRange(in, Locations.toRange(in, columns), columns);
         assertEquals(in, out);
+    }
+
+    private void roundtripUri(String uri) {
+        var loc = Locations.toLoc(uri);
+        var uri2 = Locations.toUri(loc);
+        assertEquals(uri, uri2);
+    }
+
+    @Test
+    public void roundtripAbsoluteUris() {
+        roundtripUri("file:///foo/bar");
+        roundtripUri("file:///foo/bar%20baz.txt");
+        roundtripUri("unknown:///foo/bar");
+        roundtripUri("untitled:///foo/bar");
+        roundtripUri("memory:///foo/bar");
+    }
+
+    @Test
+    public void illegalUris() {
+        for (var uri : new String[] {"file:///foo/bar baz.txt"}) {
+            try {
+                var loc = Locations.toLoc(uri);
+                fail(String.format("Mapped invalid URI %s to %s, but should have failed", uri, loc));
+            } catch (RuntimeException e) {
+                if (!(e.getCause() instanceof URISyntaxException)) {
+                    fail("Expected excepted caused by URISyntaxException, but got " + e.getCause());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void roundtripOpaqueUris() {
+        // New, unsaved file from VS Code
+        roundtripUri("untitled:Untitled-1");
+        roundtripUri("untitled:foo/bar/Untitled-1");
+        roundtripUri("untitled:Untitled%201");
+
+        // Examples from Java documentation (https://docs.oracle.com/javase/8/docs/api/java/net/URI.html)
+        roundtripUri("mailto:java-net@java.sun.com");
+        roundtripUri("news:comp.lang.java");
+        roundtripUri("urn:isbn:096139210x");
     }
 }


### PR DESCRIPTION
Rascal source locations do no support opaque URIs. VS Code can create opaque URIs, for example `untitled:Untitled-1` for an unsaved file.

This PR modifies the VS Code URI <-> Rascal `loc` conversion to work with opaque URIs, by constructing absolute URIs that contain all information from the original opaque URI, we can produce valid source locations without losing information. We use a custom scheme to be able to recognize (absolute) URIs coming from Rascal as being originally opaque.

Closes #896.