### PR TITLE
Nullability fixes

### DIFF
--- a/rascal-lsp/src/main/checkerframework/rascal.astub
+++ b/rascal-lsp/src/main/checkerframework/rascal.astub
@@ -20,3 +20,14 @@ public abstract class TreeVisitor<E extends Throwable> extends IdentityVisitor<E
 	public abstract @Nullable ITree visitTreeChar(ITree arg) throws E;
 	public abstract @Nullable ITree visitTreeCycle(ITree arg) throws E;
 }
+
+package org.rascalmpl.values.functions;
+
+import io.usethesource.vallang.IExternalValue;
+import io.usethesource.vallang.IValue;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public interface IFunction extends IExternalValue {
+  default <T extends @NonNull IValue> T call(IValue... parameters) { }
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -622,7 +622,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
         ), exec);
     }
 
-    private <T extends @NonNull Object> InterruptibleFuture<T> execFunction(String name, CompletableFuture<@Nullable IFunction> target, T defaultResult, IValue... args) {
+    private <T extends @NonNull IValue> InterruptibleFuture<T> execFunction(String name, CompletableFuture<@Nullable IFunction> target, T defaultResult, IValue... args) {
         if (target == null) {
             return InterruptibleFuture.completedFuture(defaultResult, exec);
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -230,16 +230,9 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     private <T> CompletableFuture<T> anyTrue(
             Function<ILanguageContributions, CompletableFuture<T>> predicate,
             T falsy, BinaryOperator<T> or) {
-
-        var result = CompletableFutureUtils.completedFuture(falsy, exec);
         // no short-circuiting, but it's not problem, it's only triggered at the beginning of a registry
         // pretty soon the future will be completed.
-        for (var c: contributions) {
-            var checkCurrent = predicate.apply(c.contrib)
-                .exceptionally(e -> falsy);
-            result = result.thenCombine(checkCurrent, or);
-        }
-        return result;
+        return CompletableFutureUtils.reduce(contributions.stream().map(c -> predicate.apply(c.contrib).exceptionally(_e -> falsy)), CompletableFutureUtils.completedFuture(falsy, exec), Function.identity(), or);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -53,6 +53,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.IOUtils;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.CallHierarchyIncomingCall;
 import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams;
@@ -629,7 +630,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
 
-    private static <T> CompletableFuture<T> recoverExceptions(CompletableFuture<T> future, Supplier<T> defaultValue) {
+    private static <T> CompletableFuture<@PolyNull T> recoverExceptions(CompletableFuture<@PolyNull T> future, Supplier<@PolyNull T> defaultValue) {
         return future
             .exceptionally(e -> {
                 logger.error("Operation failed with", e);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -442,7 +442,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             .thenApply(s -> s.stream()
                 .map(e -> locCommandTupleToCodeLense(contrib.getName(), e))
                 .collect(Collectors.toList())
-            ), () -> null);
+            ), Collections::<CodeLens>emptyList);
     }
 
 
@@ -626,7 +626,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                 .thenApply(s -> s.stream()
                     .map(this::rowToInlayHint)
                     .collect(Collectors.toList())
-            ), () -> null);
+            ), Collections::emptyList);
     }
 
 
@@ -871,7 +871,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         return recoverExceptions(file.getCurrentTreeAsync(true).thenApply(Versioned::get).thenApply(FoldingRanges::getFoldingRanges)
             .whenComplete((r, e) ->
                 logger.trace("Folding regions success, reporting {} regions back", r == null ? 0 : r.size())
-            ), Collections::emptyList);
+            ), Collections::<FoldingRange>emptyList);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -65,7 +65,7 @@ public class CapabilityRegistration {
 
     private final LanguageClient client;
     private final Executor exec;
-    private final CompletableFuture<Void> noop;
+    private final CompletableFuture<@Nullable Void> noop;
 
     private final Set<AbstractDynamicCapability<?>> dynamicCapabilities;
     private final Set<AbstractDynamicCapability<?>> staticCapabilities;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -414,7 +414,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 return findQualifiedNameUnderCursor(focus);
             })
             .thenApply(cur -> Locations.toRange(TreeAdapter.getLocation(cur), columns))
-            .thenApply(Either3::forFirst), () -> null);
+            .thenApply(Either3::forFirst), () -> Either3.forSecond(new PrepareRenameResult()));
     }
 
     @Override
@@ -723,7 +723,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return availableRascalServices().executeCommand(command).get();
     }
 
