### PR TITLE
Fixed leakage of lsp+ through remote resolveProjectLocation

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
@@ -90,7 +90,7 @@ public class RemoteIDEServicesServer implements IRemoteIDEServices {
     public CompletableFuture<ISourceLocation> resolveProjectLocation(ISourceLocation loc) {
         logger.trace("resolveProjectLocation({})", loc);
         try {
-            return CompletableFutureUtils.completedFuture(URIResolverRegistry.getInstance().logicalToPhysical(loc), exec);
+            return CompletableFutureUtils.completedFuture(Locations.toClientLocation(URIResolverRegistry.getInstance().logicalToPhysical(loc)), exec);
         } catch (IOException e) {
             return CompletableFutureUtils.completedFuture(loc, exec);
         }


### PR DESCRIPTION
Calling `readFile` from a VS Code terminal to get the contents of currently opened files should retrieve the state on disk, not the editor state.