### PR TITLE
Infer project root correctly from within target folder

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -251,7 +251,7 @@ public class PathConfigs {
         ISourceLocation root = lastRoot;
         do {
             root = lastRoot;
-            lastRoot = inferLongestProjectRoot(URIUtil.getParentLocation(root));
+            lastRoot = inferDeepestProjectRoot(URIUtil.getParentLocation(root));
         } while (!lastRoot.equals(URIUtil.getParentLocation(root)));
         return root;
     }
@@ -259,7 +259,7 @@ public class PathConfigs {
     /**
      * Infers the longest project root-like path that `member` is in. Might return a sub-directory of `target/`.
      */
-    private static ISourceLocation inferLongestProjectRoot(ISourceLocation member) {
+    private static ISourceLocation inferDeepestProjectRoot(ISourceLocation member) {
         ISourceLocation current = member;
         URIResolverRegistry reg = URIResolverRegistry.getInstance();
         if (!reg.isDirectory(current)) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -243,7 +243,23 @@ public class PathConfigs {
         }
     }
 
+    /**
+     * Infers the root of the project that `member` is in.
+     */
     private static ISourceLocation inferProjectRoot(ISourceLocation member) {
+        ISourceLocation lastRoot = member;
+        ISourceLocation root = lastRoot;
+        do {
+            root = lastRoot;
+            lastRoot = inferLongestProjectRoot(URIUtil.getParentLocation(root));
+        } while (!lastRoot.equals(URIUtil.getParentLocation(root)));
+        return root;
+    }
+
+    /**
+     * Infers the longest project root-like path that `member` is in. Might return a sub-directory of `target/`.
+     */
+    private static ISourceLocation inferLongestProjectRoot(ISourceLocation member) {
         ISourceLocation current = member;
         URIResolverRegistry reg = URIResolverRegistry.getInstance();
         if (!reg.isDirectory(current)) {
@@ -254,13 +270,13 @@ public class PathConfigs {
             if (reg.exists(URIUtil.getChildLocation(current, "META-INF/RASCAL.MF"))) {
                 return current;
             }
-
-            if (URIUtil.getParentLocation(current).equals(current)) {
+            var parent = URIUtil.getParentLocation(current);
+            if (parent.equals(current)) {
                 // we went all the way up to the root
                 return reg.isDirectory(member) ? member : URIUtil.getParentLocation(member);
             }
 
-            current = URIUtil.getParentLocation(current);
+            current = parent;
         }
 
         return current;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -248,7 +248,7 @@ public class PathConfigs {
      */
     private static ISourceLocation inferProjectRoot(ISourceLocation member) {
         ISourceLocation lastRoot = member;
-        ISourceLocation root = lastRoot;
+        ISourceLocation root;
         do {
             root = lastRoot;
             lastRoot = inferDeepestProjectRoot(URIUtil.getParentLocation(root));

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -207,7 +207,21 @@ loc targetToProject(loc l) {
 }
 
 @memo
+@synopsis{Infers the root of the project that `member` is in.}
 loc inferProjectRoot(loc member) {
+    parentRoot = member;
+    root = parentRoot;
+
+    do {
+        root = parentRoot;
+        parentRoot = inferLongestProjectRoot(root.parent);
+    } while (root.parent? && parentRoot != root.parent);
+    return root;
+}
+
+@synopsis{Infers the longest project root-like path that `member` is in.}
+@pitfalls{Might return a sub-directory of `target/`.}
+loc inferLongestProjectRoot(loc member) {
     current = targetToProject(member);
     if (!isDirectory(current)) {
         current = current.parent;

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/IDECheckerWrapper.rsc
@@ -214,14 +214,14 @@ loc inferProjectRoot(loc member) {
 
     do {
         root = parentRoot;
-        parentRoot = inferLongestProjectRoot(root.parent);
+        parentRoot = inferDeepestProjectRoot(root.parent);
     } while (root.parent? && parentRoot != root.parent);
     return root;
 }
 
 @synopsis{Infers the longest project root-like path that `member` is in.}
 @pitfalls{Might return a sub-directory of `target/`.}
-loc inferLongestProjectRoot(loc member) {
+loc inferDeepestProjectRoot(loc member) {
     current = targetToProject(member);
     if (!isDirectory(current)) {
         current = current.parent;


### PR DESCRIPTION
The project root for `bird/bird-core/target/classes` was computed as `bird/bird-core/target/classes` (since it contains *a copy of* `META-INF/RASCAL.MF`). This caused path configs to be computed from the wrong root, in turn causing type-checks to fail. An example of this is #948.

This PR fixes the root inference algorithm by computing roots until the shortest root path is found.

Closes #948.