### PR TITLE
Set language for all open editors.

### DIFF
--- a/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
@@ -99,12 +99,12 @@ export class ParameterizedLanguageServer implements vscode.Disposable {
         await (await client).sendRequest("rascal/sendRegisterLanguage", lang);
 
         if (this.dedicatedLanguage === undefined) {
-            for (const editor of vscode.window.visibleTextEditors) {
-                const ext = path.extname(editor.document.uri.path);
+            for (const doc of vscode.workspace.textDocuments) {
+                const ext = path.extname(doc.uri.path);
                 if (ext !== "" && lang.extensions.includes(ext.substring(1))) {
                     // (Re)set the language ID to re-trigger contribution requests
-                    await vscode.languages.setTextDocumentLanguage(editor.document, "plaintext");
-                    vscode.languages.setTextDocumentLanguage(editor.document, this.languageId);
+                    await vscode.languages.setTextDocumentLanguage(doc, "plaintext");
+                    await vscode.languages.setTextDocumentLanguage(doc, this.languageId);
                 }
             }
 


### PR DESCRIPTION
This PR fixes an issue where open (but inactive) editor tabs were not set to the 'Parametric' language.