### PR TITLE
Upload VSIX without archiving

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,6 +190,7 @@ jobs:
         with:
           path: rascal-vscode-extension/*.vsix
           retention-days: 20
+          archive: false
 
       - name: Publish release to Open VSX Registry
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/

h/t/ @DavyLandman 