### PR TITLE
Fix NPE from contributions

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -251,15 +251,17 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private static <T extends IValue> CompletableFuture<@PolyNull T> getContributionParameter(CompletableFuture<ISet> contributions, String name, String parameter, @PolyNull T defaultVal, Class<T> t) {
         return contributions.thenApply(c -> {
             var contrib = getContribution(c, name);
-            if (contrib == null) {
-                return defaultVal;
+            if (contrib != null) {
+                var val = contrib.asWithKeywordParameters().getParameter(parameter);
+                if (val != null) {
+                    try {
+                        return t.cast(val);
+                    } catch (ClassCastException e) {
+                        return defaultVal;
+                    }
+                }
             }
-
-            try {
-                return t.cast(contrib.asWithKeywordParameters().getParameter(parameter));
-            } catch (ClassCastException e) {
-                return defaultVal;
-            }
+            return defaultVal;
         });
     }
 

--- a/rascal-vscode-extension/CHANGELOG.md
+++ b/rascal-vscode-extension/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 We only list significant changes, for a full changelog please review the [commit history](https://github.com/usethesource/rascal-language-servers/commits/main/).
 
+## v-next
+
+### Improved features
+
+* Fixed an issue where language features would not work if certain arguments were not set.
+  * Parsing would not work for languages without `parsing::useSpecialCaseHighlighting`.
+  * Completion would not work for languages without `completion::additionalTriggerCharacters`.
+
 ## 0.13.1
 
 Works best with Rascal 0.42.0 (and rascal-maven-plugin 0.30.7). Due to changes in the type checker, users will most likely also have to update their library dependencies to the latest release.


### PR DESCRIPTION
Return default value when contribution parameter is not present, instead of causing an NPE.

Bug introduced here:
https://github.com/usethesource/rascal-language-servers/pull/706/changes#diff-8bea72cc04924f9c55207b52a566ae0f6c7b97bcd99ab2df995c994c96f8c8c5R250-R262

The nullable value from `getParameter` was not considered here, and somehow not picked up by CF.

Possibly related PR: https://github.com/usethesource/vallang/pull/328.