### PR TITLE
Change name and signature of util to align with implementation and use

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/CodeActions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/CodeActions.java
@@ -83,7 +83,7 @@ public class CodeActions {
             .map(actionParser);
 
         return CompletableFutureUtils
-            .flatten(actions, CompletableFutureUtils.completedFuture(IRascalValueFactory.getInstance().list(), exec), IList::concat)
+            .reduce(actions, CompletableFutureUtils.completedFuture(IRascalValueFactory.getInstance().list(), exec), IList::concat)
             .thenApply(IList::stream);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
@@ -72,14 +72,14 @@ public class CompletableFutureUtils {
     }
 
     /**
-     * Flattens a {@link Stream} of {@link CompletableFuture} that produces values of type {@link Iterable} to a single future that produces an {@link Iterable}.
+     * Flattens a {@link Stream} of {@link CompletableFuture} that produces values of type {@link I} to a single future that produces an {@link I}.
      * @param <I> The type of the result of the futures.
-     * @param futures The futures of which to reduce the result lists.
+     * @param futures A {@link Stream} of futures to reduce.
      * @param identity The identity function of {@link I}.
      * @param concat A function that merges two values of {@link I}.
-     * @return A future that yields a list of all the elements in the lists from the reduced futures.
+     * @return A single future that, if it completes, yields the reduced result.
      */
-    public static <I extends Iterable<?>> CompletableFuture<I> flatten(Stream<CompletableFuture<I>> futures, CompletableFuture<I> identity, BinaryOperator<I> concat) {
+    public static <I> CompletableFuture<I> reduce(Stream<CompletableFuture<I>> futures, CompletableFuture<I> identity, BinaryOperator<I> concat) {
         return reduce(futures,
             identity,
             Function.identity(),

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/CompletableFutureUtilsTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/CompletableFutureUtilsTest.java
@@ -28,7 +28,6 @@ package engineering.swat.rascal.lsp.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils.completedFuture;
-import static org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils.flatten;
 import static org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils.reduce;
 
 import java.util.Arrays;
@@ -113,7 +112,7 @@ public class CompletableFutureUtilsTest {
         var inner = VF.list(VF.integer(1), VF.integer(2), VF.integer(3));
         var outer = List.of(CompletableFuture.completedFuture(inner), CompletableFuture.completedFuture(inner));
 
-        CompletableFuture<IList> reduced = flatten(outer.stream(), completedFuture(VF.list(), exec), IList::concat);
+        CompletableFuture<IList> reduced = reduce(outer.stream(), completedFuture(VF.list(), exec), IList::concat);
         assertEquals(VF.list(VF.integer(1), VF.integer(2), VF.integer(3), VF.integer(1), VF.integer(2), VF.integer(3)), reduced.get());
     }
 


### PR DESCRIPTION
Changes the name and type restrictions of `CompletableFutureUtils::flatten` to match other function in that library and align with its use.