### PR TITLE
Fix TModel race between type-checker and renaming

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -123,8 +123,8 @@ public class RascalLanguageServices {
         var context = new LSPContext(exec, docService, workspaceService, client);
 
         shortRunningTaskEvaluator = makeFutureEvaluator(context, "Rascal tasks", monitor, pcfg,  "lang::rascal::lsp::DocumentSymbols", "lang::rascal::lsp::Templates");
-        semanticEvaluator = makeFutureEvaluator(context, "Rascal semantics", monitor, compilerPcfg, "lang::rascalcore::check::Summary", "lang::rascal::lsp::refactor::Rename", "lang::rascal::lsp::Actions");
-        compilerEvaluator = makeFutureEvaluator(context, "Rascal compiler", monitor, compilerPcfg, "lang::rascal::lsp::IDECheckerWrapper");
+        semanticEvaluator = makeFutureEvaluator(context, "Rascal semantics", monitor, compilerPcfg, "lang::rascalcore::check::Summary", "lang::rascal::lsp::Actions");
+        compilerEvaluator = makeFutureEvaluator(context, "Rascal compiler", monitor, compilerPcfg, "lang::rascal::lsp::IDECheckerWrapper", "lang::rascal::lsp::refactor::Rename");
         actionStore = semanticEvaluator.thenApply(e -> ((ModuleEnvironment) e.getModule("lang::rascal::lsp::Actions")).getStore());
         rascalTextDocumentService = docService;
         this.workspaceService = workspaceService;
@@ -226,7 +226,7 @@ public class RascalLanguageServices {
 
 
     public InterruptibleFuture<ITuple> getRename(ISourceLocation cursorLoc, IList focus, Set<ISourceLocation> workspaceFolders, String newName) {
-        return runEvaluator("Rascal rename", semanticEvaluator, eval -> {
+        return runEvaluator("Rascal rename", compilerEvaluator, eval -> {
             try {
                 return (ITuple) eval.call("rascalRenameSymbol", cursorLoc, focus, VF.string(newName), workspaceFolders.stream().collect(VF.setWriter()), makePathConfigGetter(eval));
             } catch (Throw e) {
@@ -256,7 +256,7 @@ public class RascalLanguageServices {
             return InterruptibleFuture.completedFuture(emptyResult, exec);
         }
 
-        return runEvaluator("Rascal module rename", semanticEvaluator, eval ->
+        return runEvaluator("Rascal module rename", compilerEvaluator, eval ->
             (ITuple) eval.call("rascalRenameModule", fileRenames, workspaceFolders.stream().collect(VF.setWriter()), makePathConfigGetter(eval))
         , emptyResult, exec, false, client);
     }


### PR DESCRIPTION
This PR changes the distribution of tasks over evaluators, moving renaming to the compiler evaluator, since renaming and compilation might otherwise both run the type-checker in parallel on the same module.

**Pro** No more races for type-checking a certain module.
**Con** Renaming might need to wait for an unrelated, long-running, type-check.