### PR TITLE
Ensure future reductions do not use common thread pool

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -758,7 +758,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         // first we make a future stream for filtering out the "fixes" that were optionally sent along with earlier diagnostics
         // and which came back with the codeAction's list of relevant (in scope) diagnostics:
         // CompletableFuture<Stream<IValue>>
-        var quickfixes = CodeActions.extractActionsFromDiagnostics(params, contribs::parseCodeActions);
+        var quickfixes = CodeActions.extractActionsFromDiagnostics(params, contribs::parseCodeActions, exec);
 
         // here we dynamically ask the contributions for more actions,
         // based on the cursor position in the file and the current parse tree
@@ -870,7 +870,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                     .map(p -> computeSelection
                         .thenCompose(compute -> compute.apply(TreeSearch.computeFocusList(t, p.getLine(), p.getCharacter())))
                         .thenApply(selection -> SelectionRanges.toSelectionRange(p, selection, columns)))
-                    .collect(Collectors.toUnmodifiableList()))),
+                    .collect(Collectors.toUnmodifiableList()), exec)),
             Collections::emptyList);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -684,7 +684,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         // and which came back with the codeAction's list of relevant (in scope) diagnostics:
         // CompletableFuture<Stream<IValue>>
         CompletableFuture<Stream<IValue>> quickfixes
