### PR TITLE
Fix parametric completion tests

### DIFF
--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -41,6 +41,7 @@ import util::Reflective;
 extend lang::pico::\syntax::Main;
 import DateTime;
 import IO;
+import List;
 import Location;
 import String;
 
@@ -317,7 +318,7 @@ list[CompletionItem] picoCompletionService(Focus focus, int cursorOffset, Comple
     t = focus[0];
     str prefix = "<t>"[..cursorOffset];
     cc = t.src.begin.column + cursorOffset;
-    items = [];
+    list[CompletionItem] items = [];
 
     isTypingId = false;
     try {
@@ -339,7 +340,7 @@ list[CompletionItem] picoCompletionService(Focus focus, int cursorOffset, Comple
         }
     }
 
-    return items;
+    return sort(items, bool(CompletionItem i1, CompletionItem i2) {return i1.label < i2.label; });
 }
 
 @synopsis{The main function registers the Pico language with the IDE}

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -322,7 +322,7 @@ end
         const editor = await ide.openModule(TestWorkspace.picoFile);
         await editor.moveCursor(10, 10);
         await editor.typeText("  x :=");
-        await expectCompletions(editor, ["x", "n", "a", "b"]);
+        await expectCompletions(editor, ["a", "b", "n", "x"]);
     });
 
     it("serializes Rascal values as expected", async function() {

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -312,7 +312,7 @@ end
 
         await editor.moveCursor(9, 4);
         await bench.executeCommand("editor.action.triggerSuggest"); // 'completion', typically triggered with Ctrl+Space
-        expectCompletions(editor, ["a", "aa"]);
+        await expectCompletions(editor, ["a", "aa"]);
     });
 
     it("completion by trigger character works", async function() {
@@ -322,7 +322,7 @@ end
         const editor = await ide.openModule(TestWorkspace.picoFile);
         await editor.moveCursor(10, 10);
         await editor.typeText("  x :=");
-        expectCompletions(editor, ["x", "n", "a", "b"]);
+        await expectCompletions(editor, ["x", "n", "a", "b"]);
     });
 
     it("serializes Rascal values as expected", async function() {

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -312,7 +312,7 @@ end
 
         await editor.moveCursor(9, 4);
         await bench.executeCommand("editor.action.triggerSuggest"); // 'completion', typically triggered with Ctrl+Space
-        await expectCompletions(editor, ["a", "aa"]);
+        await expectCompletions(driver, editor, ["a", "aa"]);
     });
 
     it("completion by trigger character works", async function() {
@@ -322,7 +322,7 @@ end
         const editor = await ide.openModule(TestWorkspace.picoFile);
         await editor.moveCursor(10, 10);
         await editor.typeText("  x :=");
-        await expectCompletions(editor, ["a", "b", "n", "x"]);
+        await expectCompletions(driver, editor, ["a", "b", "n", "x"]);
     });
 
     it("serializes Rascal values as expected", async function() {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -538,10 +538,13 @@ export function printRascalOutputOnFailure(channel: 'Language Parametric Rascal'
     });
 }
 
-export async function expectCompletions(editor: TextEditor, expectedLabels: string[]) {
-    const completionMenu = new ContentAssist(editor);
-    const completions = await completionMenu.getItems();
+export async function expectCompletions(driver: WebDriver, editor: TextEditor, expectedLabels: string[]) {
+    const completions = await driver.wait(async () => {
+        const completionMenu = new ContentAssist(editor);
+        return await ignoreFails(completionMenu.getItems());
+    }, Delays.fast, "Completion items not found");
+
     expect(completions).to.have.length(expectedLabels.length);
-    const labels: string[] = await Promise.all(completions.map(c => c.getLabel()));
-    expect(labels).to.deep.equal(expectedLabels);
+    const labels: string[] = await Promise.all(completions!.map(c => c.getLabel()));
+    expect(labels).deep.equal(expectedLabels);
 }


### PR DESCRIPTION
This fixes the always-succeeding completion tests by awaiting the promises where asserts on the completion suggestions are done. It also sorts the completion suggests of the example in a predictable order.

Discovered in #1060, where breaking completion functionality did not make the tests fail. This is another instance of #1062.