### PR TITLE
Always use ISourceLocation for Rascal locations

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -690,6 +690,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     private TextDocumentState getFile(ISourceLocation loc) {
+        loc = loc.top();
         TextDocumentState file = files.get(loc);
         if (file == null) {
             throw new ResponseErrorException(unknownFileError(loc, loc));
@@ -975,6 +976,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     private void updateFileState(LanguageParameter lang, ISourceLocation f) {
+        f = f.top();
         logger.trace("File of language {} - updating state: {}", lang.getName(), f);
         // Since we cannot know what happened to this file before we were called, we need to be careful about races.
         // It might have been closed in the meantime, so we compute the new value if the key still exists, based on the current value.

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricSummary.java
@@ -34,8 +34,8 @@ import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.Diagnostic;
@@ -44,6 +44,7 @@ import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.parametric.ILanguageContributions;
@@ -56,7 +57,6 @@ import org.rascalmpl.vscode.lsp.util.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.Lazy;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
-import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.IRangeMap;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import org.rascalmpl.vscode.lsp.util.locations.impl.TreeMapLookup;
@@ -498,13 +498,13 @@ class OndemandSummaryFactory extends ParametricSummaryFactory {
                 return null;
             }
 
-            var pos = Locations.toRascalPosition(file, cursor, columns);
-            var focus = TreeSearch.computeFocusList(tree.get(), pos.getLine(), pos.getCharacter());
+            var pos = Locations.setRange(file, new Range(cursor, cursor), columns);
+            var focus = TreeSearch.computeFocusList(tree.get(), pos.getBeginLine(), pos.getBeginColumn());
 
             InterruptibleFuture<ISet> set = null;
 
             if (focus.isEmpty()) {
-                logger.trace("{}: could not find substree at line {} and offset {}", logName, pos.getLine(), pos.getCharacter());
+                logger.trace("{}: could not find substree at line {} and offset {}", logName, pos.getBeginLine(), pos.getBeginColumn());
                 set = InterruptibleFuture.completedFuture(IRascalValueFactory.getInstance().set(), exec);
             } else {
                 logger.trace("{}: looked up focus with length: {}, now calling dedicated function", logName, focus.length());

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -692,9 +692,8 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 .getCurrentTreeAsync(true)
                 .thenApply(Versioned::get)
                 .thenCompose((ITree tree) -> {
-                    var loc = Locations.toLoc(params.getTextDocument());
-                    var start = Locations.setPosition(loc, params.getRange().getStart(), columns);
-                    return computeCodeActions(start.getBeginLine(), start.getBeginColumn(), tree, availableFacts().getPathConfig(loc));
+                    var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getRange().getStart(), columns);
+                    return computeCodeActions(loc.getBeginLine(), loc.getBeginColumn(), tree, availableFacts().getPathConfig(loc));
                 })
                 .thenApply(IList::stream)
             , Stream::empty)

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -93,6 +93,7 @@ public class PathConfigs {
     }
 
     public PathConfig lookupConfig(ISourceLocation forFile) {
+        forFile = forFile.top();
         ISourceLocation projectRoot = translatedRoots.get(forFile);
         return currentPathConfigs.computeIfAbsent(projectRoot, this::buildPathConfig);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/SummaryBridge.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/SummaryBridge.java
@@ -35,10 +35,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.ValueFactoryFactory;
 import org.rascalmpl.vscode.lsp.util.Lazy;
-import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.IRangeMap;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import org.rascalmpl.vscode.lsp.util.locations.impl.TreeMapLookup;
@@ -80,7 +80,7 @@ public class SummaryBridge {
 
     public SummaryBridge(ISourceLocation self, IConstructor summary, ColumnMaps cm) {
         this.data = summary.asWithKeywordParameters();
-        definitions = Lazy.defer(() -> translateRelation(getKWFieldSet(data, "useDef"), self, v -> Locations.toLSPLocation((ISourceLocation)v, cm), cm));
+        definitions = Lazy.defer(() -> translateRelation(getKWFieldSet(data, "useDef"), self, v -> Locations.toLocation((ISourceLocation)v, cm), cm));
         typeNames = Lazy.defer(() -> translateMap(getKWFieldMap(data, "locationTypes"), self, v -> ((IString)v).getValue(), cm));
 
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Diagnostics.java
@@ -44,10 +44,10 @@ import org.eclipse.lsp4j.Range;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
 import org.rascalmpl.exceptions.Throw;
 import org.rascalmpl.parser.gtd.exception.ParseError;
+import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.ValueFactoryFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
-import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import io.usethesource.vallang.ICollection;
 import io.usethesource.vallang.IConstructor;
@@ -179,7 +179,7 @@ public class Diagnostics {
     }
 
     private static DiagnosticRelatedInformation related(ColumnMaps cm, ISourceLocation loc, String message) {
-        return new DiagnosticRelatedInformation(Locations.toLSPLocation(loc, cm), message);
+        return new DiagnosticRelatedInformation(Locations.toLocation(loc, cm), message);
     }
 
     private static void storeFixCommands(IConstructor d, Diagnostic result) {
@@ -220,7 +220,7 @@ public class Diagnostics {
                 ((IList) dKW.getParameter("causes")).stream()
                 .map(IConstructor.class::cast)
                 .map(c -> new DiagnosticRelatedInformation(
-                    Locations.toLSPLocation(getMessageLocation(c), otherFiles),
+                    Locations.toLocation(getMessageLocation(c), otherFiles),
                     getMessageString(c)))
                 .collect(Collectors.toList())
             );

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SelectionRanges.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/SelectionRanges.java
@@ -31,14 +31,12 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SelectionRange;
+import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
-import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.IList;
@@ -55,9 +53,9 @@ public class SelectionRanges {
      * @return A range with optional parent ranges, or an empty range when {@link ranges} is empty.
      * @throws IllegalArgumentException when the list of ranges contains anything else than source locations
      */
-    public static SelectionRange toSelectionRange(Position origin, IList ranges, ColumnMaps columns) {
+    public static SelectionRange toSelectionRange(ISourceLocation origin, IList ranges, ColumnMaps columns) {
         if (ranges.isEmpty()) {
-            return empty(origin);
+            return empty(origin, columns);
         }
 
         try {
@@ -65,7 +63,7 @@ public class SelectionRanges {
                 .map(ISourceLocation.class::cast)
                 .map(l -> Locations.toRange(l, columns))
                 .collect(Collectors.toList());
-            return toSelectionRange(origin, lspRanges);
+            return toSelectionRange(origin, lspRanges, columns);
         } catch (ClassCastException e) {
             throw new IllegalArgumentException("List of selection ranges should only contain source locations", e);
         }
@@ -76,9 +74,9 @@ public class SelectionRanges {
      * @param ranges The range hierarchy. Should be ordered child-before-parent, where any range is contained by the next.
      * @return A range with optional parent ranges
      */
-    public static SelectionRange toSelectionRange(Position origin, List<Range> ranges) {
+    public static SelectionRange toSelectionRange(ISourceLocation origin, List<Range> ranges, ColumnMaps columns) {
         if (ranges.isEmpty()) {
-            return empty(origin);
+            return empty(origin, columns);
         }
 
         // assumes child-before-parent ordering
@@ -126,7 +124,7 @@ public class SelectionRanges {
             .collect(IRascalValueFactory.getInstance().listWriter());
     }
 
-    public static SelectionRange empty(Position p) {
-        return new SelectionRange(new Range(p, p), null);
+    public static SelectionRange empty(ISourceLocation loc, ColumnMaps columns) {
+        return new SelectionRange(Locations.toRange(loc, columns), null);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -29,6 +29,7 @@ package org.rascalmpl.vscode.lsp.util.locations;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.Location;
@@ -105,17 +106,6 @@ public class Locations {
      */
     public static ISourceLocation toLoc(TextDocumentIdentifier doc, Range range, ColumnMaps columns) {
         return setRange(toLoc(doc.getUri()), range, columns);
-    }
-
-    /**
-     * This fixes line offset off-by-one and column offsets character widths.
-     * Mapping them from the LSP standard to the Rascal standard.
-     */
-    private static Position toPosition(ISourceLocation doc, Position pos, ColumnMaps columns) {
-        return new Position(
-            pos.getLine() + 1,
-            columns.get(doc).translateInverseColumn(pos.getLine(), pos.getCharacter(), false)
-        );
     }
 
     /**
@@ -230,10 +220,17 @@ public class Locations {
         return VF.sourceLocation(loc,
             offsetLength.getLeft(),
             offsetLength.getRight(),
-            rascalStart.getLine(),
-            rascalEnd.getLine(),
-            rascalStart.getCharacter(),
-            rascalEnd.getCharacter()
+            rascalStart.getLeft(),
+            rascalEnd.getLeft(),
+            rascalStart.getRight(),
+            rascalEnd.getRight()
+        );
+    }
+
+    private static Pair<Integer, Integer> toPosition(ISourceLocation doc, Position pos, ColumnMaps columns) {
+        return Pair.of(
+            pos.getLine() + 1,
+            columns.get(doc).translateInverseColumn(pos.getLine(), pos.getCharacter(), false)
         );
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -99,6 +99,10 @@ public class Locations {
         return toLoc(doc, new Range(pos, pos), columns);
     }
 
+    /**
+     * This fixes line offset off-by-one and column offsets character widths.
+     * Mapping them from the LSP standard to the Rascal standard.
+     */
     public static ISourceLocation toLoc(TextDocumentIdentifier doc, Range range, ColumnMaps columns) {
         return setRange(toLoc(doc.getUri()), range, columns);
     }
@@ -206,14 +210,20 @@ public class Locations {
         }
     }
 
+    /**
+     * Converts and sets the position information on a Rascal location.
+     */
     public static ISourceLocation setPosition(ISourceLocation loc, Position pos, ColumnMaps columns) {
         return setRange(loc, new Range(pos, pos), columns);
     }
 
-    public static ISourceLocation setRange(ISourceLocation loc, Range lspRange, ColumnMaps columns) {
+    /**
+     * Converts and sets the position information on a Rascal location.
+     */
+    public static ISourceLocation setRange(ISourceLocation loc, Range range, ColumnMaps columns) {
         var map = columns.get(loc);
-        final var lspStart = lspRange.getStart();
-        final var lspEnd = lspRange.getEnd();
+        final var lspStart = range.getStart();
+        final var lspEnd = range.getEnd();
         final var offsetLength = map.calculateInverseOffsetLength(lspStart.getLine(), lspStart.getCharacter(), lspEnd.getLine(), lspEnd.getCharacter());
         final var rascalStart = toPosition(loc, lspStart, columns);
         final var rascalEnd = toPosition(loc, lspEnd, columns);
@@ -227,14 +237,26 @@ public class Locations {
         );
     }
 
+    /**
+     * This fixes line offset off-by-one and column offsets character widths.
+     * Mapping them from the Rascal standard to the LSP standard.
+     */
     public static Position toPosition(ISourceLocation loc, ColumnMaps cm) {
         return toPosition(loc, cm, false);
     }
 
+    /**
+     * This fixes line offset off-by-one and column offsets character widths.
+     * Mapping them from the Rascal standard to the LSP standard.
+     */
     public static Position toPosition(ISourceLocation loc, ColumnMaps cm, boolean atEnd) {
         return toPosition(loc, cm.get(loc), atEnd);
     }
 
+    /**
+     * This fixes line offset off-by-one and column offsets character widths.
+     * Mapping them from the Rascal standard to the LSP standard.
+     */
     public static Position toPosition(ISourceLocation loc, LineColumnOffsetMap map, boolean atEnd) {
         var line = atEnd ? loc.getEndLine() : loc.getBeginLine();
         var column = atEnd? loc.getEndColumn() : loc.getBeginColumn();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -95,35 +95,19 @@ public class Locations {
      * This fixes line offset off-by-one and column offsets character widths.
      * Mapping them from the LSP standard to the Rascal standard.
      */
-    public static Range toRascalRange(TextDocumentIdentifier doc, Range range, ColumnMaps columns) {
-        return toRascalRange(toLoc(doc), range, columns);
+    public static ISourceLocation toLoc(TextDocumentIdentifier doc, Position pos, ColumnMaps columns) {
+        return toLoc(doc, new Range(pos, pos), columns);
+    }
+
+    public static ISourceLocation toLoc(TextDocumentIdentifier doc, Range range, ColumnMaps columns) {
+        return setRange(toLoc(doc.getUri()), range, columns);
     }
 
     /**
      * This fixes line offset off-by-one and column offsets character widths.
      * Mapping them from the LSP standard to the Rascal standard.
      */
-    public static Range toRascalRange(ISourceLocation loc, Range range, ColumnMaps columns) {
-        return new Range(
-            toRascalPosition(loc, range.getStart(), columns),
-            toRascalPosition(loc, range.getEnd(), columns)
-        );
-    }
-
-    /**
-     * This fixes line offset off-by-one and column offsets character widths.
-     * Mapping them from the LSP standard to the Rascal standard.
-     */
-    public static Position toRascalPosition(TextDocumentIdentifier doc, Position pos, ColumnMaps columns) {
-        var loc = toLoc(doc.getUri());
-        return toRascalPosition(loc, pos, columns);
-    }
-
-    /**
-     * This fixes line offset off-by-one and column offsets character widths.
-     * Mapping them from the LSP standard to the Rascal standard.
-     */
-    public static Position toRascalPosition(ISourceLocation doc, Position pos, ColumnMaps columns) {
+    private static Position toPosition(ISourceLocation doc, Position pos, ColumnMaps columns) {
         return new Position(
             pos.getLine() + 1,
             columns.get(doc).translateInverseColumn(pos.getLine(), pos.getCharacter(), false)
@@ -193,16 +177,16 @@ public class Locations {
 
     public static Location mapValueToLocation(IValue v, ColumnMaps cm) {
         if (v instanceof ISourceLocation) {
-            return Locations.toLSPLocation((ISourceLocation)v, cm);
+            return Locations.toLocation((ISourceLocation)v, cm);
         }
         throw new RuntimeException(v + "is not a ISourceLocation");
     }
 
-    public static Location toLSPLocation(ISourceLocation sloc, ColumnMaps cm) {
+    public static Location toLocation(ISourceLocation sloc, ColumnMaps cm) {
         return new Location(Locations.toUri(sloc).toString(), toRange(sloc, cm));
     }
 
-    public static Location toLSPLocation(ISourceLocation sloc, LineColumnOffsetMap map) {
+    public static Location toLocation(ISourceLocation sloc, LineColumnOffsetMap map) {
         return new Location(Locations.toUri(sloc).toString(), toRange(sloc, map));
     }
 
@@ -222,13 +206,17 @@ public class Locations {
         }
     }
 
+    public static ISourceLocation setPosition(ISourceLocation loc, Position pos, ColumnMaps columns) {
+        return setRange(loc, new Range(pos, pos), columns);
+    }
+
     public static ISourceLocation setRange(ISourceLocation loc, Range lspRange, ColumnMaps columns) {
         var map = columns.get(loc);
         final var lspStart = lspRange.getStart();
         final var lspEnd = lspRange.getEnd();
         final var offsetLength = map.calculateInverseOffsetLength(lspStart.getLine(), lspStart.getCharacter(), lspEnd.getLine(), lspEnd.getCharacter());
-        final var rascalStart = toRascalPosition(loc, lspStart, columns);
-        final var rascalEnd = toRascalPosition(loc, lspEnd, columns);
+        final var rascalStart = toPosition(loc, lspStart, columns);
+        final var rascalEnd = toPosition(loc, lspEnd, columns);
         return VF.sourceLocation(loc,
             offsetLength.getLeft(),
             offsetLength.getRight(),


### PR DESCRIPTION
The mapping from LSP locations (lines 0-based, UTF-16 columns) to and from Rascal locations (lines 1-based, UTF-32 columns) often causes confusion (and comes up during reviews, e.g. here https://github.com/usethesource/rascal-language-servers/pull/706#discussion_r2610054330). This is not at all improved by the reuse of LSP4J's `Range` and `Position` types for some Rascal locations. This PR
1. Gets rid of this reuse and mandates the use of `ISourceLocation` for any kind of Rascal location.
2. Aligns the names of functions in `Locations` by removing the last references to `LSP` from them, since now, the types speak for themselves.