-            = CodeActions.extractActionsFromDiagnostics(params, availableRascalServices()::parseCodeActions);
+            = CodeActions.extractActionsFromDiagnostics(params, availableRascalServices()::parseCodeActions, exec);
 
         // here we dynamically ask the contributions for more actions,
         // based on the cursor position in the file and the current parse tree

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/CodeActions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/CodeActions.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -70,7 +71,7 @@ public class CodeActions {
      * @param actionParser  provides the parser with a scope that imports the right definitions of Command terms.
      * @return              a future stream of parsed and type-checked Rascal CodeAction terms.
      */
-    public static CompletableFuture<Stream<IValue>> extractActionsFromDiagnostics(CodeActionParams params, Function<String, CompletableFuture<IList>> actionParser) {
+    public static CompletableFuture<Stream<IValue>> extractActionsFromDiagnostics(CodeActionParams params, Function<String, CompletableFuture<IList>> actionParser, Executor exec) {
         var actions = params.getContext().getDiagnostics()
             .stream()
             .map(Diagnostic::getData)
@@ -82,7 +83,7 @@ public class CodeActions {
             .map(actionParser);
 
         return CompletableFutureUtils
-            .flatten(actions, IRascalValueFactory.getInstance()::list, IList::concat)
+            .flatten(actions, CompletableFutureUtils.completedFuture(IRascalValueFactory.getInstance().list(), exec), IList::concat)
             .thenApply(IList::stream);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
@@ -34,7 +34,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class CompletableFutureUtils {
@@ -50,9 +49,9 @@ public class CompletableFutureUtils {
      * @param futures The futures to reduce.
      * @return A future that yields a list of the results of the reduced futures.
      */
-    public static <T> CompletableFuture<List<T>> reduce(List<CompletableFuture<T>> futures) {
+    public static <T> CompletableFuture<List<T>> reduce(List<CompletableFuture<T>> futures, Executor exec) {
         return reduce(futures,
-            LinkedList::new,
+            completedFuture(new LinkedList<>(), exec),
             Collections::singletonList, // unmodifiable, but never added to
             CompletableFutureUtils::concat
         );
@@ -64,9 +63,9 @@ public class CompletableFutureUtils {
      * @param futures The futures to reduce.
      * @return A future that yields a collection of the results of the reduced futures.
      */
-    public static <T> CompletableFuture<List<T>> reduce(Stream<CompletableFuture<T>> futures) {
+    public static <T> CompletableFuture<List<T>> reduce(Stream<CompletableFuture<T>> futures, Executor exec) {
         return reduce(futures,
-            LinkedList::new,
+            completedFuture(new LinkedList<>(), exec),
             Collections::singletonList, // unmodifiable, but never added to
             CompletableFutureUtils::concat
         );
@@ -80,7 +79,7 @@ public class CompletableFutureUtils {
      * @param concat A function that merges two values of {@link I}.
      * @return A future that yields a list of all the elements in the lists from the reduced futures.
      */
-    public static <I extends Iterable<?>> CompletableFuture<I> flatten(Stream<CompletableFuture<I>> futures, Supplier<I> identity, BinaryOperator<I> concat) {
+    public static <I extends Iterable<?>> CompletableFuture<I> flatten(Stream<CompletableFuture<I>> futures, CompletableFuture<I> identity, BinaryOperator<I> concat) {
         return reduce(futures,
             identity,
             Function.identity(),
@@ -100,11 +99,10 @@ public class CompletableFutureUtils {
      *
      */
     public static <I, C> CompletableFuture<C> reduce(Stream<CompletableFuture<I>> futures,
-            Supplier<C> identity, Function<I, C> map, BinaryOperator<C> concat) {
+            CompletableFuture<C> identity, Function<I, C> map, BinaryOperator<C> concat) {
         return futures
                 .map(t -> t.thenApply(map))
-                .reduce(CompletableFuture.completedFuture(identity.get()),
-                        (lf, rf) -> lf.thenCombine(rf, concat));
+                .reduce(identity, (lf, rf) -> lf.thenCombine(rf, concat));
     }
 
     /**
@@ -118,8 +116,8 @@ public class CompletableFutureUtils {
      * @return A single future that, if it completes, yields the reduced result.
      */
     public static <I, C> CompletableFuture<C> reduce(Iterable<CompletableFuture<I>> futures,
-            Supplier<C> identity, Function<I, C> map, BinaryOperator<C> concat) {
-        CompletableFuture<C> result = CompletableFuture.completedFuture(identity.get());
+            CompletableFuture<C> identity, Function<I, C> map, BinaryOperator<C> concat) {
+        CompletableFuture<C> result = identity;
         for (var fut : futures) {
             result = result.thenCombine(fut, (acc, t) -> concat.apply(acc, map.apply(t)));
         }

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/CompletableFutureUtilsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/CompletableFutureUtilsTest.java
@@ -27,6 +27,7 @@
 package engineering.swat.rascal.lsp.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils.completedFuture;
 import static org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils.flatten;
 import static org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils.reduce;
 
@@ -37,8 +38,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
-
 import org.apache.commons.compress.utils.Sets;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,6 +52,7 @@ public class CompletableFutureUtilsTest {
     private List<CompletableFuture<Integer>> futList;
 
     private static final IRascalValueFactory VF = IRascalValueFactory.getInstance();
+    private final Executor exec = Executors.newCachedThreadPool();
 
     @Before
     public void setUp() {
@@ -61,20 +64,20 @@ public class CompletableFutureUtilsTest {
 
     @Test
     public void reduceList() throws InterruptedException, ExecutionException {
-        CompletableFuture<List<Integer>> reduced = reduce(futList);
+        CompletableFuture<List<Integer>> reduced = reduce(futList, exec);
         assertEquals(Arrays.asList(1, 2, 3), reduced.get());
     }
 
     @Test
     public void reduceStream() throws InterruptedException, ExecutionException {
-        CompletableFuture<List<Integer>> reduced = reduce(futList.stream());
+        CompletableFuture<List<Integer>> reduced = reduce(futList.stream(), exec);
         assertEquals(Arrays.asList(1, 2, 3), reduced.get());
     }
 
     @Test
     public void reduceToSet() throws InterruptedException, ExecutionException {
         futList.add(CompletableFuture.completedFuture(1));
-        CompletableFuture<Set<Integer>> reduced = reduce(futList, Sets::newHashSet, Sets::newHashSet, this::setUnion);
+        CompletableFuture<Set<Integer>> reduced = reduce(futList, completedFuture(new HashSet<>(), exec), Sets::newHashSet, this::setUnion);
         assertEquals(Sets.newHashSet(1, 2, 3), reduced.get());
     }
 
@@ -86,7 +89,7 @@ public class CompletableFutureUtilsTest {
         );
 
         CompletableFuture<Integer> reduced = reduce(listFutList,
-            () -> 0,
+            completedFuture(0, exec),
             l -> l.stream().reduce(Integer::sum).orElse(0),
             Integer::sum
         );
@@ -95,13 +98,13 @@ public class CompletableFutureUtilsTest {
 
     @Test
     public void reduceAndAddList() throws InterruptedException, ExecutionException {
-        CompletableFuture<Integer> reduced = reduce(futList, () -> 0, Function.identity(), Integer::sum);
+        CompletableFuture<Integer> reduced = reduce(futList, completedFuture(0, exec), Function.identity(), Integer::sum);
         assertEquals(6, reduced.get().intValue());
     }
 
     @Test
     public void reduceAndAddStream() throws InterruptedException, ExecutionException {
-        CompletableFuture<Integer> reduced = reduce(futList.stream(), () -> 0, Function.identity(), Integer::sum);
+        CompletableFuture<Integer> reduced = reduce(futList.stream(), completedFuture(0, exec), Function.identity(), Integer::sum);
         assertEquals(6, reduced.get().intValue());
     }
 
@@ -110,7 +113,7 @@ public class CompletableFutureUtilsTest {
         var inner = VF.list(VF.integer(1), VF.integer(2), VF.integer(3));
         var outer = List.of(CompletableFuture.completedFuture(inner), CompletableFuture.completedFuture(inner));
 
-        CompletableFuture<IList> reduced = flatten(outer.stream(), VF::list, IList::concat);
+        CompletableFuture<IList> reduced = flatten(outer.stream(), completedFuture(VF.list(), exec), IList::concat);
         assertEquals(VF.list(VF.integer(1), VF.integer(2), VF.integer(3), VF.integer(1), VF.integer(2), VF.integer(3)), reduced.get());
     }
 


### PR DESCRIPTION
When composing/combining futures that execute on different thread pools, it is not always clear on which thread pool the resulting future will be executed. Therefore, reduction of futures should receive an identity future.