### PR TITLE
Always return a value from (unprovided) contributions

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ILanguageContributions.java
@@ -72,22 +72,22 @@ public interface ILanguageContributions {
     public CompletableFuture<IList> parseCodeActions(String command);
     public CompletableFuture<IConstructor> parseCallHierarchyData(String data);
 
-    public CompletableFuture<Boolean> hasAnalysis();
-    public CompletableFuture<Boolean> hasBuild();
-    public CompletableFuture<Boolean> hasDocumentSymbol();
-    public CompletableFuture<Boolean> hasCodeLens();
-    public CompletableFuture<Boolean> hasInlayHint();
-    public CompletableFuture<Boolean> hasRename();
-    public CompletableFuture<Boolean> hasExecution();
-    public CompletableFuture<Boolean> hasHover();
-    public CompletableFuture<Boolean> hasDefinition();
-    public CompletableFuture<Boolean> hasReferences();
-    public CompletableFuture<Boolean> hasImplementation();
-    public CompletableFuture<Boolean> hasCodeAction();
-    public CompletableFuture<Boolean> hasDidRenameFiles();
-    public CompletableFuture<Boolean> hasSelectionRange();
-    public CompletableFuture<Boolean> hasCallHierarchy();
-    public CompletableFuture<Boolean> hasCompletion();
+    public CompletableFuture<Boolean> providesAnalysis();
+    public CompletableFuture<Boolean> providesBuild();
+    public CompletableFuture<Boolean> providesDocumentSymbol();
+    public CompletableFuture<Boolean> providesCodeLens();
+    public CompletableFuture<Boolean> providesInlayHint();
+    public CompletableFuture<Boolean> providesRename();
+    public CompletableFuture<Boolean> providesExecution();
+    public CompletableFuture<Boolean> providesHover();
+    public CompletableFuture<Boolean> providesDefinition();
+    public CompletableFuture<Boolean> providesReferences();
+    public CompletableFuture<Boolean> providesImplementation();
+    public CompletableFuture<Boolean> providesCodeAction();
+    public CompletableFuture<Boolean> providesDidRenameFiles();
+    public CompletableFuture<Boolean> providesSelectionRange();
+    public CompletableFuture<Boolean> providesCallHierarchy();
+    public CompletableFuture<Boolean> providesCompletion();
 
     public CompletableFuture<Boolean> specialCaseHighlighting();
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -224,10 +224,10 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private static CompletableFuture<SummaryConfig> ondemandSummaryConfig(CompletableFuture<ISet> contributions) {
         return contributions.thenApply(c ->
             new SummaryConfig(
-                providesContribution(c, LanguageContributions.HOVER),
-                providesContribution(c, LanguageContributions.DEFINITION),
-                providesContribution(c, LanguageContributions.REFERENCES),
-                providesContribution(c, LanguageContributions.IMPLEMENTATION)));
+                hasContribution(c, LanguageContributions.HOVER),
+                hasContribution(c, LanguageContributions.DEFINITION),
+                hasContribution(c, LanguageContributions.REFERENCES),
+                hasContribution(c, LanguageContributions.IMPLEMENTATION)));
     }
 
     private static @Nullable IConstructor getContribution(ISet contributions, String name) {
@@ -239,7 +239,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
             .orElse(null);
     }
 
-    private static boolean providesContribution(ISet contributions, String name) {
+    private static boolean hasContribution(ISet contributions, String name) {
         return getContribution(contributions, name) != null;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -419,7 +419,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     @Override
     public InterruptibleFuture<ITuple> rename(IList focus, String newName) {
         debug(LanguageContributions.RENAME_SERVICE, newName, focus.isEmpty() ? "" : focus.get(0));
-        return execFunction(LanguageContributions.RENAME_SERVICE, rename, VF.tuple(VF.list(), VF.list()), focus, VF.string(newName));
+        return execFunction(LanguageContributions.RENAME_SERVICE, rename, VF.tuple(VF.list(), VF.set()), focus, VF.string(newName));
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -342,7 +342,6 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
                     return contrib;
                 }
             }
-            logger.debug("No {} defined", cons);
             return null;
         });
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/InterpretedLanguageContributions.java
@@ -103,22 +103,22 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private final CompletableFuture<@Nullable IFunction> completion;
     private final CompletableFuture<IList> completionTriggerCharacters;
 