-    private static <T, S extends T> CompletableFuture<@PolyNull T> recoverExceptions(CompletableFuture<@PolyNull T> future, Supplier<@PolyNull S> defaultValue) {
+    private static <T> CompletableFuture<@PolyNull T> recoverExceptions(CompletableFuture<@PolyNull T> future, Supplier<@PolyNull T> defaultValue) {
         return future
                 .exceptionally(e -> {
                     if (e instanceof ResponseErrorException) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -45,6 +45,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -346,10 +347,10 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             return recoverExceptions(facts.getSummary(Locations.toLoc(params.getTextDocument()))
                 .thenApply(s -> s == null ? Collections.<Location>emptyList() : s.getDefinition(params.getPosition()))
                 .thenApply(Either::forLeft)
-            , () -> Either.forLeft(Collections.emptyList()));
+            , () -> Either.forLeft(Collections.<Location>emptyList()));
         }
         else {
-            return CompletableFutureUtils.completedFuture(Either.forLeft(Collections.emptyList()), exec);
+            return CompletableFutureUtils.completedFuture(Either.forLeft(Collections.<Location>emptyList()), exec);
         }
     }
 
@@ -670,9 +671,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return recoverExceptions(f.getLastTreeAsync(false)
             .thenApply(Versioned::get)
             .thenApplyAsync(availableRascalServices()::locateCodeLenses, exec)
-            .thenApply(List::stream)
-            .thenApply(res -> res.map(this::makeRunCodeLens))
-            .thenApply(s -> s.collect(Collectors.toList())), () -> null)
+            .thenApply(lenses -> lenses.stream().map(this::makeRunCodeLens).collect(Collectors.toList())), () -> null)
             ;
     }
 
@@ -724,7 +723,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return availableRascalServices().executeCommand(command).get();
     }
 
