### PR TITLE
Use daemon threads in Rascal interface.

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/RascalInterface.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/RascalInterface.java
@@ -39,6 +39,7 @@ import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
+import org.rascalmpl.vscode.lsp.util.NamedThreadPool;
 import org.rascalmpl.vscode.lsp.util.locations.impl.TreeSearch;
 
 import io.usethesource.vallang.IConstructor;
@@ -67,8 +68,9 @@ public class RascalInterface {
                     .setRemoteInterface(LanguageRegistry.class)
                     .setInput(socket.getInputStream())
                     .setOutput(socket.getOutputStream())
+                    .setExecutorService(NamedThreadPool.cachedDaemon("rascal-interface"))
                     .create();
-                
+
                 clientLauncher.startListening();
                 registry = clientLauncher.getRemoteProxy();
             }


### PR DESCRIPTION
Companion of https://github.com/usethesource/rascal/pull/2555

Tested using local snapshot versions of Rascal and Rascal LSP.