### PR TITLE
Fix use-before-initialize (NPE) in `TextDocumentState`

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -62,6 +63,7 @@ public class TextDocumentState {
 
     private final BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser;
     private final ISourceLocation location;
+    private final ExecutorService exec;
 
     private final AtomicReference<Versioned<Update>> current;
     private final AtomicReference<@Nullable Versioned<ITree>> lastWithoutErrors;
@@ -70,12 +72,14 @@ public class TextDocumentState {
     public TextDocumentState(
             BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser,
             ISourceLocation location,
-            int initialVersion, String initialContent, long initialTimestamp) {
+            int initialVersion, String initialContent, long initialTimestamp,
+            ExecutorService exec) {
 
         this.parser = parser;
         this.location = location;
         this.lastWithoutErrors = new AtomicReference<>();
         this.last = new AtomicReference<>();
+        this.exec = exec;
 
         var u = new Update(initialVersion, initialContent, initialTimestamp);
         this.current = new AtomicReference<>(new Versioned<>(initialVersion, u));
@@ -200,7 +204,7 @@ public class TextDocumentState {
         private void parse() {
             try {
                 parser.apply(location, content)
-                    .whenComplete((ITree t, Throwable e) -> {
+                    .whenCompleteAsync((ITree t, Throwable e) -> {
                         if (e instanceof CompletionException && e.getCause() != null) {
                             e = e.getCause();
                         }
@@ -221,7 +225,7 @@ public class TextDocumentState {
                         // Complete future to get diagnostics
                         var diagnostics = new Versioned<>(version, diagnosticsList);
                         diagnosticsAsync.complete(diagnostics);
-                    });
+                    }, exec);
             } catch (NoContributionException e) {
                 logger.debug("Ignoring missing parser for {}", location, e);
                 treeAsync.completeOnTimeout(new Versioned<>(version, IRascalValueFactory.getInstance().character(0), timestamp), 60, TimeUnit.SECONDS);
@@ -255,6 +259,6 @@ public class TextDocumentState {
 
     public TextDocumentState changeParser(BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parsing) {
         var c = getCurrentContent();
-        return new TextDocumentState(parsing, this.location, c.version(), c.get(), getLastModified());
+        return new TextDocumentState(parsing, this.location, c.version(), c.get(), getLastModified(), exec);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -230,7 +230,7 @@ public class TextDocumentState {
                             // The action of `whenCompleteAsync` shouldn't throw an exception (see JavaDoc): if it
                             // unexpectedly does, then it is almost surely a bug, but the exception is swallowed, so it
                             // is very hard to debug. The try/catch block and logger call aim to make it easier.
-                            logger.error("Unexpected exception after parsing: {}", exc);
+                            logger.error("Unexpected exception after parsing", exc);
                         }
                     }, exec);
             } catch (NoContributionException e) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -205,26 +205,33 @@ public class TextDocumentState {
             try {
                 parser.apply(location, content)
                     .whenCompleteAsync((ITree t, Throwable e) -> {
-                        if (e instanceof CompletionException && e.getCause() != null) {
-                            e = e.getCause();
-                        }
-                        var diagnosticsList = toDiagnosticsList(t, e); // `t` and `e` are nullable
-
-                        // Complete future to get the tree
-                        if (t == null) {
-                            treeAsync.completeExceptionally(e);
-                        } else {
-                            var tree = new Versioned<>(version, t, timestamp);
-                            Versioned.replaceIfNewer(last, tree);
-                            if (diagnosticsList.isEmpty()) {
-                                Versioned.replaceIfNewer(lastWithoutErrors, tree);
+                        try {
+                            if (e instanceof CompletionException && e.getCause() != null) {
+                                e = e.getCause();
                             }
-                            treeAsync.complete(tree);
-                        }
+                            var diagnosticsList = toDiagnosticsList(t, e); // `t` and `e` are nullable
 
-                        // Complete future to get diagnostics
-                        var diagnostics = new Versioned<>(version, diagnosticsList);
-                        diagnosticsAsync.complete(diagnostics);
+                            // Complete future to get the tree
+                            if (t == null) {
+                                treeAsync.completeExceptionally(e);
+                            } else {
+                                var tree = new Versioned<>(version, t, timestamp);
+                                Versioned.replaceIfNewer(last, tree);
+                                if (diagnosticsList.isEmpty()) {
+                                    Versioned.replaceIfNewer(lastWithoutErrors, tree);
+                                }
+                                treeAsync.complete(tree);
+                            }
+
+                            // Complete future to get diagnostics
+                            var diagnostics = new Versioned<>(version, diagnosticsList);
+                            diagnosticsAsync.complete(diagnostics);
+                        } catch (Exception exc) {
+                            // The action of `whenCompleteAsync` shouldn't throw an exception (see JavaDoc): if it
+                            // unexpectedly does, then it is almost surely a bug, but the exception is swallowed, so it
+                            // is very hard to debug. The try/catch block and logger call aim to make it easier.
+                            logger.error("Unexpected exception after parsing: {}", exc);
+                        }
                     }, exec);
             } catch (NoContributionException e) {
                 logger.debug("Ignoring missing parser for {}", location, e);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -74,11 +74,11 @@ public class TextDocumentState {
 
         this.parser = parser;
         this.location = location;
+        this.lastWithoutErrors = new AtomicReference<>();
+        this.last = new AtomicReference<>();
 
         var u = new Update(initialVersion, initialContent, initialTimestamp);
         this.current = new AtomicReference<>(new Versioned<>(initialVersion, u));
-        this.lastWithoutErrors = new AtomicReference<>();
-        this.last = new AtomicReference<>();
     }
 
     public ISourceLocation getLocation() {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -713,7 +713,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
 
     private TextDocumentState open(TextDocumentItem doc, long timestamp) {
         return files.computeIfAbsent(Locations.toLoc(doc),
-            l -> new TextDocumentState(contributions(l)::parsing, l, doc.getVersion(), doc.getText(), timestamp));
+            l -> new TextDocumentState(contributions(l)::parsing, l, doc.getVersion(), doc.getText(), timestamp, exec));
     }
 
     private TextDocumentState getFile(ISourceLocation loc) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -557,7 +557,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     private TextDocumentState open(TextDocumentItem doc, long timestamp) {
         return documents.computeIfAbsent(Locations.toLoc(doc),
-            l -> new TextDocumentState(availableRascalServices()::parseSourceFile, l, doc.getVersion(), doc.getText(), timestamp));
+            l -> new TextDocumentState(availableRascalServices()::parseSourceFile, l, doc.getVersion(), doc.getText(), timestamp, exec));
     }
 
     private TextDocumentState getFile(TextDocumentIdentifier doc) {


### PR DESCRIPTION
The UI tests on Ubuntu have become flaky (#1034 and #1037). This PR fixes a bug in the constructor of `TextDocumentState` to remove one cause of the flakiness.

### Problem

Before this PR, the constructor of `TextDocumentState`:
 1. Creates an initial `Update` object. The constructor of `Update`:
     1. Submits the parse call for the initial content to the worker pool.
     2. After parsing, stores the tree in an `AtomicReference` field of `TextDocumentState`.
 2. Initializes an `AtomicReference` object to store a tree after parsing.

Due to scheduling, it could happen that step 1.ii was executed before step 2. In that case, an NPE occurs, as an attempt is made to set the `AtomicReference` with the tree, but it hasn't been initialized yet. This NPE is swallowed inside a completion stage, though, so only the fallout (of not having stored the tree) is observable -- this is what happened in the UI tests.

### Solution

This PR:
  - Makes sure that the `AtomicReference` object is initialized before use. This addresses the root cause of the issue.
  - Makes sure that the post-parsing logic is executed in the worker pool (instead of the request pool). This doesn't address the root cause of the issue, but it is adjacent to it.
  - Improves exception reporting to make future debugging easier.

Related PRs (subsumed by this PR):
 - Fix that didn't work: #1051
 - Debugging: #1040