### PR TITLE
Quick fix: hide `target` from search results

### DIFF
--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
@@ -34,7 +34,7 @@ import analysis::diff::edits::TextEdits;
 import ParseTree;
 import String;
 import lang::rascal::vis::ImportGraph;
-import util::Reflective;
+extend util::Reflective; // extend for private `vscodeSettingsFile`
 import util::IDEServices;
 import List;
 import IO;
@@ -46,6 +46,7 @@ The commands must be evaluated by ((evaluateRascalCommand))
 data Command
     = visualImportGraphCommand(PathConfig pcfg)
     | sortImportsAndExtends(Header h)
+    | excludeTargetFromSearch(PathConfig pcfg)
     ;
 
 @synopsis{Detects (on-demand) source actions to register with specific places near the current cursor}
@@ -64,6 +65,11 @@ list[CodeAction] rascalCodeActions(Focus focus, PathConfig pcfg=pathConfig()) {
         result += [action(command=visualImportGraphCommand(pcfg), title="Visualize project import graph")]
                +  [action(command=sortImportsAndExtends(h), title="Sort imports and extends")]
                ;
+    }
+
+    // Check if the settings already exist and exclude some folders
+    if (!exists(vscodeSettingsFile(pcfg.projectRoot)) || !contains(readFile(vscodeSettingsFile(pcfg.projectRoot)), "search.exclude")) {
+        result += [action(command=excludeTargetFromSearch(pcfg), title="Exclude target directory from search")];
     }
 
     return result;
@@ -153,4 +159,9 @@ value evaluateRascalCommand(sortImportsAndExtends(Header h)) {
 
     applyDocumentsEdits([changed(h@\loc.top, [replace(h.imports@\loc, newHeader)])]);
     return ("result":true);
+}
+
+value evaluateRascalCommand(excludeTargetFromSearch(PathConfig pcfg)) {
+    newRascalVsCodeSettings(pcfg.projectRoot);
+    return ("result": true);
 }

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
@@ -34,7 +34,7 @@ import analysis::diff::edits::TextEdits;
 import ParseTree;
 import String;
 import lang::rascal::vis::ImportGraph;
-extend util::Reflective; // extend for private `vscodeSettingsFile`
+import util::Reflective;
 import util::IDEServices;
 import List;
 import IO;
@@ -46,7 +46,6 @@ The commands must be evaluated by ((evaluateRascalCommand))
 data Command
     = visualImportGraphCommand(PathConfig pcfg)
     | sortImportsAndExtends(Header h)
-    | excludeTargetFromSearch(PathConfig pcfg)
     ;
 
 @synopsis{Detects (on-demand) source actions to register with specific places near the current cursor}
@@ -65,11 +64,6 @@ list[CodeAction] rascalCodeActions(Focus focus, PathConfig pcfg=pathConfig()) {
         result += [action(command=visualImportGraphCommand(pcfg), title="Visualize project import graph")]
                +  [action(command=sortImportsAndExtends(h), title="Sort imports and extends")]
                ;
-    }
-
-    // Check if the settings already exist and exclude some folders
-    if (!exists(vscodeSettingsFile(pcfg.projectRoot)) || !contains(readFile(vscodeSettingsFile(pcfg.projectRoot)), "search.exclude")) {
-        result += [action(command=excludeTargetFromSearch(pcfg), title="Exclude target directory from search")];
     }
 
     return result;
@@ -159,9 +153,4 @@ value evaluateRascalCommand(sortImportsAndExtends(Header h)) {
 
     applyDocumentsEdits([changed(h@\loc.top, [replace(h.imports@\loc, newHeader)])]);
     return ("result":true);
-}
-
-value evaluateRascalCommand(excludeTargetFromSearch(PathConfig pcfg)) {
-    newRascalVsCodeSettings(pcfg.projectRoot);
-    return ("result": true);
 }

