### PR TITLE
Run UI test on Ubuntu 22.04 again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
   ui-test:
     strategy:
       matrix:
-        os: [ubicloud-standard-4, windows-latest, macos-latest]
+        os: [ubicloud-standard-4-ubuntu-2204, windows-latest, macos-latest]
       fail-fast: true
     env:
       CODE_VERSION: "1.90.2"


### PR DESCRIPTION
Since 24.04 results in many (unpredictable) failures (see experiments [here](https://github.com/usethesource/rascal-language-servers/pull/1040)), we revert to 22.04 until we can practically use 24.04.