### PR TITLE
Re-compute path config when it contains an error message.

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -68,7 +68,7 @@ public class PathConfigs {
     private static final long UPDATE_DELAY = TimeUnit.SECONDS.toNanos(5);
 
     private static final URIResolverRegistry reg = URIResolverRegistry.getInstance();
-    private final Map<ISourceLocation, Pair<PathConfig, Long>> currentPathConfigs = new ConcurrentHashMap<>();
+    private final Map<ISourceLocation, Pair<PathConfig, Instant>> currentPathConfigs = new ConcurrentHashMap<>();
     private final PathConfigUpdater updater = new PathConfigUpdater(currentPathConfigs);
     private final LoadingCache<ISourceLocation, ISourceLocation> translatedRoots =
         Caffeine.newBuilder()
@@ -103,12 +103,12 @@ public class PathConfigs {
             .getKey();
     }
 
-    private static boolean shouldBeRecomputed(@Nullable Pair<PathConfig, Long> entry) {
+    private static boolean shouldBeRecomputed(@Nullable Pair<PathConfig, Instant> entry) {
         if (entry == null) {
             // No previously computed config
             return true;
         }
-        if (Instant.ofEpochMilli(entry.getRight()).plusSeconds(1).isAfter(Instant.now())) {
+        if (entry.getRight().plusSeconds(1).isAfter(Instant.now())) {
             // Previous config is less than a second old
             return false;
         }
@@ -128,7 +128,7 @@ public class PathConfigs {
         }
     }
 
-    private Pair<PathConfig, Long> buildPathConfig(ISourceLocation projectRoot) {
+    private Pair<PathConfig, Instant> buildPathConfig(ISourceLocation projectRoot) {
         try {
             logger.debug("Building path config for: {}", projectRoot);
             ISourceLocation manifest = URIUtil.getChildLocation(projectRoot, "META-INF/RASCAL.MF");
@@ -156,10 +156,10 @@ public class PathConfigs {
     }
 
     private class PathConfigUpdater {
-        private final Map<ISourceLocation, Pair<PathConfig, Long>> currentPathConfigs;
+        private final Map<ISourceLocation, Pair<PathConfig, Instant>> currentPathConfigs;
         private final Map<ISourceLocation, List<WatchRegistration>> projectWatches;
 
-        public PathConfigUpdater(Map<ISourceLocation, Pair<PathConfig, Long>> currentPathConfigs) {
+        public PathConfigUpdater(Map<ISourceLocation, Pair<PathConfig, Instant>> currentPathConfigs) {
             this.currentPathConfigs = currentPathConfigs;
             this.projectWatches = new ConcurrentHashMap<>();
         }
@@ -224,13 +224,13 @@ public class PathConfigs {
             }
         }
 
-        private Pair<PathConfig, Long> actualBuild(ISourceLocation projectRoot) {
+        private Pair<PathConfig, Instant> actualBuild(ISourceLocation projectRoot) {
             var time = Instant.now();
             var pathConfig = PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.COMPILER, true);
             logger.debug("Path config for {}: {}", projectRoot, pathConfig);
             // Publish diagnostics in a background thread
             executor.execute(() -> diagnostics.publishDiagnostics(projectRoot, pathConfig.getMessages()));
-            return Pair.of(pathConfig, time.toEpochMilli());
+            return Pair.of(pathConfig, time);
         }
 
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -42,8 +42,10 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.library.util.PathConfig.RascalConfigMode;
@@ -66,7 +68,7 @@ public class PathConfigs {
     private static final long UPDATE_DELAY = TimeUnit.SECONDS.toNanos(5);
 
     private static final URIResolverRegistry reg = URIResolverRegistry.getInstance();
-    private final Map<ISourceLocation, PathConfig> currentPathConfigs = new ConcurrentHashMap<>();
+    private final Map<ISourceLocation, Pair<PathConfig, Long>> currentPathConfigs = new ConcurrentHashMap<>();
     private final PathConfigUpdater updater = new PathConfigUpdater(currentPathConfigs);
     private final LoadingCache<ISourceLocation, ISourceLocation> translatedRoots =
         Caffeine.newBuilder()
@@ -96,11 +98,22 @@ public class PathConfigs {
     public PathConfig lookupConfig(ISourceLocation forFile) {
         forFile = forFile.top();
         ISourceLocation projectRoot = translatedRoots.get(forFile);
-        return currentPathConfigs.compute(projectRoot, (project, current) -> (current == null || hasErrors(current)) ? buildPathConfig(project) : current);
+        return currentPathConfigs
+            .compute(projectRoot, (project, current) -> shouldBeRecomputed(current) ? buildPathConfig(project) : current)
+            .getKey();
     }
 
-    private static boolean hasErrors(PathConfig pcfg) {
-        return pcfg.getMessages().stream()
+    private static boolean shouldBeRecomputed(@Nullable Pair<PathConfig, Long> entry) {
+        if (entry == null) {
+            // No previously computed config
+            return true;
+        }
+        if (Instant.ofEpochMilli(entry.getRight()).plusSeconds(1).isAfter(Instant.now())) {
+            // Previous config is less than a second old
+            return false;
+        }
+        // Previous config had errors
+        return entry.getLeft().getMessages().stream()
             .filter(IConstructor.class::isInstance)
             .map(IConstructor.class::cast)
             .anyMatch(e -> "error".equals(e.getName()));
@@ -115,9 +128,9 @@ public class PathConfigs {
         }
     }
 
-    private PathConfig buildPathConfig(ISourceLocation projectRoot) {
+    private Pair<PathConfig, Long> buildPathConfig(ISourceLocation projectRoot) {
         try {
-            logger.debug("Building pcfg from: {}", projectRoot);
+            logger.debug("Building path config for: {}", projectRoot);
             ISourceLocation manifest = URIUtil.getChildLocation(projectRoot, "META-INF/RASCAL.MF");
             if (reg.exists(manifest)) {
                 updater.watchFile(projectRoot, manifest);
@@ -125,7 +138,6 @@ public class PathConfigs {
             registerMavenWatches(reg, projectRoot);
 
             var result = updater.actualBuild(projectRoot);
-            logger.debug("New path config: {}", result);
             return result;
         }
         catch (IOException e) {
@@ -144,10 +156,10 @@ public class PathConfigs {
     }
 
     private class PathConfigUpdater {
-        private final Map<ISourceLocation, PathConfig> currentPathConfigs;
+        private final Map<ISourceLocation, Pair<PathConfig, Long>> currentPathConfigs;
         private final Map<ISourceLocation, List<WatchRegistration>> projectWatches;
 
-        public PathConfigUpdater(Map<ISourceLocation, PathConfig> currentPathConfigs) {
+        public PathConfigUpdater(Map<ISourceLocation, Pair<PathConfig, Long>> currentPathConfigs) {
             this.currentPathConfigs = currentPathConfigs;
             this.projectWatches = new ConcurrentHashMap<>();
         }
@@ -212,11 +224,13 @@ public class PathConfigs {
             }
         }
 
-        private PathConfig actualBuild(ISourceLocation projectRoot) {
+        private Pair<PathConfig, Long> actualBuild(ISourceLocation projectRoot) {
+            var time = Instant.now();
             var pathConfig = PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.COMPILER, true);
+            logger.debug("Path config for {}: {}", projectRoot, pathConfig);
             // Publish diagnostics in a background thread
             executor.execute(() -> diagnostics.publishDiagnostics(projectRoot, pathConfig.getMessages()));
-            return pathConfig;
+            return Pair.of(pathConfig, time.toEpochMilli());
         }
 
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -54,6 +54,7 @@ import org.rascalmpl.uri.URIUtil;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.ISourceLocation;
 
 /**
@@ -95,7 +96,14 @@ public class PathConfigs {
     public PathConfig lookupConfig(ISourceLocation forFile) {
         forFile = forFile.top();
         ISourceLocation projectRoot = translatedRoots.get(forFile);
-        return currentPathConfigs.computeIfAbsent(projectRoot, this::buildPathConfig);
+        return currentPathConfigs.compute(projectRoot, (project, current) -> (current == null || hasErrors(current)) ? buildPathConfig(project) : current);
+    }
+
+    private static boolean hasErrors(PathConfig pcfg) {
+        return pcfg.getMessages().stream()
+            .filter(IConstructor.class::isInstance)
+            .map(IConstructor.class::cast)
+            .anyMatch(e -> "error".equals(e.getName()));
     }
 
     private static long safeLastModified(ISourceLocation uri) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -98,9 +98,12 @@ public class PathConfigs {
     public PathConfig lookupConfig(ISourceLocation forFile) {
         forFile = forFile.top();
         ISourceLocation projectRoot = translatedRoots.get(forFile);
-        return currentPathConfigs
-            .compute(projectRoot, (project, current) -> shouldBeRecomputed(current) ? buildPathConfig(project) : current)
-            .getKey();
+        var entry = currentPathConfigs.compute(projectRoot, (project, current) -> shouldBeRecomputed(current) ? buildPathConfig(project) : current);
+        if (entry == null) {
+            // This can only happen when the `compute` function throws an exception
+            throw new RuntimeException(String.format("Path config computation for %s failed", projectRoot));
+        }
+        return entry.getKey();
     }
 
     private static boolean shouldBeRecomputed(@Nullable Pair<PathConfig, Instant> entry) {


### PR DESCRIPTION
Re-compute a path config when the previously computed cached config contains errors, to see if the causes of these errors have been resolved externally.

Closes #979