### PR TITLE
Lint & fix floating+misused promises

### DIFF
--- a/rascal-vscode-extension/.eslintrc.json
+++ b/rascal-vscode-extension/.eslintrc.json
@@ -3,7 +3,8 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": 6,
-        "sourceType": "module"
+        "sourceType": "module",
+        "project": true
     },
     "plugins": [
         "@typescript-eslint",
@@ -24,6 +25,8 @@
         "@typescript-eslint/naming-convention": "warn",
         "@typescript-eslint/semi": "warn",
         "@typescript-eslint/no-unused-vars": [ "warn", { "varsIgnorePattern": "^_",  "argsIgnorePattern": "^_"  } ],
+        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/no-misused-promises": "error",
         "curly": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -55,7 +55,7 @@ export class RascalExtension implements vscode.Disposable {
         this.registerMainRun();
         this.registerImportModule();
         this.registerCopySourceLocationCommand();
-        checkForJVMUpdate();
+        void checkForJVMUpdate();
 
         vscode.window.registerTreeDataProvider('rascalmpl-configuration-view', new RascalLibraryProvider(this.rascal.rascalClient, this.log));
         vscode.window.registerTreeDataProvider('rascalmpl-debugger-view', new RascalDebugViewProvider(this.rascal.rascalDebugClient, context));
@@ -84,7 +84,7 @@ export class RascalExtension implements vscode.Disposable {
     private registerTerminalCommand() {
         this.context.subscriptions.push(
             vscode.commands.registerCommand("rascalmpl.createTerminal", () => {
-                this.startTerminal(vscode.window.activeTextEditor?.document.uri);
+                void this.startTerminal(vscode.window.activeTextEditor?.document.uri);
             })
         );
     }
@@ -95,7 +95,7 @@ export class RascalExtension implements vscode.Disposable {
                 if (!text.document.uri || !moduleName) {
                     return;
                 }
-                this.startTerminal(text.document.uri, `import ${moduleName};\nmain();\n`);
+                void this.startTerminal(text.document.uri, `import ${moduleName};\nmain();\n`);
             })
         );
     }
@@ -107,7 +107,7 @@ export class RascalExtension implements vscode.Disposable {
                 if (!text.document.uri || !moduleName) {
                     return;
                 }
-                this.startTerminal(text.document.uri, `import ${moduleName};\n`);
+                void this.startTerminal(text.document.uri, `import ${moduleName};\n`);
             })
         );
     }

--- a/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
+++ b/rascal-vscode-extension/src/auto-jvm/JavaLookup.ts
@@ -190,7 +190,7 @@ async function downloadJDK(): Promise<string> {
     }
 
     const result = await downloadJDKWithProgress(choice);
-    vscode.window.showInformationMessage(`Finished downloading ${choice} JDK, Rascal will now start`);
+    void vscode.window.showInformationMessage(`Finished downloading ${choice} JDK, Rascal will now start`);
     return result;
 }
 
@@ -229,7 +229,7 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
                     const latest = await dl.identifyLatestTemurinLTSRelease(currentPreferredJVMEngine, dl.mapTemuringCorrettoArch(), dl.mapTemurinPlatform());
                     const currentVersion = "jdk-"+releaseInfo.java_runtime_version;
                     if(currentVersion !== latest){
-                        askUserForJVMUpdate(temurin, latest, currentVersion);
+                        void askUserForJVMUpdate(temurin, latest, currentVersion);
                     }
                     return;
                 }
@@ -239,7 +239,7 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
                     }
                     const latest = await dl.identifyLatestMicrofotJDKRelease(currentPreferredJVMEngine, dl.mapMSArchitectures(), dl.mapMSPlatforms());
                     if(releaseInfo.java_version !== latest){
-                        askUserForJVMUpdate(msJava, latest, releaseInfo.java_version);
+                        void askUserForJVMUpdate(msJava, latest, releaseInfo.java_version);
                     }
                     return;
                 }
@@ -250,7 +250,7 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
                     const latest = await dl.identifyLatestCorrettoRelease(currentPreferredJVMEngine, dl.mapTemuringCorrettoArch(), dl.mapCorrettoPlatform());
                     const currentVersion = releaseInfo.implementor_version.slice(9);
                     if(currentVersion !== latest){
-                        askUserForJVMUpdate(amazon, latest, currentVersion);
+                        void askUserForJVMUpdate(amazon, latest, currentVersion);
                     }
                     return;
                 }
@@ -259,11 +259,11 @@ export async function checkForJVMUpdate(mainJVMsPath:string = mainJVMPath){
     }
 }
 
