### PR TITLE
Fix many static warnings in rename code

### DIFF
--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -359,13 +359,13 @@ set[&T] flatMapPerFile(set[&U] us, set[&T](loc, set[&U]) func, rel[&U, loc] locO
 set[&T] flatMapPerFile(set[Define] defs, set[&T](loc, set[Define]) func) =
     flatMapPerFile(defs, func, {<d, d.defined> | d <- defs});
 
-default void renameAdditionalUses(set[Define] defs, str newName, TModel tm, Renamer r) {}
+default void renameAdditionalUses(set[Define] _defs, str _newName, TModel _tm, Renamer _r) {}
 
 @synopsis{Decide if a cursor is supported based on focus list only.}
-default bool isUnsupportedCursor(list[Tree] cursor, Renamer _) = false;
+default bool isUnsupportedCursor(list[Tree] _cursor, Renamer _r) = false;
 
 @synopsis{Decide whether a cursor is supported based on type information.}
-default bool isUnsupportedCursor(list[Tree] cursor, TModel tm, Renamer _) = false;
+default bool isUnsupportedCursor(list[Tree] _cursor, TModel _tm, Renamer _r) = false;
 
-@synopsis{Decide whether a cusro is supported based on resolved definitions.}
-default bool isUnsupportedCursor(list[Tree] cursor, set[Define] cursorDefs, TModel tm, Renamer _) = false;
+@synopsis{Decide whether a cursor is supported based on resolved definitions.}
+default bool isUnsupportedCursor(list[Tree] _cursor, set[Define] _cursorDefs, TModel _tm, Renamer _r) = false;

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Common.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Common.rsc
@@ -53,8 +53,8 @@ import util::Util;
 
 data RenameConfig(
     set[loc] workspaceFolders = {}
-  , PathConfig(loc) getPathConfig = PathConfig(loc l) { throw "No path config for <l>"; }
-  , TModel(loc, Renamer) augmentedTModelForLoc = TModel(loc l, Renamer r) { throw "Not implemented."; }
+  , PathConfig(loc) getPathConfig = PathConfig(loc l) { throw "Path config for <l> not implemented"; }
+  , TModel(loc, Renamer) augmentedTModelForLoc = TModel(loc _, Renamer _) { throw "Not implemented."; }
 );
 
 bool isContainedInScope(loc l, loc scope, TModel tm) {

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -34,7 +34,9 @@ import analysis::typepal::TModel;
 import analysis::diff::edits::TextEdits;
 import lang::rascal::lsp::refactor::Rename;
 import lang::rascal::lsp::refactor::rename::Common;
+
 import lang::rascalcore::check::BasicRascalConfig;
+import lang::rascalcore::check::ModuleLocations;
 
 import IO;
 import List;
@@ -63,8 +65,8 @@ tuple[set[loc], set[loc], set[loc]] findOccurrenceFilesUnchecked(set[Define] _:{
     newModNameNumberOfNames = size(findAll(newModName, "::")) + 1;
 
     try {
-        loc oldLoc = getModuleLocation(modName, r.getConfig().getPathConfig(d.top));
-        loc newLoc = getModuleLocation(newModName, r.getConfig().getPathConfig(d.top));
+        loc oldLoc = getRascalModuleLocation(modName, r.getConfig().getPathConfig(d.top));
+        loc newLoc = getRascalModuleLocation(newModName, r.getConfig().getPathConfig(d.top));
         if (oldLoc != newLoc) {
             r.msg(error(d, "Cannot rename, since module \'<newModName>\' already exists at <newLoc>"));
             return <{}, {}, {}>;

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/Modules.rsc
@@ -175,7 +175,7 @@ test bool moduleExists() = testRenameOccurrences({
 test bool moduleRenameWithoutExtension()
     = testProject({byText("Foo", "", {})},
         "moduleRenameWithoutExtension",
-        bool({TestModule foo}, loc testDir, PathConfig pcfg) {
+        bool({TestModule foo}, loc _testDir, PathConfig pcfg) {
             loc oldLoc = foo.file;
             loc newLoc = |<oldLoc.scheme>:///<oldLoc.path[..-4]>|; // remove .rsc extension
 
@@ -192,7 +192,7 @@ test bool moduleRenameWithoutExtension()
 test bool moduleRenameOutsideSources()
     = testProject({byText("Foo", "", {})},
         "moduleRenameOutsideSources",
-        bool({TestModule foo}, loc testDir, PathConfig pcfg) {
+        bool({TestModule foo}, loc _testDir, PathConfig pcfg) {
             loc oldLoc = foo.file;
             loc newLoc = |<oldLoc.scheme>:///<oldLoc.parent.parent.path>/<oldLoc.file>|;
 

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/ProjectOnDisk.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/ProjectOnDisk.rsc
@@ -35,7 +35,7 @@ import lang::rascalcore::check::Checker;
 import analysis::diff::edits::TextEdits;
 
 Edits testProjectOnDisk(loc projectDir, str file, str oldName, int occurrence = 0, str newName = "<oldName>_new", list[str] srcDirs = ["src/main/rascal"], list[loc] libs = []) {
-    PathConfig pcfg;
+    PathConfig pcfg = pathConfig();
     if (projectDir.file == "rascal") {
         pcfg = pathConfig(
             srcs = [ projectDir + "src/org/rascalmpl/library"

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/TestUtils.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/tests/rename/TestUtils.rsc
@@ -89,7 +89,7 @@ void verifyTypeCorrectRenaming(loc root, list[DocumentEdit] edits, PathConfig pc
     remove(backupLoc, recursive = true);
     copy(root, backupLoc, recursive = true);
 
-    executeDocumentEdits(sortEdits(groupEditsByFile(edits)));
+    executeFileSystemChanges(sortEdits(groupEditsByFile(edits)));
     remove(pcfg.bin, recursive = true);
 
     list[ModuleMessages] checkAfter = checkAll(root, ccfg);
@@ -158,7 +158,7 @@ bool moveRenameTest(set[TestModule] modules, set[tuple[tuple[int, int], tuple[in
     testDir = |memory:///tests/move|;
     remove(testDir);
     pcfg = getTestPathConfig(testDir);
-    getPathConfig = PathConfig(loc l) {
+    getPathConfig = PathConfig(loc _) {
         return pcfg;
     };
 
@@ -174,7 +174,7 @@ bool moveRenameTest(set[TestModule] modules, set[tuple[tuple[int, int], tuple[in
         writeFile(p, "module <name>\n<body>");
     }
 
-    renames = [<old, new> | <m, new> <- modsAndPaths, srcDir := relativize(pcfg.srcs, new), old := srcsFile(replaceAll(m.name, "\\", ""), pcfg, RASCAL_CONF, force=true)];
+    renames = [<old, new> | <m, new> <- modsAndPaths, old := srcsFile(replaceAll(m.name, "\\", ""), pcfg, RASCAL_CONF, force=true)];
 
     edits = rascalRenameModule(renames, toSet(pcfg.srcs), getPathConfig);
 


### PR DESCRIPTION
This PR fixes many static warnings in the rename code, as detected by https://github.com/usethesource/rascal-core-big-tests/actions/runs/22363577181/job/64723442268#step:8:9316