-    private final CompletableFuture<Boolean> hasAnalysis;
-    private final CompletableFuture<Boolean> hasBuild;
-    private final CompletableFuture<Boolean> hasDocumentSymbol;
-    private final CompletableFuture<Boolean> hasCodeLens;
-    private final CompletableFuture<Boolean> hasInlayHint;
-    private final CompletableFuture<Boolean> hasExecution;
-    private final CompletableFuture<Boolean> hasHover;
-    private final CompletableFuture<Boolean> hasDefinition;
-    private final CompletableFuture<Boolean> hasReferences;
-    private final CompletableFuture<Boolean> hasImplementation;
-    private final CompletableFuture<Boolean> hasCodeAction;
-    private final CompletableFuture<Boolean> hasRename;
-    private final CompletableFuture<Boolean> hasDidRenameFiles;
-    private final CompletableFuture<Boolean> hasSelectionRange;
-    private final CompletableFuture<Boolean> hasCallHierarchy;
-    private final CompletableFuture<Boolean> hasCompletion;
+    private final CompletableFuture<Boolean> providesAnalysis;
+    private final CompletableFuture<Boolean> providesBuild;
+    private final CompletableFuture<Boolean> providesDocumentSymbol;
+    private final CompletableFuture<Boolean> providesCodeLens;
+    private final CompletableFuture<Boolean> providesInlayHint;
+    private final CompletableFuture<Boolean> providesExecution;
+    private final CompletableFuture<Boolean> providesHover;
+    private final CompletableFuture<Boolean> providesDefinition;
+    private final CompletableFuture<Boolean> providesReferences;
+    private final CompletableFuture<Boolean> providesImplementation;
+    private final CompletableFuture<Boolean> providesCodeAction;
+    private final CompletableFuture<Boolean> providesRename;
+    private final CompletableFuture<Boolean> providesDidRenameFiles;
+    private final CompletableFuture<Boolean> providesSelectionRange;
+    private final CompletableFuture<Boolean> providesCallHierarchy;
+    private final CompletableFuture<Boolean> providesCompletion;
 
     private final CompletableFuture<Boolean> specialCaseHighlighting;
 
@@ -171,22 +171,22 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
             this.completionTriggerCharacters = getContributionParameter(contributions, LanguageContributions.COMPLETION, LanguageContributions.COMPLETION_TRIGGER_CHARACTERS, VF.list(), IList.class);
 
             // assign boolean properties once instead of wasting futures all the time
-            this.hasAnalysis = nonNull(this.analysis);
-            this.hasBuild = nonNull(this.build);
-            this.hasDocumentSymbol = nonNull(this.documentSymbol);
-            this.hasCodeLens = nonNull(this.codeLens);
-            this.hasInlayHint = nonNull(this.inlayHint);
-            this.hasExecution = nonNull(this.execution);
-            this.hasHover = nonNull(this.hover);
-            this.hasDefinition = nonNull(this.definition);
-            this.hasReferences = nonNull(this.references);
-            this.hasImplementation = nonNull(this.implementation);
-            this.hasCodeAction = nonNull(this.codeAction);
-            this.hasRename = nonNull(this.rename);
-            this.hasDidRenameFiles = nonNull(this.didRenameFiles);
-            this.hasSelectionRange = nonNull(this.selectionRange);
-            this.hasCallHierarchy = nonNull(this.prepareCallHierarchy);
-            this.hasCompletion = nonNull(this.completion);
+            this.providesAnalysis = nonNull(this.analysis);
+            this.providesBuild = nonNull(this.build);
+            this.providesDocumentSymbol = nonNull(this.documentSymbol);
+            this.providesCodeLens = nonNull(this.codeLens);
+            this.providesInlayHint = nonNull(this.inlayHint);
+            this.providesExecution = nonNull(this.execution);
+            this.providesHover = nonNull(this.hover);
+            this.providesDefinition = nonNull(this.definition);
+            this.providesReferences = nonNull(this.references);
+            this.providesImplementation = nonNull(this.implementation);
+            this.providesCodeAction = nonNull(this.codeAction);
+            this.providesRename = nonNull(this.rename);
+            this.providesDidRenameFiles = nonNull(this.didRenameFiles);
+            this.providesSelectionRange = nonNull(this.selectionRange);
+            this.providesCallHierarchy = nonNull(this.prepareCallHierarchy);
+            this.providesCompletion = nonNull(this.completion);
 
             this.specialCaseHighlighting = getContributionParameter(contributions,
                 LanguageContributions.PARSING,
@@ -224,10 +224,10 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     private static CompletableFuture<SummaryConfig> ondemandSummaryConfig(CompletableFuture<ISet> contributions) {
         return contributions.thenApply(c ->
             new SummaryConfig(
-                hasContribution(c, LanguageContributions.HOVER),
-                hasContribution(c, LanguageContributions.DEFINITION),
-                hasContribution(c, LanguageContributions.REFERENCES),
-                hasContribution(c, LanguageContributions.IMPLEMENTATION)));
+                providesContribution(c, LanguageContributions.HOVER),
+                providesContribution(c, LanguageContributions.DEFINITION),
+                providesContribution(c, LanguageContributions.REFERENCES),
+                providesContribution(c, LanguageContributions.IMPLEMENTATION)));
     }
 
     private static @Nullable IConstructor getContribution(ISet contributions, String name) {
@@ -239,7 +239,7 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
             .orElse(null);
     }
 
