### PR TITLE
Fix Json configuration for language servers to encode complex values as Json objects

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseLanguageServer.java
@@ -117,7 +117,7 @@ public abstract class BaseLanguageServer {
             .setRemoteInterface(IBaseLanguageClient.class)
             .setInput(in)
             .setOutput(out)
-            .configureGson(GsonUtils.complexAsBase64String())
+            .configureGson(GsonUtils.complexAsJsonObject())
             .setExecutorService(threadPool)
             .create();
 


### PR DESCRIPTION
The language servers in the rascal-lsp project were encoding complex values as Base64-encoded strings for transport over json-rpc, whereas such values should have been (and had been) encoded as Json objects. This was an [accidental change](https://github.com/usethesource/rascal-language-servers/commit/de2c22e21397dce1133c6d733526295460e3f53d) and this PR reverts that.