-export function askUserForJVMUpdate(jdktype: string, newVersion: string, currentVersion: string){
-    vscode.window.showInformationMessage(`Rascal VS Code extension has previously downloaded a ${jdktype} distribution of the OpenJDK (${currentVersion}). There is a new update (${newVersion}). In general the update contains bugfixes and security patches. Should we install the update?`, ...["Install update", "Do not update"]).then(async ans => {
+export async function askUserForJVMUpdate(jdktype: string, newVersion: string, currentVersion: string){
+    await vscode.window.showInformationMessage(`Rascal VS Code extension has previously downloaded a ${jdktype} distribution of the OpenJDK (${currentVersion}). There is a new update (${newVersion}). In general the update contains bugfixes and security patches. Should we install the update?`, ...["Install update", "Do not update"]).then(async ans => {
         if(ans === "Install update"){
             await downloadJDKWithProgress(jdktype);
-            vscode.window.showInformationMessage(`Finished updating ${jdktype} JDK. The new version will be used for the next VS Code session.`);
+            await vscode.window.showInformationMessage(`Finished updating ${jdktype} JDK. The new version will be used for the next VS Code session.`);
         }
     });
 }

--- a/rascal-vscode-extension/src/auto-jvm/downloaders.ts
+++ b/rascal-vscode-extension/src/auto-jvm/downloaders.ts
@@ -368,6 +368,7 @@ async function fetchUnpackZipInMemory(url: string, subpath: string, mainJVMPath:
     }
     return new Promise((resolve, reject) => {
         let detectedRootPath = "";
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         zipFile.on("entry", async (entry: yauzl.Entry) => {
             progress(50 / zipFile.entryCount, "Unpacking zip file");
 

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -73,7 +73,7 @@ export class RascalDebugClient {
 
     async startDebuggingSession(serverPort: number){
         const conf: DebugConfiguration = {type: "rascalmpl", name: "Rascal debugger", request: "attach", serverPort: serverPort};
-        debug.startDebugging(undefined, conf);
+        await debug.startDebugging(undefined, conf);
     }
 
     registerDebugServerPort(processID: number, serverPort: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -47,7 +47,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         this.context.subscriptions.push(
             vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
                 if (replNode.serverPort !== undefined) {
-                    this.rascalDebugClient.startDebuggingSession(replNode.serverPort);
+                    void this.rascalDebugClient.startDebuggingSession(replNode.serverPort);
                 }
             }, this)
         );

--- a/rascal-vscode-extension/src/fs/RascalFileSystemProviders.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemProviders.ts
@@ -96,14 +96,14 @@ export class RascalFileSystemProvider implements vscode.FileSystemProvider {
     }
 
     watch(uri: vscode.Uri, options: { recursive: boolean; excludes: string[]; }): vscode.Disposable {
-        this.sendRequest(uri, "rascal/filesystem/watch", <WatchParameters>{
+        void this.sendRequest(uri, "rascal/filesystem/watch", <WatchParameters>{
             uri: uri.toString(),
             recursive:options.recursive,
             excludes: options.excludes
         });
 
-        return new vscode.Disposable(() => {
-            this.sendRequest(uri, "rascal/filesystem/unwatch", {
+        return new vscode.Disposable(async () => {
+            await this.sendRequest(uri, "rascal/filesystem/unwatch", {
                 uri: uri.toString()
             });
         });

--- a/rascal-vscode-extension/src/fs/VSCodeURIResolver.ts
+++ b/rascal-vscode-extension/src/fs/VSCodeURIResolver.ts
@@ -122,7 +122,7 @@ export interface WatchEventReceiver {
 function buildWatchReceiver(connection: rpc.MessageConnection) : WatchEventReceiver {
     return {
         emitWatch : (e) => {
-            connection.sendNotification(new rpc.NotificationType1<ISourceLocationChanged>("rascal/vfs/watcher/emitWatch"), e);
+            void connection.sendNotification(new rpc.NotificationType1<ISourceLocationChanged>("rascal/vfs/watcher/emitWatch"), e);
         }
     };
 }
@@ -262,7 +262,7 @@ class ResolverClient implements VSCodeResolverServer, Disposable  {
         this.fs = vscode.workspace.fs;
         this.connection = connection;
         if (debug) {
-            connection.trace(rpc.Trace.Verbose, {
+            void connection.trace(rpc.Trace.Verbose, {
                 log: (a) => {
                     this.logger.debug("[VFS]: " + a);
                 }

--- a/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
+++ b/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
@@ -114,7 +114,7 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
             // Do nothing for now. this::setClient will take care of this once the client is available.
             return;
         }
-        this.client.sendNotification("rascal/logLevel", newLevel);
+        void this.client.sendNotification("rascal/logLevel", newLevel);
     }
 
     private printLogOutput(loglevel: LogLevel, message: string) {

--- a/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
@@ -55,7 +55,7 @@ export class ParameterizedLanguageServer implements vscode.Disposable {
                     // so we wait 1ms just to be sure we're not triggering an endless loop.
                     setTimeout(() => {
                         if (!e.isClosed && e.languageId !== this.languageId) {
-                            vscode.languages.setTextDocumentLanguage(e, this.languageId);
+                            void vscode.languages.setTextDocumentLanguage(e, this.languageId);
                         }
                     }, 1);
                 }
@@ -63,11 +63,11 @@ export class ParameterizedLanguageServer implements vscode.Disposable {
         }
         else {
             // trigger creating of dedicated instance
-            this.getLanguageClient();
+            void this.getLanguageClient();
         }
     }
     dispose() {
-        this.parametricClient?.then(c => c.dispose());
+        void this.parametricClient?.then(c => c.dispose());
     }
 
     private activateParametricLanguageClient(): Promise<BaseLanguageClient> {
@@ -121,7 +121,7 @@ export class ParameterizedLanguageServer implements vscode.Disposable {
 
     async unregisterLanguage(lang: LanguageParameter) {
         const client = this.getLanguageClient();
-        (await client).sendRequest("rascal/sendUnregisterLanguage", lang);
+        void (await client).sendRequest("rascal/sendUnregisterLanguage", lang);
 
         if (this.dedicatedLanguage === undefined) {
             for (const ext of lang.extensions) {

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -54,22 +54,22 @@ export async function activateLanguageClient(
 
     await client.start();
     logger.setClient(client);
-    client.sendNotification("rascal/vfs/register", {
+    void client.sendNotification("rascal/vfs/register", {
         port: await vfsServer.serverPort
     });
 
     client.onNotification("rascal/showContent", (uri: string, title: string, viewColumn: integer) => {
-        showContentPanel(uri, title, viewColumn);
+        void showContentPanel(uri, title, viewColumn);
     });
 
 
     client.onNotification("rascal/editDocument", (uri: string, range: vscode.Range | undefined, viewColumn: integer) => {
-        openEditor(uri, range, viewColumn);
+        void openEditor(uri, range, viewColumn);
     });
 
     const schemesReply = client.sendRequest<string[]>("rascal/filesystem/schemes");
 
-    schemesReply.then( schemes => {
+    void schemesReply.then( schemes => {
         vfsServer.ignoreSchemes(schemes);
         new RascalFileSystemProvider(client, logger).tryRegisterSchemes(schemes);
     });

--- a/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
@@ -62,9 +62,9 @@ export class RascalLanguageServer implements vscode.Disposable {
 
         this.languageRegistry = new LanguageRegistry(dslLSP, logger);
 
-        this.rascalClient.then(client => {
+        void this.rascalClient.then(client => {
             client.onNotification("rascal/startDebuggingSession", (serverPort:number) => {
-                this.rascalDebugClient.startDebuggingSession(serverPort);
+                void this.rascalDebugClient.startDebuggingSession(serverPort);
             });
             client.onNotification("rascal/registerDebugServerPort", (processID:number, serverPort:number) => {
                 this.rascalDebugClient.registerDebugServerPort(processID, serverPort);
@@ -72,7 +72,7 @@ export class RascalLanguageServer implements vscode.Disposable {
         });
     }
     dispose() {
-        this.rascalClient.then(c => c.dispose());
+        void this.rascalClient.then(c => c.dispose());
         this.languageRegistry.dispose();
     }
 }

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -247,7 +247,7 @@ end
         const editor = await ide.openModule(TestWorkspace.picoFile);
         await editor.moveCursor(5, 6);
 
-        ide.renameSymbol(editor, bench, "z");
+        await ide.renameSymbol(editor, bench, "z");
 
         await driver.wait(() => (editor.isDirty()), Delays.extremelySlow, "Rename should have resulted in changes in the editor");
 

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -196,7 +196,7 @@ describe('IDE', function () {
         const checkRascalStatus = ide.statusContains("Loading Rascal");
         await driver.wait(async () => !(await checkRascalStatus()), Delays.extremelySlow, "Rascal evaluators have not finished loading");
 
-        ide.renameSymbol(editor, bench, "i");
+        await ide.renameSymbol(editor, bench, "i");
 
         await driver.wait(() => (editor.isDirty()), Delays.extremelySlow, "Rename should have resulted in changes in the editor");
 

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -283,7 +283,7 @@ export class IDEOperations {
                 await new Workbench().executeCommand("workbench.action.revertAndCloseActiveEditor");
             } catch (ex) {
                 const title = ignoreFails(new TextEditor().getTitle()) ?? 'unknown';
-                this.screenshot(`revert of ${title} failed ` + tryCount);
+                await this.screenshot(`revert of ${title} failed ` + tryCount);
                 console.log(`Revert of ${title} failed, but we ignore it`, ex);
             }
             try {
@@ -299,7 +299,7 @@ export class IDEOperations {
                 return !(await new TextEditor().isDirty());
             }
             catch (ignored) {
-                this.screenshot("open editor check failed " + tryCount);
+                await this.screenshot("open editor check failed " + tryCount);
                 console.log("Open editor dirty check failed: ", ignored);
                 return false;
 

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -45,7 +45,7 @@ export class RascalMFValidator implements vscode.Disposable {
         vscode.workspace.onDidChangeWorkspaceFolders(async ws => {
             for (const added of ws.added) {
                 if (await isRascalProject(added.uri)) {
-                    this.verifyRascalMF(added.uri);
+                    await this.verifyRascalMF(added.uri);
                 }
             }
             for (const rem of ws.removed) {
@@ -57,7 +57,7 @@ export class RascalMFValidator implements vscode.Disposable {
         // also at the start, check the already opened folders
         for (const openProject of vscode.workspace.workspaceFolders || []) {
             const mfURI = buildMFChildPath(openProject.uri);
-            vscode.workspace.fs.stat(mfURI).then(_s => this.verifyRascalMF(mfURI));
+            void vscode.workspace.fs.stat(mfURI).then(_s => void this.verifyRascalMF(mfURI));
         }
 
         // all changed files should be checked on save (for example a git pull)

--- a/rascal-vscode-extension/src/ux/RascalMFValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalMFValidator.ts
@@ -45,7 +45,7 @@ export class RascalMFValidator implements vscode.Disposable {
         vscode.workspace.onDidChangeWorkspaceFolders(async ws => {
             for (const added of ws.added) {
                 if (await isRascalProject(added.uri)) {
-                    await this.verifyRascalMF(added.uri);
+                    void this.verifyRascalMF(added.uri);
                 }
             }
             for (const rem of ws.removed) {

--- a/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
+++ b/rascal-vscode-extension/src/ux/RascalProjectValidator.ts
@@ -51,21 +51,22 @@ export class RascalProjectValidator implements vscode.Disposable {
         watcher.onDidChange(this.rascalMFChanged, this, this.toDispose);
         watcher.onDidDelete(this.rascalMFChanged, this, this.toDispose);
 
-        this.validateAllOpenEditors();
+        void this.validateAllOpenEditors();
     }
 
     async validateAllOpenEditors() {
-        for (const tab of vscode.window.tabGroups.all.flatMap(t => t.tabs)) {
-            if (tab.input instanceof vscode.TabInputText) {
-                try {
-                    const document = await vscode.workspace.openTextDocument((<vscode.TabInputText>tab.input).uri);
-                    this.validate(document);
-                } catch (e) {
-                    this.log.debug("Swallowing: ", e);
+        await Promise.all(vscode.window.tabGroups.all
+            .flatMap(t => t.tabs)
+            .map(async (tab) => {
+                if (tab.input instanceof vscode.TabInputText) {
+                    try {
+                        const document = await vscode.workspace.openTextDocument((<vscode.TabInputText>tab.input).uri);
+                        await this.validate(document);
+                    } catch (e) {
+                        this.log.debug("Swallowing: ", e);
+                    }
                 }
-            }
-
-        }
+            }));
     }
 
     async rascalMFChanged(mfFile : Uri) {
@@ -77,7 +78,7 @@ export class RascalProjectValidator implements vscode.Disposable {
         if (this.cachedSourcePaths.delete(mfFile.toString())) {
             // we had calculated the source paths before
             // lets see re-validate all messages we've reported
-            this.validateAllOpenEditors();
+            await this.validateAllOpenEditors();
         }
     }
 

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -80,7 +80,7 @@ export class VsCodeSettingsFixer implements vscode.Disposable {
 
         // Fix settings for currently open projects
         for (const projectRoot of vscode.workspace.workspaceFolders || []) {
-            this.fixSettings(projectRoot.uri); // Do not await; process workspaces in parallel
+            void this.fixSettings(projectRoot.uri); // Do not await; process workspaces in parallel
         }
     }
 


### PR DESCRIPTION
This PR adds ESLint checks for suspicous use of promises. In particular, it disallows implicit floating promises. This PR also fixes all errors produced by the linter. In most cases by adding `void`, but in some cases (for example in specific `async` functions, `await` seems like the more sensible choice.

Closes #1062.