### PR TITLE
Remove stale progress bars

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/EvaluatorUtil.java
@@ -114,6 +114,7 @@ public class EvaluatorUtil {
                 actualEval.jobStart(task);
                 synchronized (actualEval) {
                     boolean jobSuccess = false;
+                    boolean endedAll = false;
                     try {
                         runningEvaluator.set(actualEval);
                         if (interrupted.get()) {
@@ -126,9 +127,10 @@ public class EvaluatorUtil {
                         // Since the interrupt is not caught by try-catch in Rascal, any jobs started from Rascal with the same name as this task will be 'nested', and might lead to stale progress bars.
                         // Here, we remove all (nested) jobs.
                         actualEval.endAllJobs();
+                        endedAll = true;
                         return interruptedResult;
                     } finally {
-                        if (jobSuccess) {
+                        if (jobSuccess || !endedAll) {
                             actualEval.jobEnd(task, jobSuccess);
                         }
                         if (monitor instanceof RascalLSPMonitor) {


### PR DESCRIPTION
This PR makes sure jobs are always ended, even when interrupted at a very early stage. 

Fixes #912.