### PR TITLE
Fix: no file operation notifications for directories

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/FileOperationCapability.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/FileOperationCapability.java
@@ -76,9 +76,15 @@ public abstract class FileOperationCapability extends AbstractDynamicCapability<
 
     @Override
     protected final CompletableFuture<@Nullable FileOperationOptions> options(ICapabilityParams params) {
-        return CompletableFutureUtils.completedFuture(new FileOperationOptions(params.fileExtensions().stream()
+        var patterns = params.fileExtensions().stream()
             .map(FileOperationCapability::extensionFilter)
-            .collect(Collectors.toList())), exec);
+            .collect(Collectors.toList());
+
+        var anyFolder = new FileOperationPattern("**/*");
+        anyFolder.setMatches(FileOperationPatternKind.Folder);
+        patterns.add(new FileOperationFilter(anyFolder));
+
+        return CompletableFutureUtils.completedFuture(new FileOperationOptions(patterns), exec);
     }
 
     /**

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -28,11 +28,14 @@ package org.rascalmpl.vscode.lsp.rascal;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.FileOperationFilter;
 import org.eclipse.lsp4j.FileOperationOptions;
 import org.eclipse.lsp4j.FileOperationPattern;
+import org.eclipse.lsp4j.FileOperationPatternKind;
 import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.FileOperationsWorkspaceCapabilities;
 import org.eclipse.lsp4j.ServerCapabilities;
@@ -43,8 +46,6 @@ import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.util.Nullables;
 
 public class RascalWorkspaceService extends BaseWorkspaceService {
-
-    private static final List<FileOperationFilter> fileFilters = List.of(new FileOperationFilter(new FileOperationPattern("**/*.rsc")));
 
     RascalWorkspaceService(ExecutorService exec, IBaseTextDocumentService documentService) {
         super(exec, documentService);
@@ -59,7 +60,13 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
             capabilities.getWorkspace().setFileOperations(new FileOperationsServerCapabilities());
         }
         var fileOperationCapabilities = capabilities.getWorkspace().getFileOperations();
-        var whichFiles = new FileOperationOptions(fileFilters);
+
+        var rascalFile = new FileOperationPattern("**/*.rsc");
+        rascalFile.setMatches(FileOperationPatternKind.File);
+        var projectFolder = new FileOperationPattern("**/*");
+        projectFolder.setMatches(FileOperationPatternKind.Folder);
+        var whichFiles = new FileOperationOptions(Stream.of(rascalFile, projectFolder).map(FileOperationFilter::new).collect(Collectors.toList()));
+
         if (Nullables.has(clientCap.getWorkspace(), WorkspaceClientCapabilities::getFileOperations, FileOperationsWorkspaceCapabilities::getDidCreate)) {
             fileOperationCapabilities.setDidCreate(whichFiles);
         }


### PR DESCRIPTION
This fixes missing file operations for directories, both for Rascal and DSLs. Fixes #981.