-    private static <T, S extends T> CompletableFuture<T> recoverExceptions(CompletableFuture<T> future, Supplier<S> defaultValue) {
+    private static <T, S extends T> CompletableFuture<@PolyNull T> recoverExceptions(CompletableFuture<@PolyNull T> future, Supplier<@PolyNull S> defaultValue) {
         return future
                 .exceptionally(e -> {
                     if (e instanceof ResponseErrorException) {
@@ -735,7 +734,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 });
     }
 
-    private static <T> CompletableFuture<List<T>> recoverExceptions(CompletableFuture<List<T>> future) {
+    private static <T> CompletableFuture<List<@PolyNull T>> recoverExceptions(CompletableFuture<List<@PolyNull T>> future) {
         return recoverExceptions(future, Collections::emptyList);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/CodeActions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/CodeActions.java
@@ -88,7 +88,7 @@ public class CodeActions {
     /* merges two streams of CodeAction terms and then converts them to LSP objects */
     public static CompletableFuture<List<Either<Command, CodeAction>>> mergeAndConvertCodeActions(IBaseTextDocumentService doc, String dedicatedLanguageName, String languageName, CompletableFuture<Stream<IValue>> quickfixes, CompletableFuture<Stream<IValue>> codeActions) {
         return codeActions.thenCombine(quickfixes, (actions, quicks) ->
-            Stream.concat(quicks, actions)
+            Stream.<IValue>concat(quicks, actions)
                 .map(IConstructor.class::cast)
                 .map(cons -> constructorToCodeAction(doc, dedicatedLanguageName, languageName, cons))
                 .map(Either::<Command,CodeAction>forRight)

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Diagnostics.java
@@ -256,7 +256,7 @@ public class Diagnostics {
             .collect(Collectors.toList());
     }
 
-    public static Map<ISourceLocation, List<Diagnostic>> translateMessages(ICollection<?> messages, ColumnMaps cm) {
+    public static Map<ISourceLocation, List<Diagnostic>> translateMessages(IList messages, ColumnMaps cm) {
         return messages.stream()
             .filter(IConstructor.class::isInstance)
             .map(IConstructor.class::cast)

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
@@ -42,7 +42,7 @@ public class CompletableFutureUtils {
     private CompletableFutureUtils() {/* hidden */ }
 
     public static <T> CompletableFuture<@PolyNull T> completedFuture(@PolyNull T value, Executor exec) {
-        return CompletableFuture.supplyAsync(() -> value, exec);
+        return CompletableFuture.<@PolyNull T>supplyAsync(() -> value, exec);
     }
 
     /**

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
@@ -41,7 +41,7 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
 public class CompletableFutureUtils {
     private CompletableFutureUtils() {/* hidden */ }
 
-    public static <T> CompletableFuture<T> completedFuture(T value, Executor exec) {
+    public static <T> CompletableFuture<@PolyNull T> completedFuture(@PolyNull T value, Executor exec) {
         return CompletableFuture.supplyAsync(() -> value, exec);
     }
 
@@ -133,7 +133,7 @@ public class CompletableFutureUtils {
      */
     public static <I, C> CompletableFuture<C> reduce(Iterable<CompletableFuture<I>> futures,
             CompletableFuture<C> identity, Function<I, C> map, BinaryOperator<C> concat) {
-        CompletableFuture<C> result = identity;
+        var result = identity;
         for (var fut : futures) {
             result = result.thenCombine(fut, (acc, t) -> concat.apply(acc, map.apply(t)));
         }
@@ -141,7 +141,7 @@ public class CompletableFutureUtils {
         return result;
     }
 
-    private static <T> List<@PolyNull T> concat(List<@PolyNull T> l, List<@PolyNull T> r) {
+    private static <T> List<T> concat(List<T> l, List<T> r) {
         if (r.isEmpty()) {
             return l;
         }
@@ -149,7 +149,7 @@ public class CompletableFutureUtils {
             return r;
         }
 
-        var ls = new LinkedList<@PolyNull T>(l);
+        var ls = new LinkedList<T>(l);
         ls.addAll(r);
         return ls;
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/CompletableFutureUtils.java
@@ -36,13 +36,12 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 
 public class CompletableFutureUtils {
     private CompletableFutureUtils() {/* hidden */ }
 
-    public static <T> CompletableFuture<@PolyNull T> completedFuture(@PolyNull T value, Executor exec) {
-        return CompletableFuture.<@PolyNull T>supplyAsync(() -> value, exec);
+    public static <T> CompletableFuture<T> completedFuture(T value, Executor exec) {
+        return CompletableFuture.supplyAsync(() -> value, exec);
     }
 
     /**

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
@@ -94,7 +94,7 @@ public class InterruptibleFuture<T> {
     }
 
     public static <T> InterruptibleFuture<T> completedFuture(T result, Executor exec) {
-        return new InterruptibleFuture<>(CompletableFutureUtils.completedFuture(result, exec), () -> {});
+        return new InterruptibleFuture<>(CompletableFutureUtils.<T>completedFuture(result, exec), () -> {});
     }
 
     /**

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
@@ -32,7 +32,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 
 public class InterruptibleFuture<T> {
 
@@ -102,9 +101,9 @@ public class InterruptibleFuture<T> {
      * Turn an completable future with a interruptible future inside into a
      * normal interruptible future by inlining them
      */
-    public static <T> InterruptibleFuture<@PolyNull T> flatten(CompletableFuture<InterruptibleFuture<@PolyNull T>> f, Executor exec) {
+    public static <T> InterruptibleFuture<T> flatten(CompletableFuture<InterruptibleFuture<T>> f, Executor exec) {
         return new InterruptibleFuture<>(
-            f.<@PolyNull T>thenCompose(InterruptibleFuture::get),
+            f.thenCompose(InterruptibleFuture::get),
             () -> f.thenAcceptAsync(InterruptibleFuture::interrupt, exec) // schedule interrupt async so that we don't deadlock during interrupt
         );
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
@@ -94,7 +94,7 @@ public class InterruptibleFuture<T> {
     }
 
     public static <T> InterruptibleFuture<T> completedFuture(T result, Executor exec) {
-        return new InterruptibleFuture<>(CompletableFutureUtils.<T>completedFuture(result, exec), () -> {});
+        return new InterruptibleFuture<>(CompletableFutureUtils.completedFuture(result, exec), () -> {});
     }
 
     /**

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/ReplaceableFuture.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/ReplaceableFuture.java
@@ -31,8 +31,8 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
 
 /**
  * A wrapper around CompletableFuture's that allow for us to replace the results of a still running future, and call an
@@ -111,7 +111,7 @@ public class ReplaceableFuture<T> {
         return new InterruptibleFuture<>(result, with::interrupt);
     }
 
-    public static <T> ReplaceableFuture<T> completedFuture(T result, Executor exec) {
+    public static <T> ReplaceableFuture<@PolyNull T> completedFuture(@PolyNull T result, Executor exec) {
         return new ReplaceableFuture<>(CompletableFutureUtils.completedFuture(result, exec));
     }
 }


### PR DESCRIPTION
This PR fixes nullability bugs by using CF [`3.54.0`](https://github.com/typetools/checker-framework/releases/tag/checker-framework-3.54.0). However, since it contains some bugs as well (inference crashes on some of our code), this PR does not actually update the dependency.