### PR TITLE
Improve performance of `didRenameFiles` refactorings

### DIFF
--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -78,7 +78,11 @@ str escapeReservedName(str name) = name in reservedNames ? forceEscapeSingleName
 str perName(str qname, str(str) f, str sep = "::") = intercalate(sep, [f(n) | n <- split(sep, qname)]);
 
 @memo{maximumSize(100), expireAfter(minutes=5)}
-str normalizeEscaping(str qname, str sep = "::") = perName(qname, str(str n) { return escapeMinusIdentifier(escapeReservedName(forceUnescapeNames(n))); }, sep = sep);
+str normalizeEscaping(str qname, str sep = "::") = perName(qname, normalizeSingleNameEscaping, sep = sep);
+
+// Order is important; unescape everything *first* before re-escaping where necessary
+@memo{maximumSize(100), expireAfter(minutes=5)}
+str normalizeSingleNameEscaping(str name) = escapeMinusIdentifier(escapeReservedName(forceUnescapeNames(name)));
 
 @memo list[Name] asNames(QualifiedName qn) = [n | Name n <- qn.names];
 

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -274,28 +274,3 @@ tuple[list[DocumentEdit], set[Message]] propagateModuleRenames(lrel[loc old, loc
 
     return <any(msg <- messages, msg is error) ? [] : toList(edits), messages>;
 }
-
-void benchmark(loc rascal = |home:///swat/projects/Rascal/rascal|) {
-    pcfg = pathConfig(
-        srcs = [
-            rascal + "src/org/rascalmpl/library"
-          , rascal + "src/org/rascalmpl/compiler"
-        ],
-        bin = rascal + "target/classes"
-    );
-
-    moves = [
-        <rascal + "src/org/rascalmpl/library/List.rsc", rascal + "src/org/rascalmpl/library/nested/List.rsc">,
-        <rascal + "src/org/rascalmpl/library/Set.rsc", rascal + "src/org/rascalmpl/library/nested/Set.rsc">,
-        <rascal + "src/org/rascalmpl/library/Map.rsc", rascal + "src/org/rascalmpl/library/nested/Map.rsc">,
-        <rascal + "src/org/rascalmpl/library/Relation.rsc", rascal + "src/org/rascalmpl/library/nested/Relation.rsc">,
-        <rascal + "src/org/rascalmpl/library/util/Math.rsc", rascal + "src/org/rascalmpl/library/nested/utility/Math.rsc">
-    ];
-
-    <edits, messages> = propagateModuleRenames(moves, {rascal}, PathConfig(loc _) { return pcfg; });
-    print("Messages: ");
-    iprintln(messages);
-
-    print("Edits: ");
-    println(size(edits));
-}

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -155,7 +155,7 @@ private Maybe[tuple[str, loc]] qualifiedPrefix(QualifiedName qn) {
     }
 
     // Normalize like in ((normalizeEscaping)) now that we're processing the individual names
-    return just(<intercalate("::", [escapeMinusIdentifier(escapeReservedName(forceUnescapeNames("<n>"))) | n <- prefixNames]), cover([n.src | n <- prefixNames])>);
+    return just(<intercalate("::", [normalizeSingleNameEscaping("<n>") | n <- prefixNames]), cover([n.src | n <- prefixNames])>);
 }
 
 private bool isReachable(PathConfig toProject, PathConfig fromProject) =
