### PR TITLE
switched parameter order of rascal/edit event to fix #1049

### DIFF
--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -63,7 +63,7 @@ export async function activateLanguageClient(
     });
 
 
-    client.onNotification("rascal/editDocument", (uri: string, viewColumn: integer, range: vscode.Range) => {
+    client.onNotification("rascal/editDocument", (uri: string, range: vscode.Range, viewColumn: integer) => {
         openEditor(uri, range, viewColumn);
     });
 
@@ -127,9 +127,11 @@ async function openEditor(uriString: string, range:vscode.Range, viewColumn: int
         // don't use the `selection` field here because we can not control scrolling behavior from that with editors which are already open
     });
 
-    // set the primary selection and move it into view (but don't scroll unless necessary)
-    editor.selection = new vscode.Selection(range.start, range.end);
-    editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    if (range !== null) {
+        // set the primary selection and move it into view (but don't scroll unless necessary)
+        editor.selection = new vscode.Selection(range.start, range.end);
+        editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    }
 }
 
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -111,7 +111,7 @@ async function showContentPanel(url: string, title:string, viewColumn:integer): 
     contentPanels.set(id, panel);
 }
 
-async function openEditor(uriString: string, range:vscode.Range, viewColumn: integer) {
+async function openEditor(uriString: string, range: vscode.Range | undefined, viewColumn: integer) {
     const uri = vscode.Uri.parse(uriString);
 
     const doc = await vscode.workspace.openTextDocument(uri);

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -127,7 +127,7 @@ async function openEditor(uriString: string, range: vscode.Range | undefined, vi
         // don't use the `selection` field here because we can not control scrolling behavior from that with editors which are already open
     });
 
-    if (range !== null) {
+    if (range !== undefined) {
         // set the primary selection and move it into view (but don't scroll unless necessary)
         editor.selection = new vscode.Selection(range.start, range.end);
         editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -63,7 +63,7 @@ export async function activateLanguageClient(
     });
 
 
-    client.onNotification("rascal/editDocument", (uri: string, range: vscode.Range, viewColumn: integer) => {
+    client.onNotification("rascal/editDocument", (uri: string, range: vscode.Range | undefined, viewColumn: integer) => {
         openEditor(uri, range, viewColumn);
     });
 


### PR DESCRIPTION
Fixes #1049 which has downstream (unreported) issues in uses of IDEServices::edit in vis::Graph and vis::Chart, salix en salix-contrib, and drAmbiguity.