--- a/rascal-vscode-extension/package-lock.json
+++ b/rascal-vscode-extension/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.13.1-head",
       "license": "BSD-2-Clause",
       "dependencies": {
+        "jsonc-parser": "^3.3.1",
         "tar": "7.x",
         "vscode-languageclient": "9.x",
         "yauzl": "3.x"
@@ -5070,7 +5071,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {

--- a/rascal-vscode-extension/package-lock.json
+++ b/rascal-vscode-extension/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.13.1-head",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "jsonc-parser": "^3.3.1",
         "tar": "7.x",
         "vscode-languageclient": "9.x",
         "yauzl": "3.x"
@@ -31,6 +30,7 @@
         "esbuild": "0.27.x",
         "eslint": "8.x",
         "eslint-plugin-editorconfig": "4.x",
+        "jsonc-parser": "3.x",
         "license-check-and-add": "4.x",
         "mocha": "11.x",
         "typescript": "5.x",
@@ -5071,6 +5071,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -296,7 +296,7 @@
   "scripts": {
     "lsp4j:package": "cp ../rascal-lsp/target/rascal-lsp*.jar assets/jars/rascal-lsp.jar && cp ../rascal-lsp/target/lib/*.jar assets/jars/",
     "vscode:prepublish": "npm run lsp4j:package && npm run package",
-    "esbuild-base": "npx esbuild ./src/extension.ts --bundle --packages=bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "npx esbuild ./src/extension.ts --bundle --packages=bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --main-fields=module,main",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "package": "npm run esbuild-base -- --minify",

--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/sponsors/usethesource/"
   },
   "dependencies": {
+    "jsonc-parser": "3.x",
     "tar": "7.x",
     "vscode-languageclient": "9.x",
     "yauzl": "3.x"

--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -27,10 +27,11 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { TestVirtualFileSystem } from './fs/TestVirtualFileSystem';
 import { RascalExtension } from './RascalExtension';
 import { RascalMFValidator } from './ux/RascalMFValidator';
 import { RascalProjectValidator } from './ux/RascalProjectValidator';
-import { TestVirtualFileSystem } from './fs/TestVirtualFileSystem';
+import { VsCodeSettingsFixer } from './ux/VsCodeSettingsFixer';
 
 const testDeployMode = (process.env['RASCAL_LSP_DEV_DEPLOY'] || "false") === "true";
 const deployMode = (process.env['RASCAL_LSP_DEV'] || "false") !== "true";
@@ -41,6 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
     const extension = new RascalExtension(context, jars, icon, deployMode);
     context.subscriptions.push(extension);
     context.subscriptions.push(new RascalMFValidator());
+    context.subscriptions.push(new VsCodeSettingsFixer());
     context.subscriptions.push(new RascalProjectValidator(extension.logger()));
     if (deployMode || testDeployMode) {
         context.subscriptions.push(new TestVirtualFileSystem(extension.logger()));

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -114,8 +114,7 @@ enum FixKind {
 
 export async function isRascalProject(projectRoot: vscode.Uri) {
     try {
-        const mfURI = buildMFChildPath(projectRoot);
-        await vscode.workspace.fs.stat(mfURI);
+        await vscode.workspace.fs.stat(buildMFChildPath(projectRoot));
         return true;
     }
     catch (_missingFile) {

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -44,13 +44,8 @@ export class RascalMFValidator implements vscode.Disposable {
         // any new project should be checked
         vscode.workspace.onDidChangeWorkspaceFolders(async ws => {
             for (const added of ws.added) {
-                try {
-                    const mfURI = buildMFChildPath(added.uri);
-                    await vscode.workspace.fs.stat(mfURI);
-                    this.verifyRascalMF(mfURI);
-                }
-                catch (_missingFile) {
-                    // most likely not a rascal project
+                if (await isRascalProject(added.uri)) {
+                    this.verifyRascalMF(added.uri);
                 }
             }
             for (const rem of ws.removed) {
@@ -115,6 +110,18 @@ enum FixKind {
     missingSpaceAfterSeparator,
     removeInvalidCharsProjectName
 
+}
+
+export async function isRascalProject(projectRoot: vscode.Uri) {
+    try {
+        const mfURI = buildMFChildPath(projectRoot);
+        await vscode.workspace.fs.stat(mfURI);
+        return true;
+    }
+    catch (_missingFile) {
+        // most likely not a rascal project
+        return false;
+    }
 }
 
 function checkMissingLastLine(mfBody: vscode.TextDocument, diagnostics: vscode.Diagnostic[]) {

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import * as JSON5 from 'json5';
+import * as jsonc from 'jsonc-parser';
 import { posix } from 'path';
 import * as vscode from 'vscode';
 
@@ -136,8 +136,8 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
                 // Empty file; insert full settings
                 d.code = FixKind.insertSettings;
             } else {
-                // Settings might have comments, trailing commas, etc., so we use JSON5.
-                const settings = JSON5.parse(contents);
+                // Settings might have comments, trailing commas, etc., so we use JSONC.
+                const settings = jsonc.parse(contents);
                 if (!(SEARCH_EXCLUDE_SETTING_KEY in settings)) {
                     d.code = FixKind.insertSearchExclude;
                 } else if (!("target" in settings[SEARCH_EXCLUDE_SETTING_KEY] || "/target/" in settings[SEARCH_EXCLUDE_SETTING_KEY])) {

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -112,8 +112,8 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
 
 }
 
-function projectRoot(uri: vscode.Uri): vscode.Uri | undefined {
-    while (!hasFile(uri, buildMFChildPath)) {
+async function projectRoot(uri: vscode.Uri): Promise<vscode.Uri | undefined> {
+    while (!await hasFile(uri, buildMFChildPath)) {
         const newUri = uri.with({ path: posix.dirname(uri.path) });
         if (newUri === uri) {
             return undefined;
@@ -168,7 +168,7 @@ class FixSettingsActions implements vscode.CodeActionProvider {
         for (const d of context.diagnostics) {
             switch (d.code) {
                 case FixKind.createSettings: {
-                    const root = projectRoot(document.uri);
+                    const root = await projectRoot(document.uri);
                     if (!root) {
                         break;
                     }

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -143,7 +143,6 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
             }
         } catch (e) {
             // The settings are not valid JSON, or something else we cannot recover from.
-            console.error(e);
         } finally {
             this.diagnostics.set(settingsFile, settingsDiagnostics);
         }

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+import * as fs from 'fs/promises';
+import { posix } from 'path';
+import * as vscode from 'vscode';
+
+const VSCODE_DIR = ".vscode";
+const SETTINGS_FILE = "settings.json";
+const SEARCH_EXCLUDE = `
+    "search.exclude": {
+        "/target/": true
+    },
+`;
+export class VsCodeSettingsFixer implements vscode.Disposable {
+
+    private readonly diagnostics: vscode.DiagnosticCollection;
+    private readonly disposables: vscode.Disposable[] = [];
+
+    constructor () {
+        this.diagnostics = vscode.languages.createDiagnosticCollection("VSCode workspace settings diagnostics");
+
+        vscode.workspace.onDidChangeWorkspaceFolders(async changes => {
+            // Clean up diagnostics when closing a project
+            for (const r of changes.removed) {
+                this.diagnostics.delete(buildSettingsPath(r.uri));
+            }
+            // Fix settings for newly opened projects
+            for (const a of changes.added) {
+                await this.fixWorkspaceSettings(a.uri);
+            }
+        });
+
+        const watcher = vscode.workspace.createFileSystemWatcher(posix.join("**", VSCODE_DIR, SETTINGS_FILE));
+        watcher.onDidChange(this.fixWorkspaceSettings, this, this.disposables);
+        watcher.onDidDelete(e => this.diagnostics.delete(e), this, this.disposables);
+
+        // Fix settings for currently open projects
+        for (const projectRoot of vscode.workspace.workspaceFolders || []) {
+            this.fixWorkspaceSettings(projectRoot.uri); // Note dangling promise
+        }
+
+        // Register code actions
+        this.disposables.push(vscode.languages.registerCodeActionsProvider({ pattern: posix.join("**", VSCODE_DIR, SETTINGS_FILE) }, new FixSettingsActions()));
+    }
+
+    private async fixWorkspaceSettings(projectRoot: vscode.Uri) {
+        const vsCodeDir = vscode.Uri.joinPath(projectRoot, VSCODE_DIR);
+        const settingsFile = vscode.Uri.joinPath(vsCodeDir, SETTINGS_FILE);
+
+        const settingsDoc = await vscode.workspace.openTextDocument(settingsFile);
+        const contents = settingsDoc.getText();
+        if (contents.trim().length === 0) {
+            await fs.writeFile(settingsFile.toString(), "{}");
+        }
+        try {
+            const settings = JSON.parse(contents);
+            if (!("search.exclude" in settings)) {
+                const d = new vscode.Diagnostic(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)), "Files in `target` appear in search results. Be careful; editing those files breaks the project build.", vscode.DiagnosticSeverity.Warning);
+                d.code = FixKind.insertSearchExclude;
+                this.diagnostics.set(settingsFile, [d]);
+            }
+        } catch { /* ignore errors */ }
+    }
+
+    dispose() {
+        this.disposables.forEach(d => d.dispose());
+    }
+
+}
+
+function buildSettingsPath(projectRoot: vscode.Uri) {
+    return vscode.Uri.joinPath(projectRoot, VSCODE_DIR, SETTINGS_FILE);
+}
+
+class FixSettingsActions implements vscode.CodeActionProvider {
+    provideCodeActions(document: vscode.TextDocument, _range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, _token: vscode.CancellationToken): vscode.ProviderResult<(vscode.CodeAction | vscode.Command)[]> {
+        const result: vscode.CodeAction[] = [];
+        for (const d of context.diagnostics) {
+            switch (d.code) {
+                case FixKind.insertSearchExclude: {
+                    const beginOfSettings = document.positionAt(document.getText().indexOf("{") + 1);
+                    const addSearchExclude = new vscode.CodeAction("Exclude `target` from search", vscode.CodeActionKind.QuickFix);
+                    addSearchExclude.diagnostics = [d];
+                    addSearchExclude.edit = new vscode.WorkspaceEdit();
+                    addSearchExclude.edit.insert(document.uri, beginOfSettings, SEARCH_EXCLUDE);
+                    result.push(addSearchExclude);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+}
+
+enum FixKind {
+    insertSearchExclude
+}

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -71,7 +71,7 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
             }
         });
 
-        const updateSettings = async f => this.fixSettings(await projectRoot(f));
+        const updateSettings = async (f: vscode.Uri) => this.fixSettings(await projectRoot(f));
         const watcher = vscode.workspace.createFileSystemWatcher(SETTINGS_GLOB);
         watcher.onDidCreate(updateSettings, this, this.disposables);
         watcher.onDidChange(updateSettings, this, this.disposables);

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -63,7 +63,8 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
             }
         });
 
-        const watcher = vscode.workspace.createFileSystemWatcher(posix.join("**", VSCODE_DIR, "*.json"));
+        const settingsGlob = posix.join("**", VSCODE_DIR, SETTINGS_FILE);
+        const watcher = vscode.workspace.createFileSystemWatcher(settingsGlob);
         watcher.onDidCreate(f => this.fixWorkspaceSettings(this.projectRootFromSettings(f)), this, this.disposables);
         watcher.onDidChange(f => this.fixWorkspaceSettings(this.projectRootFromSettings(f)), this, this.disposables);
         watcher.onDidDelete(this.clearFileDiagnostics, this, this.disposables);
@@ -75,11 +76,11 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
         }
 
         // Register code actions
-        this.disposables.push(vscode.languages.registerCodeActionsProvider({ pattern: posix.join("**", VSCODE_DIR, "**") }, new FixSettingsActions()));
+        this.disposables.push(vscode.languages.registerCodeActionsProvider({ pattern: settingsGlob }, new FixSettingsActions()));
     }
 
     private projectRootFromSettings(uri: vscode.Uri): vscode.Uri {
-        return vscode.Uri.joinPath(uri, "..", "..");
+        return uri.with({ path: posix.dirname(posix.dirname(uri.path)) });
     }
 
     private clearWorkspaceDiagnostics(uri: vscode.Uri) {

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -195,7 +195,7 @@ class FixSettingsActions implements vscode.CodeActionProvider {
 
     private fixTargetExclude(settingsDoc: vscode.TextDocument, diag: vscode.Diagnostic): vscode.CodeAction {
         const d = new vscode.CodeAction("Exclude target from search", vscode.CodeActionKind.QuickFix);
-        const edits = jsonc.modify(settingsDoc.getText(), ["search.exclude", "/target/"], true, {});
+        const edits = jsonc.modify(settingsDoc.getText(), [SEARCH_EXCLUDE_SETTING_KEY, "/target/"], true, {formattingOptions: {keepLines: true}});
         d.edit = new vscode.WorkspaceEdit();
         d.edit.set(settingsDoc.uri, this.convertEdits(settingsDoc, edits));
         d.diagnostics = [diag];


### PR DESCRIPTION
This adds a couple of aids to quickly build a useful `.vscode/settings.json`.

When no `search.exclude` entry exists in the settings, we offer a quick-fix for excluding the `target` folder from VS Code search results. 
<img width="976" height="458" alt="afbeelding" src="https://github.com/user-attachments/assets/929dea96-0ed5-44bb-b8f1-21bd44ad6531" />

Closes #941.