-    private static boolean hasContribution(ISet contributions, String name) {
+    private static boolean providesContribution(ISet contributions, String name) {
         return getContribution(contributions, name) != null;
     }
 
@@ -495,82 +495,82 @@ public class InterpretedLanguageContributions implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefinition() {
-        return hasDefinition;
+    public CompletableFuture<Boolean> providesDefinition() {
+        return providesDefinition;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferences() {
-        return hasReferences;
+    public CompletableFuture<Boolean> providesReferences() {
+        return providesReferences;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementation() {
-        return hasImplementation;
+    public CompletableFuture<Boolean> providesImplementation() {
+        return providesImplementation;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasHover() {
-        return hasHover;
+    public CompletableFuture<Boolean> providesHover() {
+        return providesHover;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasExecution() {
-        return hasExecution;
+    public CompletableFuture<Boolean> providesExecution() {
+        return providesExecution;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHint() {
-        return hasInlayHint;
+    public CompletableFuture<Boolean> providesInlayHint() {
+        return providesInlayHint;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasRename() {
-        return hasRename;
+    public CompletableFuture<Boolean> providesRename() {
+        return providesRename;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDidRenameFiles() {
-        return hasDidRenameFiles;
+    public CompletableFuture<Boolean> providesDidRenameFiles() {
+        return providesDidRenameFiles;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLens() {
-        return hasCodeLens;
+    public CompletableFuture<Boolean> providesCodeLens() {
+        return providesCodeLens;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumentSymbol() {
-        return hasDocumentSymbol;
+    public CompletableFuture<Boolean> providesDocumentSymbol() {
+        return providesDocumentSymbol;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeAction() {
-        return hasCodeAction;
+    public CompletableFuture<Boolean> providesCodeAction() {
+        return providesCodeAction;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasSelectionRange() {
-        return hasSelectionRange;
+    public CompletableFuture<Boolean> providesSelectionRange() {
+        return providesSelectionRange;
     }
 
-    public CompletableFuture<Boolean> hasCallHierarchy() {
-        return hasCallHierarchy;
-    }
-
-    @Override
-    public CompletableFuture<Boolean> hasCompletion() {
-        return hasCompletion;
+    public CompletableFuture<Boolean> providesCallHierarchy() {
+        return providesCallHierarchy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalysis() {
-        return hasAnalysis;
+    public CompletableFuture<Boolean> providesCompletion() {
+        return providesCompletion;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuild() {
-        return hasBuild;
+    public CompletableFuture<Boolean> providesAnalysis() {
+        return providesAnalysis;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> providesBuild() {
+        return providesBuild;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -78,22 +78,22 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     private volatile CompletableFuture<ILanguageContributions> callHierarchy = failedInitialization();
     private volatile CompletableFuture<ILanguageContributions> completion = failedInitialization();
 
-    private volatile CompletableFuture<Boolean> hasAnalysis = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasBuild = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasDocumentSymbol = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCodeLens = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasInlayHint = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasExecution = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasHover = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasDefinition = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasReferences = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasImplementation = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCodeAction = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasRename = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasDidRenameFiles = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasSelectionRange = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCallHierarchy = failedInitialization();
-    private volatile CompletableFuture<Boolean> hasCompletion = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesAnalysis = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesBuild = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesDocumentSymbol = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesCodeLens = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesInlayHint = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesExecution = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesHover = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesDefinition = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesReferences = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesImplementation = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesCodeAction = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesRename = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesDidRenameFiles = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesSelectionRange = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesCallHierarchy = failedInitialization();
+    private volatile CompletableFuture<Boolean> providesCompletion = failedInitialization();
 
     private volatile CompletableFuture<Boolean> specialCaseHighlighting = failedInitialization();
 
@@ -156,39 +156,39 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // future
         parsing = firstOrFail();
 
-        analysis = findFirstOrDefault(ILanguageContributions::hasAnalysis, "analysis");
-        build = findFirstOrDefault(ILanguageContributions::hasBuild, "build");
-        documentSymbol = findFirstOrDefault(ILanguageContributions::hasDocumentSymbol, "documentSymbol");
-        codeLens = findFirstOrDefault(ILanguageContributions::hasCodeLens, "codeLens");
-        inlayHint = findFirstOrDefault(ILanguageContributions::hasInlayHint, "inlayHint");
-        execution = findFirstOrDefault(ILanguageContributions::hasExecution, "execution");
-        hover = findFirstOrDefault(ILanguageContributions::hasHover, "hover");
-        definition = findFirstOrDefault(ILanguageContributions::hasDefinition, "definition");
-        references = findFirstOrDefault(ILanguageContributions::hasReferences, "references");
-        implementation = findFirstOrDefault(ILanguageContributions::hasImplementation, "implementation");
-        codeAction = findFirstOrDefault(ILanguageContributions::hasCodeAction, "codeAction");
-        rename = findFirstOrDefault(ILanguageContributions::hasRename, "rename");
-        didRenameFiles = findFirstOrDefault(ILanguageContributions::hasDidRenameFiles, "didRenameFiles");
-        selectionRange = findFirstOrDefault(ILanguageContributions::hasSelectionRange, "selectionRange");
-        callHierarchy = findFirstOrDefault(ILanguageContributions::hasCallHierarchy, "callHierarchy");
-        completion = findFirstOrDefault(ILanguageContributions::hasCompletion, "completion");
+        analysis = findFirstOrDefault(ILanguageContributions::providesAnalysis, "analysis");
+        build = findFirstOrDefault(ILanguageContributions::providesBuild, "build");
+        documentSymbol = findFirstOrDefault(ILanguageContributions::providesDocumentSymbol, "documentSymbol");
+        codeLens = findFirstOrDefault(ILanguageContributions::providesCodeLens, "codeLens");
+        inlayHint = findFirstOrDefault(ILanguageContributions::providesInlayHint, "inlayHint");
+        execution = findFirstOrDefault(ILanguageContributions::providesExecution, "execution");
+        hover = findFirstOrDefault(ILanguageContributions::providesHover, "hover");
+        definition = findFirstOrDefault(ILanguageContributions::providesDefinition, "definition");
+        references = findFirstOrDefault(ILanguageContributions::providesReferences, "references");
+        implementation = findFirstOrDefault(ILanguageContributions::providesImplementation, "implementation");
+        codeAction = findFirstOrDefault(ILanguageContributions::providesCodeAction, "codeAction");
+        rename = findFirstOrDefault(ILanguageContributions::providesRename, "rename");
+        didRenameFiles = findFirstOrDefault(ILanguageContributions::providesDidRenameFiles, "didRenameFiles");
+        selectionRange = findFirstOrDefault(ILanguageContributions::providesSelectionRange, "selectionRange");
+        callHierarchy = findFirstOrDefault(ILanguageContributions::providesCallHierarchy, "callHierarchy");
+        completion = findFirstOrDefault(ILanguageContributions::providesCompletion, "completion");
 
-        hasAnalysis = anyTrue(ILanguageContributions::hasAnalysis);
-        hasBuild = anyTrue(ILanguageContributions::hasBuild);
-        hasDocumentSymbol = anyTrue(ILanguageContributions::hasDocumentSymbol);
-        hasCodeLens = anyTrue(ILanguageContributions::hasCodeLens);
-        hasInlayHint = anyTrue(ILanguageContributions::hasInlayHint);
-        hasExecution = anyTrue(ILanguageContributions::hasExecution);
-        hasHover = anyTrue(ILanguageContributions::hasHover);
-        hasDefinition = anyTrue(ILanguageContributions::hasDefinition);
-        hasReferences = anyTrue(ILanguageContributions::hasReferences);
-        hasImplementation = anyTrue(ILanguageContributions::hasImplementation);
-        hasCodeAction = anyTrue(ILanguageContributions::hasCodeAction);
-        hasRename = anyTrue(ILanguageContributions::hasRename);
-        hasDidRenameFiles = anyTrue(ILanguageContributions::hasDidRenameFiles);
-        hasSelectionRange = anyTrue(ILanguageContributions::hasSelectionRange);
-        hasCallHierarchy = anyTrue(ILanguageContributions::hasCallHierarchy);
-        hasCompletion = anyTrue(ILanguageContributions::hasCompletion);
+        providesAnalysis = anyTrue(ILanguageContributions::providesAnalysis);
+        providesBuild = anyTrue(ILanguageContributions::providesBuild);
+        providesDocumentSymbol = anyTrue(ILanguageContributions::providesDocumentSymbol);
+        providesCodeLens = anyTrue(ILanguageContributions::providesCodeLens);
+        providesInlayHint = anyTrue(ILanguageContributions::providesInlayHint);
+        providesExecution = anyTrue(ILanguageContributions::providesExecution);
+        providesHover = anyTrue(ILanguageContributions::providesHover);
+        providesDefinition = anyTrue(ILanguageContributions::providesDefinition);
+        providesReferences = anyTrue(ILanguageContributions::providesReferences);
+        providesImplementation = anyTrue(ILanguageContributions::providesImplementation);
+        providesCodeAction = anyTrue(ILanguageContributions::providesCodeAction);
+        providesRename = anyTrue(ILanguageContributions::providesRename);
+        providesDidRenameFiles = anyTrue(ILanguageContributions::providesDidRenameFiles);
+        providesSelectionRange = anyTrue(ILanguageContributions::providesSelectionRange);
+        providesCallHierarchy = anyTrue(ILanguageContributions::providesCallHierarchy);
+        providesCompletion = anyTrue(ILanguageContributions::providesCompletion);
 
         // Always use the special-case highlighting status of *the first*
         // contribution (possibly using the default value in the Rascal ADT if
@@ -371,82 +371,82 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeAction() {
-        return hasCodeAction;
+    public CompletableFuture<Boolean> providesCodeAction() {
+        return providesCodeAction;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasHover() {
-        return hasHover;
+    public CompletableFuture<Boolean> providesHover() {
+        return providesHover;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefinition() {
-        return hasDefinition;
+    public CompletableFuture<Boolean> providesDefinition() {
+        return providesDefinition;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferences() {
-        return hasReferences;
+    public CompletableFuture<Boolean> providesReferences() {
+        return providesReferences;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementation() {
-        return hasImplementation;
+    public CompletableFuture<Boolean> providesImplementation() {
+        return providesImplementation;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumentSymbol() {
-        return hasDocumentSymbol;
+    public CompletableFuture<Boolean> providesDocumentSymbol() {
+        return providesDocumentSymbol;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalysis() {
-        return hasAnalysis;
+    public CompletableFuture<Boolean> providesAnalysis() {
+        return providesAnalysis;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuild() {
-        return hasBuild;
+    public CompletableFuture<Boolean> providesBuild() {
+        return providesBuild;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLens() {
-        return hasCodeLens;
+    public CompletableFuture<Boolean> providesCodeLens() {
+        return providesCodeLens;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasExecution() {
-        return hasExecution;
+    public CompletableFuture<Boolean> providesExecution() {
+        return providesExecution;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHint() {
-        return hasInlayHint;
+    public CompletableFuture<Boolean> providesInlayHint() {
+        return providesInlayHint;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasSelectionRange() {
-        return hasSelectionRange;
+    public CompletableFuture<Boolean> providesSelectionRange() {
+        return providesSelectionRange;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasRename() {
-        return hasRename;
+    public CompletableFuture<Boolean> providesRename() {
+        return providesRename;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDidRenameFiles() {
-        return hasDidRenameFiles;
+    public CompletableFuture<Boolean> providesDidRenameFiles() {
+        return providesDidRenameFiles;
     }
 
-    public CompletableFuture<Boolean> hasCallHierarchy() {
-        return hasCallHierarchy;
+    public CompletableFuture<Boolean> providesCallHierarchy() {
+        return providesCallHierarchy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCompletion() {
-        return hasCompletion;
+    public CompletableFuture<Boolean> providesCompletion() {
+        return providesCompletion;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/LanguageContributionsMultiplexer.java
@@ -31,6 +31,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.values.parsetrees.ITree;
@@ -47,6 +49,8 @@ import io.usethesource.vallang.IValue;
 
 @SuppressWarnings("java:S3077") // Fields in this class are read/written sequentially
 public class LanguageContributionsMultiplexer implements ILanguageContributions {
+
+    private static final Logger logger = LogManager.getLogger(LanguageContributionsMultiplexer.class);
 
     private final ExecutorService exec;
     private final String name;
@@ -152,22 +156,22 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         // future
         parsing = firstOrFail();
 
-        analysis = findFirstOrDefault(ILanguageContributions::hasAnalysis);
-        build = findFirstOrDefault(ILanguageContributions::hasBuild);
-        documentSymbol = findFirstOrDefault(ILanguageContributions::hasDocumentSymbol);
-        codeLens = findFirstOrDefault(ILanguageContributions::hasCodeLens);
-        inlayHint = findFirstOrDefault(ILanguageContributions::hasInlayHint);
-        execution = findFirstOrDefault(ILanguageContributions::hasExecution);
-        hover = findFirstOrDefault(ILanguageContributions::hasHover);
-        definition = findFirstOrDefault(ILanguageContributions::hasDefinition);
-        references = findFirstOrDefault(ILanguageContributions::hasReferences);
-        implementation = findFirstOrDefault(ILanguageContributions::hasImplementation);
-        codeAction = findFirstOrDefault(ILanguageContributions::hasCodeAction);
-        rename = findFirstOrDefault(ILanguageContributions::hasRename);
-        didRenameFiles = findFirstOrDefault(ILanguageContributions::hasDidRenameFiles);
-        selectionRange = findFirstOrDefault(ILanguageContributions::hasSelectionRange);
-        callHierarchy = findFirstOrDefault(ILanguageContributions::hasCallHierarchy);
-        completion = findFirstOrDefault(ILanguageContributions::hasCompletion);
+        analysis = findFirstOrDefault(ILanguageContributions::hasAnalysis, "analysis");
+        build = findFirstOrDefault(ILanguageContributions::hasBuild, "build");
+        documentSymbol = findFirstOrDefault(ILanguageContributions::hasDocumentSymbol, "documentSymbol");
+        codeLens = findFirstOrDefault(ILanguageContributions::hasCodeLens, "codeLens");
+        inlayHint = findFirstOrDefault(ILanguageContributions::hasInlayHint, "inlayHint");
+        execution = findFirstOrDefault(ILanguageContributions::hasExecution, "execution");
+        hover = findFirstOrDefault(ILanguageContributions::hasHover, "hover");
+        definition = findFirstOrDefault(ILanguageContributions::hasDefinition, "definition");
+        references = findFirstOrDefault(ILanguageContributions::hasReferences, "references");
+        implementation = findFirstOrDefault(ILanguageContributions::hasImplementation, "implementation");
+        codeAction = findFirstOrDefault(ILanguageContributions::hasCodeAction, "codeAction");
+        rename = findFirstOrDefault(ILanguageContributions::hasRename, "rename");
+        didRenameFiles = findFirstOrDefault(ILanguageContributions::hasDidRenameFiles, "didRenameFiles");
+        selectionRange = findFirstOrDefault(ILanguageContributions::hasSelectionRange, "selectionRange");
+        callHierarchy = findFirstOrDefault(ILanguageContributions::hasCallHierarchy, "callHierarchy");
+        completion = findFirstOrDefault(ILanguageContributions::hasCompletion, "completion");
 
         hasAnalysis = anyTrue(ILanguageContributions::hasAnalysis);
         hasBuild = anyTrue(ILanguageContributions::hasBuild);
@@ -204,7 +208,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
         return it.next().contrib;
     }
 
-    private CompletableFuture<ILanguageContributions> findFirstOrDefault(Function<ILanguageContributions, CompletableFuture<Boolean>> filter) {
+    private CompletableFuture<ILanguageContributions> findFirstOrDefault(Function<ILanguageContributions, CompletableFuture<Boolean>> filter, String contribName) {
         return CompletableFuture.supplyAsync(() -> {
             for (var c : contributions) {
                 try {
@@ -219,6 +223,7 @@ public class LanguageContributionsMultiplexer implements ILanguageContributions 
                 }
             }
             // otherwise return the first one, that contains defaults on what to do if it's missing
+            logger.info("No contribution for {}; defaulting to empty implementation", contribName);
             return firstOrFail();
         }, exec);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/NoContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/NoContributions.java
@@ -200,82 +200,82 @@ public class NoContributions implements ILanguageContributions {
     }
 
     @Override
-    public CompletableFuture<Boolean> hasAnalysis() {
+    public CompletableFuture<Boolean> providesAnalysis() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasBuild() {
+    public CompletableFuture<Boolean> providesBuild() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDocumentSymbol() {
+    public CompletableFuture<Boolean> providesDocumentSymbol() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeLens() {
+    public CompletableFuture<Boolean> providesCodeLens() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasInlayHint() {
+    public CompletableFuture<Boolean> providesInlayHint() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasRename() {
+    public CompletableFuture<Boolean> providesRename() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasExecution() {
+    public CompletableFuture<Boolean> providesExecution() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasHover() {
+    public CompletableFuture<Boolean> providesHover() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDefinition() {
+    public CompletableFuture<Boolean> providesDefinition() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasReferences() {
+    public CompletableFuture<Boolean> providesReferences() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasImplementation() {
+    public CompletableFuture<Boolean> providesImplementation() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCodeAction() {
+    public CompletableFuture<Boolean> providesCodeAction() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasDidRenameFiles() {
+    public CompletableFuture<Boolean> providesDidRenameFiles() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasSelectionRange() {
+    public CompletableFuture<Boolean> providesSelectionRange() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCallHierarchy() {
+    public CompletableFuture<Boolean> providesCallHierarchy() {
         return falsy;
     }
 
     @Override
-    public CompletableFuture<Boolean> hasCompletion() {
+    public CompletableFuture<Boolean> providesCompletion() {
         return falsy;
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/NoContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/NoContributions.java
@@ -30,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.rascalmpl.uri.URIUtil;
+import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
 import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
@@ -41,16 +43,21 @@ import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.ITuple;
 import io.usethesource.vallang.IValue;
+import io.usethesource.vallang.IValueFactory;
 
 /**
  * An implementation of {@link ILanguageContributions} that has no contributions.
- * It is intended to be used as a placeholder for files which do not have any contributions registered.
+ * It is intended to be used as a placeholder for files which do not have any contributions registered,
+ * or as a super-class for very selective contributions.
+ * The default values that these contributions return should mirror the ones in `InterpretedLanguageContributions`.
  */
 public class NoContributions implements ILanguageContributions {
 
     private static final Logger logger = LogManager.getLogger(NoContributions.class);
+    private static final IValueFactory VF = IRascalValueFactory.getInstance();
 
-    private String name;
+    private final String name;
+    private final Executor exec;
     private final CompletableFuture<Boolean> falsy;
 
     public class NoContributionException extends RuntimeException {
@@ -61,7 +68,16 @@ public class NoContributions implements ILanguageContributions {
 
     public NoContributions(String name, Executor exec) {
         this.name = name;
+        this.exec = exec;
         this.falsy = CompletableFutureUtils.completedFuture(false, exec);
+    }
+
+    private final <T> InterruptibleFuture<T> interruptible(T t) {
+        return InterruptibleFuture.completedFuture(t, exec);
+    }
+
+    private final <T> CompletableFuture<T> completable(T t) {
+        return CompletableFutureUtils.completedFuture(t, exec);
     }
 
     @Override
@@ -71,112 +87,116 @@ public class NoContributions implements ILanguageContributions {
 
     @Override
     public CompletableFuture<ITree> parsing(ISourceLocation loc, String input) {
-        throw new NoContributionException("parsing");
+        return CompletableFuture.failedFuture(new NoContributionException("parsing"));
     }
 
     @Override
     public InterruptibleFuture<IConstructor> analysis(ISourceLocation loc, ITree input) {
-        throw new NoContributionException("analysis");
+        return interruptible(EmptySummary.newInstance(loc));
     }
 
     @Override
     public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
-        throw new NoContributionException("build");
+        return interruptible(EmptySummary.newInstance(loc));
     }
 
     @Override
     public InterruptibleFuture<IList> documentSymbol(ITree input) {
-        throw new NoContributionException("documentSymbol");
+        return interruptible(VF.list());
     }
 
     @Override
     public InterruptibleFuture<IList> codeLens(ITree input) {
-        throw new NoContributionException("codeLens");
+        return interruptible(VF.list());
     }
 
     @Override
     public InterruptibleFuture<IList> inlayHint(ITree input) {
-        throw new NoContributionException("inlayHint");
+        return interruptible(VF.list());
     }
 
     @Override
     public InterruptibleFuture<IValue> execution(String command) {
-        throw new NoContributionException("execution");
+        // Similar to default in ParametricTextDocumentService::executeCommand
+        return interruptible(VF.string("Execution not configured"));
     }
 
     @Override
     public InterruptibleFuture<ISet> hover(IList focus) {
-        throw new NoContributionException("hover");
+        return interruptible(VF.set());
     }
 
     @Override
     public InterruptibleFuture<ISet> definition(IList focus) {
-        throw new NoContributionException("definition");
+        return interruptible(VF.set());
     }
 
     @Override
     public InterruptibleFuture<ISet> references(IList focus) {
-        throw new NoContributionException("references");
+        return interruptible(VF.set());
     }
 
     @Override
     public InterruptibleFuture<ISet> implementation(IList focus) {
-        throw new NoContributionException("implementation");
+        return interruptible(VF.set());
     }
 
     @Override
     public InterruptibleFuture<IList> codeAction(IList focus) {
-        throw new NoContributionException("codeLens");
+        return interruptible(VF.list());
     }
 
     @Override
     public InterruptibleFuture<IList> selectionRange(IList focus) {
-        throw new NoContributionException("selectionRange");
+        return interruptible(VF.list());
     }
 
     @Override
     public InterruptibleFuture<ISourceLocation> prepareRename(IList focus) {
-        throw new NoContributionException("prepareRename");
+        return interruptible(URIUtil.unknownLocation());
     }
 
     @Override
     public InterruptibleFuture<ITuple> rename(IList focus, String name) {
-        throw new NoContributionException("rename");
+        return interruptible(VF.tuple(VF.list(), VF.set()));
     }
 
     @Override
     public InterruptibleFuture<ITuple> didRenameFiles(IList fileRenames) {
-        throw new NoContributionException("didRenameFiles");
+        return interruptible(VF.tuple(VF.list(), VF.set()));
     }
 
     @Override
     public InterruptibleFuture<IList> prepareCallHierarchy(IList focus) {
-        throw new NoContributionException("prepareCallHierarchy");
+        return interruptible(VF.list());
     }
 
     @Override
     public InterruptibleFuture<IList> incomingOutgoingCalls(IConstructor hierarchyItem, IConstructor direction) {
-        throw new NoContributionException("incomingOutgoingCalls");
+        return interruptible(VF.list());
     }
 
     @Override
     public CompletableFuture<IList> parseCodeActions(String command) {
-        throw new NoContributionException("parseCodeActions");
+        return completable(VF.list());
     }
 
     @Override
     public CompletableFuture<IConstructor> parseCallHierarchyData(String data) {
-        throw new NoContributionException("parseCallHierarchyData");
+        // This should only be called on the same contributions on which `callHierarchy` was called. It parses some data from the call hierarchy.
+        // Since our `callHierarchy` return nothing, this should really never be called. There is also no sensible default.
+        // Hence, we throw an exception here.
+        return CompletableFuture.failedFuture(new NoContributionException("parseCallHierarchyData"));
     }
 
     @Override
     public InterruptibleFuture<IList> completion(IList focus, IInteger cursorOffset, IConstructor trigger) {
-        throw new NoContributionException("completion");
+        return interruptible(VF.list());
     }
 
     @Override
     public CompletableFuture<IList> completionTriggerCharacters() {
-        throw new NoContributionException("completionTriggerCharacters");
+        return completable(VF.list());
     }
 
     @Override
@@ -266,17 +286,17 @@ public class NoContributions implements ILanguageContributions {
 
     @Override
     public CompletableFuture<SummaryConfig> getAnalyzerSummaryConfig() {
-        throw new NoContributionException("getAnalyzerSummaryConfig");
+        return completable(SummaryConfig.FALSY);
     }
 
     @Override
     public CompletableFuture<SummaryConfig> getBuilderSummaryConfig() {
-        throw new NoContributionException("getBuilderSummaryConfig");
+        return completable(SummaryConfig.FALSY);
     }
 
     @Override
     public CompletableFuture<SummaryConfig> getOndemandSummaryConfig() {
-        throw new NoContributionException("getOndemandSummaryConfig");
+        return completable(SummaryConfig.FALSY);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -323,6 +323,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public void initialized() {
         if (dedicatedLanguage != null) {
             // if there was one scheduled, we now start it up, since the connection has been made
+            // and the client and capabilities are initialized
             this.registerLanguage(dedicatedLanguage);
         }
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -878,7 +878,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         ILanguageContributions contrib = contributions(loc);
         TextDocumentState file = getFile(loc);
 
-        CompletableFuture<Function<IList, CompletableFuture<IList>>> computeSelection = contrib.hasSelectionRange().thenApply(hasDef -> {
+        CompletableFuture<Function<IList, CompletableFuture<IList>>> computeSelection = contrib.providesSelectionRange().thenApply(hasDef -> {
             if (!hasDef.booleanValue()) {
                 logger.debug("Selection range not implemented; falling back to default implementation ({})", params.getTextDocument());
                 return focus -> CompletableFutureUtils.completedFuture(SelectionRanges.uniqueTreeLocations(focus), exec);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -317,16 +317,14 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public void connect(LanguageClient client) {
         this.client = client;
         facts.values().forEach(v -> v.setClient(client));
-        if (dedicatedLanguage != null) {
-            // if there was one scheduled, we now start it up, since the connection has been made
-            this.registerLanguage(dedicatedLanguage);
-        }
     }
 
     @Override
     public void initialized() {
-        // reserved for future use
-        // e.g. dynamic registration of capabilities
+        if (dedicatedLanguage != null) {
+            // if there was one scheduled, we now start it up, since the connection has been made
+            this.registerLanguage(dedicatedLanguage);
+        }
     }
 
     // LSP interface methods

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -45,6 +45,7 @@ import org.rascalmpl.values.functions.IFunction;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.ParserSpecification;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
+import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.ISourceLocation;
@@ -113,6 +114,31 @@ public class ParserOnlyContribution extends NoContributions {
     @Override
     public CompletableFuture<Boolean> specialCaseHighlighting() {
         return specialCaseHighlighting;
+    }
+
+    @Override
+    public InterruptibleFuture<IConstructor> analysis(ISourceLocation loc, ITree input) {
+        return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc), exec);
+    }
+
+    @Override
+    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
+        return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc), exec);
+    }
+
+    @Override
+    public CompletableFuture<SummaryConfig> getAnalyzerSummaryConfig() {
+        return CompletableFutureUtils.completedFuture(SummaryConfig.FALSY, exec);
+    }
+
+    @Override
+    public CompletableFuture<SummaryConfig> getBuilderSummaryConfig() {
+        return CompletableFutureUtils.completedFuture(SummaryConfig.FALSY, exec);
+    }
+
+    @Override
+    public CompletableFuture<SummaryConfig> getOndemandSummaryConfig() {
+        return CompletableFutureUtils.completedFuture(SummaryConfig.FALSY, exec);
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParserOnlyContribution.java
@@ -45,7 +45,6 @@ import org.rascalmpl.values.functions.IFunction;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.ParserSpecification;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
-import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.ISourceLocation;
@@ -114,31 +113,6 @@ public class ParserOnlyContribution extends NoContributions {
     @Override
     public CompletableFuture<Boolean> specialCaseHighlighting() {
         return specialCaseHighlighting;
-    }
-
-    @Override
-    public InterruptibleFuture<IConstructor> analysis(ISourceLocation loc, ITree input) {
-        return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc), exec);
-    }
-
-    @Override
-    public InterruptibleFuture<IConstructor> build(ISourceLocation loc, ITree input) {
-        return InterruptibleFuture.completedFuture(EmptySummary.newInstance(loc), exec);
-    }
-
-    @Override
-    public CompletableFuture<SummaryConfig> getAnalyzerSummaryConfig() {
-        return CompletableFutureUtils.completedFuture(SummaryConfig.FALSY, exec);
-    }
-
-    @Override
-    public CompletableFuture<SummaryConfig> getBuilderSummaryConfig() {
-        return CompletableFutureUtils.completedFuture(SummaryConfig.FALSY, exec);
-    }
-
-    @Override
-    public CompletableFuture<SummaryConfig> getOndemandSummaryConfig() {
-        return CompletableFutureUtils.completedFuture(SummaryConfig.FALSY, exec);
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CompletionCapability.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CompletionCapability.java
@@ -69,7 +69,7 @@ public class CompletionCapability extends AbstractDynamicCapability<CompletionRe
 
     @Override
     protected CompletableFuture<Boolean> isProvidedBy(ICapabilityParams params) {
-        return params.contributions().hasCompletion();
+        return params.contributions().providesCompletion();
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/concurrent/InterruptibleFuture.java
@@ -98,6 +98,10 @@ public class InterruptibleFuture<T> {
         return new InterruptibleFuture<>(CompletableFutureUtils.completedFuture(result, exec), () -> {});
     }
 
+    public static <T> InterruptibleFuture<T> failedFuture(Throwable ex) {
+        return new InterruptibleFuture<>(CompletableFuture.failedFuture(ex), () -> {});
+    }
+
     /**
      * Turn an completable future with a interruptible future inside into a
      * normal interruptible future by inlining them

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistrationTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistrationTest.java
@@ -150,7 +150,7 @@ public class CapabilityRegistrationTest {
         }
 
         @Override
-        public CompletableFuture<Boolean> hasCompletion() {
+        public CompletableFuture<Boolean> providesCompletion() {
             return CompletableFutureUtils.completedFuture(true, exec);
         }
 


### PR DESCRIPTION
This PR fixes exceptions during registration of a language with a pre-compiled parser, which was introduced in #893.

1. Always return a default value for any contribution, even if it not provided by the language.
2. Rename `hasContribution` -> `providesContribution` to match the above semantic.
3. Improve logging of when the default contribution is used.
4. For dedicated parametric language servers  (i.e. pre-built single language extensions), postpone language registration until after the client is connected, fixing an exception during dynamic capability registration.

Fixes #1018.