@@ -182,7 +182,7 @@ list[TextEdit] getChanges(loc f, PathConfig wsProject, lrel[str oldName, str new
     }
 
     str contents = readFile(f);
-    if (!any(str qName <- qualifiedNameChanges.oldName, str fName := qName[findLast(qName, ":") + 1..], contains(contents, fName))) {
+    if (!any(str qName <- qualifiedNameChanges.oldName, all(str name <- split("::", qName), contains(contents, normalizeSingleNameEscaping(name))))) {
         // Since the escaping in qualifiedNameChanges is already normalized, no need to do that here.
         // If the base of the module name (filename without extension) does not appear in the module, we have nothing to do there for sure.
         return [];

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -177,6 +177,10 @@ list[TextEdit] getChangesByContents(str contents, PathConfig wsProject, lrel[str
 }
 
 list[TextEdit] getChanges(loc f, PathConfig wsProject, lrel[str oldName, str newName, PathConfig pcfg] qualifiedNameChanges, void(Message) registerMessage) {
+    if ([] := qualifiedNameChanges) {
+        return [];
+    }
+
     str contents = readFile(f);
     if (!any(str qName <- qualifiedNameChanges.oldName, str fName := qName[findLast(qName, ":") + 1..], contains(contents, fName))) {
         // Since the escaping in qualifiedNameChanges is already normalized, no need to do that here.

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -274,3 +274,28 @@ tuple[list[DocumentEdit], set[Message]] propagateModuleRenames(lrel[loc old, loc
 
     return <any(msg <- messages, msg is error) ? [] : toList(edits), messages>;
 }
+
+void benchmark(loc rascal = |home:///swat/projects/Rascal/rascal|) {
+    pcfg = pathConfig(
+        srcs = [
+            rascal + "src/org/rascalmpl/library"
+          , rascal + "src/org/rascalmpl/compiler"
+        ],
+        bin = rascal + "target/classes"
+    );
+
+    moves = [
+        <rascal + "src/org/rascalmpl/library/List.rsc", rascal + "src/org/rascalmpl/library/nested/List.rsc">,
+        <rascal + "src/org/rascalmpl/library/Set.rsc", rascal + "src/org/rascalmpl/library/nested/Set.rsc">,
+        <rascal + "src/org/rascalmpl/library/Map.rsc", rascal + "src/org/rascalmpl/library/nested/Map.rsc">,
+        <rascal + "src/org/rascalmpl/library/Relation.rsc", rascal + "src/org/rascalmpl/library/nested/Relation.rsc">,
+        <rascal + "src/org/rascalmpl/library/util/Math.rsc", rascal + "src/org/rascalmpl/library/nested/utility/Math.rsc">
+    ];
+
+    <edits, messages> = propagateModuleRenames(moves, {rascal}, PathConfig(loc _) { return pcfg; });
+    print("Messages: ");
+    iprintln(messages);
+
+    print("Edits: ");
+    println(size(edits));
+}

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -136,7 +136,7 @@ void renameAdditionalUses(set[Define] _:{<_, moduleName, _, moduleId(), modDef, 
     // That's intended, since this function is only supposed to rename uses.
     if ({loc u, *_} := tm.useDef<0>) {
         for (/QualifiedName qn := r.getConfig().parseLoc(u.top), any(d <- tm.useDef[qn.src], d.top == modDef.top),
-            just(<qualPref, prefLoc>) := qualifiedPrefix(qn), moduleName == qualPref) {
+            just(<moduleName, prefLoc>) := qualifiedPrefix(qn)) {
             r.textEdit(replace(prefLoc, newName));
         }
     }

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -182,7 +182,7 @@ list[TextEdit] getChanges(loc f, PathConfig wsProject, lrel[str oldName, str new
     }
 
     str contents = readFile(f);
-    if (!any(str qName <- qualifiedNameChanges.oldName, all(str name <- split("::", qName), contains(contents, normalizeSingleNameEscaping(name))))) {
+    if (!any(str qName <- qualifiedNameChanges.oldName, str basename := normalizeSingleNameEscaping(qName[findLast(qName, ":") + 1..]), contains(contents, basename))) {
         // Since the escaping in qualifiedNameChanges is already normalized, no need to do that here.
         // If the base of the module name (filename without extension) does not appear in the module, we have nothing to do there for sure.
         return [];

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -58,7 +58,6 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
     modName = normalizeEscaping(defName);
     modNameTree = [QualifiedName] modName;
     newModName = normalizeEscaping(newName);
-    newModNameTree = [QualifiedName] newModName;
 
     modNameNumberOfNames = size(findAll(modName, "::")) + 1;
     newModNameNumberOfNames = size(findAll(newModName, "::")) + 1;
@@ -89,17 +88,17 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
                 case QualifiedName qn: {
                     // Import of redundantly escaped module name
                     qnSize = size(asNames(qn));
-                    if (qnSize == modNameNumberOfNames && modName == normalizeEscaping("<qn>")) {
+                    if (!markedUse && qnSize == modNameNumberOfNames && modName == normalizeEscaping("<qn>")) {
                         useFiles += f;
                         markedUse = true;
                     }
                     else if (qnSize == modNameNumberOfNames + 1 || qnSize == newModNameNumberOfNames + 1
                         , just(<qualPref, _>) := qualifiedPrefix(qn)) {
-                        if (qualPref == modName) {
+                        if (!markedUse && qualPref == modName) {
                             useFiles += f;
                             markedUse = true;
                         }
-                        else if (qualPref == newModName) {
+                        else if (!markedNew && qualPref == newModName) {
                             newFiles += f;
                             markedNew = true;
                         }

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -27,6 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 @bootstrapParser
 module lang::rascal::tests::rename::ProjectOnDisk
 
+import IO;
 import lang::rascal::lsp::refactor::Rename;
 import lang::rascal::tests::rename::TestUtils;
 import util::Reflective;
@@ -34,7 +35,7 @@ import lang::rascalcore::check::Checker;
 
 import analysis::diff::edits::TextEdits;
 
-Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) {
+Edits renameOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) {
     PathConfig pcfg;
     if (projectDir.file == "rascal") {
         pcfg = pathConfig(
@@ -56,4 +57,32 @@ Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 
     // extension for Rascal compiler
     pcfg = pcfg[resources = pcfg.bin];
     return getEdits(projectDir + file, {projectDir}, occurrence, oldName, newName, PathConfig(_) { return pcfg; });
+}
+
+Edits renameFilesOnDisk(loc rascalDir) {
+    pcfg = pathConfig(
+        srcs = [
+            rascalDir + "src/org/rascalmpl/library"
+          , rascalDir + "src/org/rascalmpl/compiler"
+        ],
+        bin = rascalDir + "target/classes"
+    );
+
+    moves = [
+        <rascalDir + "src/org/rascalmpl/library/List.rsc", rascalDir + "src/org/rascalmpl/library/nested/List.rsc">,
+        <rascalDir + "src/org/rascalmpl/library/Set.rsc", rascalDir + "src/org/rascalmpl/library/nested/Set.rsc">,
+        <rascalDir + "src/org/rascalmpl/library/Map.rsc", rascalDir + "src/org/rascalmpl/library/nested/Map.rsc">,
+        <rascalDir + "src/org/rascalmpl/library/Relation.rsc", rascalDir + "src/org/rascalmpl/library/nested/Relation.rsc">,
+        <rascalDir + "src/org/rascalmpl/library/util/Math.rsc", rascalDir + "src/org/rascalmpl/library/nested/utility/Math.rsc">
+    ];
+
+    <edits, messages> = rascalRenameModule(moves, {rascalDir}, PathConfig(loc _) { return pcfg; });
+
+    print("Messages: ");
+    iprintln(messages);
+
+    print("Edits: ");
+    println(size(edits));
+
+    return <edits, messages>;
 }


### PR DESCRIPTION
Improve performance of `didRenameFiles` callbacks.
1. Do not parse a file when the module basename does not appear in its contents.
2. Escape less often.
3. Reduce number of qualified name prefix computations and checks.

Especially when the number of files-to-be-renamed is a relatively small fraction of the repository, this makes a huge change.
 
- Rename only `util::Math`: from 65-75 to 15-20 seconds.
- Rename `List`, `Set`, `Map`, `Relation`, `util::Math`: from 65-75 to 50-55 seconds.

### Before optimizations

```
rascal>benchmark(("before optimizations": void() { renameFilesOnDisk(|home:///swat/projects/Rascal/rascal|); }))
Messages: {}
Edits: 40
FRAMES PROFILE: 131 data points, 48166 ticks, tick = 1 milliSecs
             Scope   Ticks        %  Source
        getChanges   36723    76.2%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(7456,871,<172,0>,<187,1>)
   qualifiedPrefix    6289    13.1%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6142,277,<146,0>,<151,1>)
 fullQualifiedName    4534     9.4%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6062,79,<145,0>,<145,79>)

ASTS PROFILE: 131 data points, 48166 ticks, tick = 1 milliSecs
                Scope   Ticks        %  Source
parseModuleWithSpaces   26166    54.3%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(7672,1,<174,48>,<174,49>)
           getChanges    5889    12.2%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(7912,7,<178,88>,<178,95>)
      qualifiedPrefix    2603     5.4%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6306,13,<148,39>,<148,52>)
           getChanges    2337     4.9%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(7747,1,<176,35>,<176,36>)
    fullQualifiedName    2241     4.7%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6133,2,<145,71>,<145,73>)
           getChanges    1957     4.1%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(7819,2,<177,70>,<177,72>)
      qualifiedPrefix    1189     2.5%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6246,1,<147,37>,<147,38>)
    fullQualifiedName     943     2.0%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6127,2,<145,65>,<145,67>)
      qualifiedPrefix     768     1.6%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6255,2,<147,46>,<147,48>)
      qualifiedPrefix     581     1.2%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6302,2,<148,35>,<148,37>)
    fullQualifiedName     576     1.2%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6062,79,<145,0>,<145,79>)
```

### After optimizations

```
rascal>benchmark(("after optimizations": void() { renameFilesOnDisk(|home:///swat/projects/Rascal/rascal|); }))
Messages: {}
Edits: 40
FRAMES PROFILE: 122 data points, 10399 ticks, tick = 1 milliSecs
                        Scope   Ticks        %  Source
                   getChanges    7277    70.0%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(7615,1596,<179,0>,<211,1>)
              qualifiedPrefix    1538    14.8%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6060,543,<146,0>,<159,1>)
            fullQualifiedName    1357    13.0%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(5961,98,<145,0>,<145,98>)
                         find     126     1.2%  |std:///util/FileSystem.rsc|(712,315,<23,0>,<29,7>)

ASTS PROFILE: 122 data points, 10399 ticks, tick = 1 milliSecs
                        Scope   Ticks        %  Source
        parseModuleWithSpaces    5086    48.9%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(8363,1,<191,48>,<191,49>)
                   getChanges     850     8.2%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(8696,7,<199,73>,<199,80>)
            fullQualifiedName     600     5.8%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6051,2,<145,90>,<145,92>)
                   getChanges     392     3.8%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(8436,1,<193,34>,<193,35>)
              qualifiedPrefix     391     3.8%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6360,9,<154,15>,<154,24>)
              qualifiedPrefix     311     3.0%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6135,2,<147,8>,<147,10>)
            fullQualifiedName     239     2.3%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6044,2,<145,83>,<145,85>)
                   getChanges     215     2.1%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(8480,2,<194,39>,<194,41>)
                   getChanges     199     1.9%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(8617,5,<198,33>,<198,38>)
              qualifiedPrefix     194     1.9%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6295,1,<152,26>,<152,27>)
              qualifiedPrefix     176     1.7%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6304,2,<152,35>,<152,37>)
            fullQualifiedName     172     1.7%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6046,2,<145,85>,<145,87>)
            fullQualifiedName     161     1.5%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(5961,98,<145,0>,<145,98>)
                   getChanges     160     1.5%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(8532,2,<195,46>,<195,48>)
            fullQualifiedName     159     1.5%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6042,6,<145,81>,<145,87>)
                     readFile     153     1.5%  |std:///IO.rsc|(19907,8,<576,84>,<576,92>)
              qualifiedPrefix     153     1.5%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6251,9,<149,15>,<149,24>)
              qualifiedPrefix     144     1.4%  |file:///C:/Users/toine/swat/projects/Rascal/rascal-language-servers/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc|(6060,543,<146,0>,<159,1>)
```

Closes #847.