### PR TITLE
Factor out text document management

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -29,7 +29,6 @@ package org.rascalmpl.vscode.lsp;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CreateFilesParams;
 import org.eclipse.lsp4j.DeleteFilesParams;
@@ -38,14 +37,12 @@ import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
-import org.rascalmpl.util.locations.ColumnMaps;
-import org.rascalmpl.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
 
 import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValue;
 
-public interface IBaseTextDocumentService extends TextDocumentService {
+public interface IBaseTextDocumentService extends TextDocumentService, ITextDocumentStateManager {
     static final Duration NO_DEBOUNCE = Duration.ZERO;
     static final Duration NORMAL_DEBOUNCE = Duration.ofMillis(800);
 
@@ -61,11 +58,6 @@ public interface IBaseTextDocumentService extends TextDocumentService {
     void projectRemoved(String name, ISourceLocation projectRoot);
 
     CompletableFuture<IValue> executeCommand(String languageName, String command);
-    LineColumnOffsetMap getColumnMap(ISourceLocation file);
-    ColumnMaps getColumnMaps();
-    @Nullable TextDocumentState getDocumentState(ISourceLocation file);
-
-    boolean isManagingFile(ISourceLocation file);
 
     void didCreateFiles(CreateFilesParams params);
     void didRenameFiles(RenameFilesParams params, List<WorkspaceFolder> workspaceFolders);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/ITextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/ITextDocumentStateManager.java
@@ -26,7 +26,7 @@
  */
 package org.rascalmpl.vscode.lsp;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import java.io.FileNotFoundException;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.util.locations.LineColumnOffsetMap;
 
@@ -35,6 +35,6 @@ import io.usethesource.vallang.ISourceLocation;
 public interface ITextDocumentStateManager {
     LineColumnOffsetMap getColumnMap(ISourceLocation file);
     ColumnMaps getColumnMaps();
-    @Nullable TextDocumentState getDocumentState(ISourceLocation file);
+    TextDocumentState getEditorState(ISourceLocation file) throws FileNotFoundException;
     boolean isManagingFile(ISourceLocation file);
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/ITextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/ITextDocumentStateManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.vscode.lsp;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.rascalmpl.util.locations.ColumnMaps;
+import org.rascalmpl.util.locations.LineColumnOffsetMap;
+
+import io.usethesource.vallang.ISourceLocation;
+
+public interface ITextDocumentStateManager {
+    LineColumnOffsetMap getColumnMap(ISourceLocation file);
+    ColumnMaps getColumnMaps();
+    @Nullable TextDocumentState getDocumentState(ISourceLocation file);
+    boolean isManagingFile(ISourceLocation file);
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -41,7 +41,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.function.TriConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.Diagnostic;
@@ -72,11 +71,12 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
     private final Map<ISourceLocation, TextDocumentState> files = new ConcurrentHashMap<>();
     private final ColumnMaps columns;
 
+    @SuppressWarnings({"methodref.receiver.bound"}) // this::getContents
     public TextDocumentStateManager() {
         this.columns = new ColumnMaps(this::getContents);
     }
 
-    public String getContents(@UnknownInitialization TextDocumentStateManager this, ISourceLocation file) {
+    public String getContents(ISourceLocation file) {
         file = file.top();
         var ideState = files.get(file);
         if (ideState != null) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -72,7 +72,7 @@ public class TextDocumentStateManager {
     private final ColumnMaps columns;
 
     public TextDocumentStateManager() {
-        this.columns = new ColumnMaps(l -> getContents(l));
+        this.columns = new ColumnMaps(this::getContents);
     }
 
     public String getContents(@UnknownInitialization TextDocumentStateManager this, ISourceLocation file) {
@@ -114,7 +114,7 @@ public class TextDocumentStateManager {
         loc = loc.top();
         TextDocumentState file = files.get(loc);
         if (file == null) {
-            throw new FileNotFoundException(String.format("Unknown file: {}", loc));
+            throw new FileNotFoundException(String.format("Unknown file: %s", loc));
         }
         return file;
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -29,25 +29,32 @@ package org.rascalmpl.vscode.lsp;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.function.TriConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.values.parsetrees.ITree;
+import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
+import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
@@ -142,4 +149,27 @@ public class TextDocumentStateManager {
     protected static ResponseError unknownFileError(ISourceLocation loc, @Nullable Object data) {
         return new ResponseError(ResponseErrorCode.RequestFailed, "Unknown file: " + loc, data);
     }
+
+    protected static ResponseError unknownFileError(VersionedTextDocumentIdentifier doc, @Nullable Object data) {
+        return unknownFileError(Locations.toLoc(doc), data);
+    }
+
+    protected void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp, TriConsumer<ISourceLocation, Versioned<List<Diagnostics.Template>>, List<Diagnostic>> reportDiagnostics) throws FileNotFoundException {
+        logger.trace("New contents for {}", doc);
+        TextDocumentState file = getFile(Locations.toLoc(doc));
+        updateFile(file.getLocation());
+        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp), reportDiagnostics);
+    }
+
+    protected void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync, TriConsumer<ISourceLocation, Versioned<List<Diagnostics.Template>>, List<Diagnostic>> reportDiagnostics) {
+        diagnosticsAsync.thenAccept(diagnostics -> {
+            List<Diagnostic> parseErrors = diagnostics.get().stream()
+                .map(diagnostic -> diagnostic.instantiate(getColumnMaps()))
+                .collect(Collectors.toList());
+
+            logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, file.getLocation());
+            reportDiagnostics.accept(file.getLocation(), diagnostics, parseErrors);
+        });
+    }
+
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -77,10 +77,14 @@ public class TextDocumentStateManager {
 
     public String getContents(@UnknownInitialization TextDocumentStateManager this, ISourceLocation file) {
         file = file.top();
-        try {
-            return getFile(file).getCurrentContent().get();
-        } catch (FileNotFoundException ignored) {}
-
+        var ideState = files.get(file);
+        if (ideState != null) {
+            return ideState.getCurrentContent().get();
+        }
+        if (!URIResolverRegistry.getInstance().isFile(file)) {
+            logger.error("Trying to get the contents of a directory: {}", file);
+            return "";
+        }
         try (Reader src = URIResolverRegistry.getInstance().getCharacterReader(file)) {
             return IOUtils.toString(src);
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -72,7 +72,7 @@ public abstract class TextDocumentStateManager implements ITextDocumentStateMana
     private final ColumnMaps columns;
 
     @SuppressWarnings({"methodref.receiver.bound"}) // this::getContents
-    public TextDocumentStateManager() {
+    protected TextDocumentStateManager() {
         this.columns = new ColumnMaps(this::getContents);
     }
 
@@ -188,7 +188,7 @@ public abstract class TextDocumentStateManager implements ITextDocumentStateMana
         return files.keySet();
     }
 
-    protected void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) throws FileNotFoundException {
+    protected void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
         logger.trace("New contents for {}", doc);
         TextDocumentState file = getFile(Locations.toLoc(doc));
         invalidateColumnMaps(file.getLocation());

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -47,6 +47,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.rascalmpl.uri.URIResolverRegistry;
@@ -114,13 +115,34 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
         return columns.get(loc.top());
     }
 
-    protected TextDocumentState getFile(@UnknownInitialization TextDocumentStateManager this, ISourceLocation loc) throws FileNotFoundException {
+    /**
+     * Get open file state.
+     * @param loc The location of the file.
+     * @return The current state in the editor.
+     * @throws FileNotFoundException If the file is not open.
+     */
+    public TextDocumentState getEditorState(ISourceLocation loc) throws FileNotFoundException {
         loc = loc.top();
         TextDocumentState file = files.get(loc);
         if (file == null) {
             throw new FileNotFoundException(String.format("Unknown file: %s", loc));
         }
         return file;
+    }
+
+    /**
+     * Get open file state. If the file is not open, throws an (unchecked) {@link ResponseErrorException}.
+     *
+     * Intentionally protected function, only to be used from LSP endpoints. Users outside of the LSP context should call {@link TextDocumentStateManager#getEditorState}.
+     * @param loc The location of the file.
+     * @return The current state in the editor.
+     */
+    protected TextDocumentState getFile(ISourceLocation loc) {
+        try {
+            return getEditorState(loc);
+        } catch (FileNotFoundException ignored) {
+            throw new ResponseErrorException(unknownFileError(loc, loc));
+        }
     }
 
     protected TextDocumentState openFile(TextDocumentItem doc, BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser, long timestamp, ExecutorService exec)  {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -114,11 +114,6 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
     }
 
     @Override
-    public @Nullable TextDocumentState getDocumentState(ISourceLocation file) {
-        return files.get(file.top());
-    }
-
-    @Override
     public LineColumnOffsetMap getColumnMap(ISourceLocation loc) {
         return columns.get(loc.top());
     }
@@ -129,6 +124,7 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
      * @return The current state in the editor.
      * @throws FileNotFoundException If the file is not open.
      */
+    @Override
     public TextDocumentState getEditorState(ISourceLocation loc) throws FileNotFoundException {
         loc = loc.top();
         TextDocumentState file = files.get(loc);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -60,9 +60,10 @@ import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import io.usethesource.vallang.ISourceLocation;
 
 /**
- * Management of {{@link TextDocumentState}} associated with locations.
+ * Manages open files and their contents.
  *
- *
+ * This class maintains a set of open files, their state, and information derived from their contents, like column maps.
+ * This functionality is shared by implementations of {@link IBaseTextDocumentService}.
  */
 public class TextDocumentStateManager implements ITextDocumentStateManager {
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -76,6 +76,14 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
         this.columns = new ColumnMaps(this::getContents);
     }
 
+    protected static ResponseError unknownFileError(ISourceLocation loc, @Nullable Object data) {
+        return new ResponseError(ResponseErrorCode.RequestFailed, "Unknown file: " + loc, data);
+    }
+
+    protected static ResponseError unknownFileError(VersionedTextDocumentIdentifier doc, @Nullable Object data) {
+        return unknownFileError(Locations.toLoc(doc), data);
+    }
+
     public String getContents(ISourceLocation file) {
         file = file.top();
         var ideState = files.get(file);
@@ -131,11 +139,12 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
     }
 
     /**
-     * Get open file state. If the file is not open, throws an (unchecked) {@link ResponseErrorException}.
+     * Get open file state.
      *
      * Intentionally protected function, only to be used from LSP endpoints. Users outside of the LSP context should call {@link TextDocumentStateManager#getEditorState}.
      * @param loc The location of the file.
      * @return The current state in the editor.
+     * @throws ResponseErrorException If the file is not open.
      */
     protected TextDocumentState getFile(ISourceLocation loc) {
         try {
@@ -150,16 +159,23 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
             l -> new TextDocumentState(parser, l, doc.getVersion(), doc.getText(), timestamp, exec));
     }
 
-    protected void updateFile(ISourceLocation loc) {
+    private void invalidateColumnMaps(ISourceLocation loc) {
         columns.clear(loc.top());
     }
 
-    protected boolean removeFile(ISourceLocation loc) {
-        updateFile(loc);
-        return files.remove(loc.top()) != null;
+    /**
+     * Close a file/editor.
+     * @param loc The location of the file.
+     * @throws ResponseErrorException If the file was not open.
+     */
+    protected void closeFile(ISourceLocation loc) {
+        invalidateColumnMaps(loc);
+        if (files.remove(loc.top()) == null) {
+            throw new ResponseErrorException(unknownFileError(loc, loc));
+        }
     }
 
-    protected @Nullable TextDocumentState updateFileState(ISourceLocation f, BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser) {
+    protected @Nullable TextDocumentState changeParser(ISourceLocation f, BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser) {
         f = f.top();
         logger.trace("Updating state: {}", f);
 
@@ -176,18 +192,10 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
         return files.keySet();
     }
 
-    protected static ResponseError unknownFileError(ISourceLocation loc, @Nullable Object data) {
-        return new ResponseError(ResponseErrorCode.RequestFailed, "Unknown file: " + loc, data);
-    }
-
-    protected static ResponseError unknownFileError(VersionedTextDocumentIdentifier doc, @Nullable Object data) {
-        return unknownFileError(Locations.toLoc(doc), data);
-    }
-
     protected void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp, TriConsumer<ISourceLocation, Versioned<List<Diagnostics.Template>>, List<Diagnostic>> reportDiagnostics) throws FileNotFoundException {
         logger.trace("New contents for {}", doc);
         TextDocumentState file = getFile(Locations.toLoc(doc));
-        updateFile(file.getLocation());
+        invalidateColumnMaps(file.getLocation());
         handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp), reportDiagnostics);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -64,7 +64,7 @@ import io.usethesource.vallang.ISourceLocation;
  *
  *
  */
-public class TextDocumentStateManager {
+public class TextDocumentStateManager implements ITextDocumentStateManager {
 
     private static final Logger logger = LogManager.getLogger(TextDocumentStateManager.class);
 
@@ -94,18 +94,22 @@ public class TextDocumentStateManager {
         }
     }
 
+    @Override
     public ColumnMaps getColumnMaps() {
         return columns;
     }
 
+    @Override
     public boolean isManagingFile(ISourceLocation loc) {
         return files.containsKey(loc.top());
     }
 
+    @Override
     public @Nullable TextDocumentState getDocumentState(ISourceLocation file) {
         return files.get(file.top());
     }
 
+    @Override
     public LineColumnOffsetMap getColumnMap(ISourceLocation loc) {
         return columns.get(loc.top());
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.vscode.lsp;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.function.BiFunction;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.util.locations.ColumnMaps;
+import org.rascalmpl.util.locations.LineColumnOffsetMap;
+import org.rascalmpl.values.parsetrees.ITree;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
+
+import io.usethesource.vallang.ISourceLocation;
+
+/**
+ * Management of {{@link TextDocumentState}} associated with locations.
+ *
+ *
+ */
+public class TextDocumentStateManager {
+
+    private static final Logger logger = LogManager.getLogger(TextDocumentStateManager.class);
+
+    private final Map<ISourceLocation, TextDocumentState> files = new ConcurrentHashMap<>();
+    private final ColumnMaps columns;
+
+    public TextDocumentStateManager() {
+        this.columns = new ColumnMaps(l -> getContents(l));
+    }
+
+    public String getContents(@UnknownInitialization TextDocumentStateManager this, ISourceLocation file) {
+        file = file.top();
+        try {
+            return getFile(file).getCurrentContent().get();
+        } catch (FileNotFoundException ignored) {}
+
+        try (Reader src = URIResolverRegistry.getInstance().getCharacterReader(file)) {
+            return IOUtils.toString(src);
+        }
+        catch (IOException e) {
+            logger.error("Error opening file {} to get contents", file, e);
+            return "";
+        }
+    }
+
+    public ColumnMaps getColumnMaps() {
+        return columns;
+    }
+
+    public boolean isManagingFile(ISourceLocation loc) {
+        return files.containsKey(loc.top());
+    }
+
+    public @Nullable TextDocumentState getDocumentState(ISourceLocation file) {
+        return files.get(file.top());
+    }
+
+    public LineColumnOffsetMap getColumnMap(ISourceLocation loc) {
+        return columns.get(loc.top());
+    }
+
+    protected TextDocumentState getFile(@UnknownInitialization TextDocumentStateManager this, ISourceLocation loc) throws FileNotFoundException {
+        loc = loc.top();
+        TextDocumentState file = files.get(loc);
+        if (file == null) {
+            throw new FileNotFoundException(String.format("Unknown file: {}", loc));
+        }
+        return file;
+    }
+
+    protected TextDocumentState openFile(TextDocumentItem doc, BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser, long timestamp, ExecutorService exec)  {
+        return files.computeIfAbsent(Locations.toLoc(doc),
+            l -> new TextDocumentState(parser, l, doc.getVersion(), doc.getText(), timestamp, exec));
+    }
+
+    protected void updateFile(ISourceLocation loc) {
+        columns.clear(loc.top());
+    }
+
+    protected boolean removeFile(ISourceLocation loc) {
+        updateFile(loc);
+        return files.remove(loc.top()) != null;
+    }
+
+    protected @Nullable TextDocumentState updateFileState(ISourceLocation f, BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser) {
+        f = f.top();
+        logger.trace("Updating state: {}", f);
+
+        // Since we cannot know what happened to this file before we were called, we need to be careful about races.
+        // It might have been closed in the meantime, so we compute the new value if the key still exists, based on the current value.
+        var state = files.computeIfPresent(f, (loc, currentState) -> currentState.changeParser(parser));
+        if (state == null) {
+            logger.debug("Updating the parser of {} failed, since it was closed.", f);
+        }
+        return state;
+    }
+
+    protected Set<@KeyFor("this.files") ISourceLocation> getOpenFiles() {
+        return files.keySet();
+    }
+
+    protected static ResponseError unknownFileError(ISourceLocation loc, @Nullable Object data) {
+        return new ResponseError(ResponseErrorCode.RequestFailed, "Unknown file: " + loc, data);
+    }
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -38,12 +38,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.function.TriConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
@@ -53,6 +51,7 @@ import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.values.parsetrees.ITree;
+import org.rascalmpl.vscode.lsp.model.DiagnosticsReporter;
 import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
@@ -65,7 +64,7 @@ import io.usethesource.vallang.ISourceLocation;
  * This class maintains a set of open files, their state, and information derived from their contents, like column maps.
  * This functionality is shared by implementations of {@link IBaseTextDocumentService}.
  */
-public class TextDocumentStateManager implements ITextDocumentStateManager {
+public abstract class TextDocumentStateManager implements ITextDocumentStateManager {
 
     private static final Logger logger = LogManager.getLogger(TextDocumentStateManager.class);
 
@@ -189,22 +188,25 @@ public class TextDocumentStateManager implements ITextDocumentStateManager {
         return files.keySet();
     }
 
-    protected void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp, TriConsumer<ISourceLocation, Versioned<List<Diagnostics.Template>>, List<Diagnostic>> reportDiagnostics) throws FileNotFoundException {
+    protected void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) throws FileNotFoundException {
         logger.trace("New contents for {}", doc);
         TextDocumentState file = getFile(Locations.toLoc(doc));
         invalidateColumnMaps(file.getLocation());
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp), reportDiagnostics);
+        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
     }
 
-    protected void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync, TriConsumer<ISourceLocation, Versioned<List<Diagnostics.Template>>, List<Diagnostic>> reportDiagnostics) {
+    protected void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync) {
         diagnosticsAsync.thenAccept(diagnostics -> {
-            List<Diagnostic> parseErrors = diagnostics.get().stream()
+            var parseErrors = diagnostics.map(d -> d.stream()
                 .map(diagnostic -> diagnostic.instantiate(getColumnMaps()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
 
-            logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, file.getLocation());
-            reportDiagnostics.accept(file.getLocation(), diagnostics, parseErrors);
+            var loc = file.getLocation();
+            logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, loc);
+            getDiagnosticsReporter(loc).reportParseErrors(loc, parseErrors);
         });
     }
+
+    abstract protected DiagnosticsReporter getDiagnosticsReporter(ISourceLocation file);
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -150,9 +151,9 @@ public abstract class TextDocumentStateManager implements ITextDocumentStateMana
         }
     }
 
-    protected TextDocumentState openFile(TextDocumentItem doc, BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser, long timestamp, ExecutorService exec)  {
+    protected TextDocumentState openFile(TextDocumentItem doc, Function<ISourceLocation, BiFunction<ISourceLocation, String, CompletableFuture<ITree>>> parserGetter, long timestamp, ExecutorService exec)  {
         return files.computeIfAbsent(Locations.toLoc(doc),
-            l -> new TextDocumentState(parser, l, doc.getVersion(), doc.getText(), timestamp, exec));
+            l -> new TextDocumentState(parserGetter.apply(l), l, doc.getVersion(), doc.getText(), timestamp, exec));
     }
 
     private void invalidateColumnMaps(ISourceLocation loc) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -207,6 +207,6 @@ public abstract class TextDocumentStateManager implements ITextDocumentStateMana
         });
     }
 
-    abstract protected DiagnosticsReporter getDiagnosticsReporter(ISourceLocation file);
+    protected abstract DiagnosticsReporter getDiagnosticsReporter(ISourceLocation file);
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/model/DiagnosticsReporter.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/model/DiagnosticsReporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.vscode.lsp.model;
+
+import java.util.List;
+import org.eclipse.lsp4j.Diagnostic;
+import org.rascalmpl.vscode.lsp.parametric.model.ParametricFileFacts;
+import org.rascalmpl.vscode.lsp.rascal.model.FileFacts;
+import org.rascalmpl.vscode.lsp.util.Versioned;
+
+import io.usethesource.vallang.ISourceLocation;
+
+/**
+ * Interface for objects that can report diagnostics on files.
+ *
+ * Encapsulates common behavior of {@link FileFacts} and {@link ParametricFileFacts}.
+ */
+public interface DiagnosticsReporter {
+    void reportParseErrors(ISourceLocation file, Versioned<List<Diagnostic>> msgs);
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -26,7 +26,6 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
-import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -313,12 +312,8 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     public void didChange(DidChangeTextDocumentParams params) {
         var timestamp = System.currentTimeMillis();
         logger.debug("Did Change file: {}", params.getTextDocument().getUri());
-        try {
-            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
-            triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
-        } catch (FileNotFoundException ignored) {
-            throw new ResponseErrorException(unknownFileError(params.getTextDocument(), params));
-        }
+        updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
+        triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -26,8 +26,7 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
-import java.io.IOException;
-import java.io.Reader;
+import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +49,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.IOUtils;
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -129,8 +128,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
-import org.rascalmpl.util.locations.ColumnMaps;
-import org.rascalmpl.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.TreeAdapter;
@@ -138,6 +135,7 @@ import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
+import org.rascalmpl.vscode.lsp.TextDocumentStateManager;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.CapabilityRegistration;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.CompletionCapability;
@@ -177,7 +175,7 @@ import io.usethesource.vallang.type.Type;
 import io.usethesource.vallang.type.TypeFactory;
 import io.usethesource.vallang.type.TypeStore;
 
-public class ParametricTextDocumentService implements IBaseTextDocumentService, LanguageClientAware {
+public class ParametricTextDocumentService extends TextDocumentStateManager implements IBaseTextDocumentService, LanguageClientAware {
     private static final IValueFactory VF = IRascalValueFactory.getInstance();
     private static final Logger logger = LogManager.getLogger(ParametricTextDocumentService.class);
 
@@ -188,9 +186,6 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     private @MonotonicNonNull LanguageClient client;
     private @MonotonicNonNull BaseWorkspaceService workspaceService;
     private @MonotonicNonNull CapabilityRegistration dynamicCapabilities;
-
-    private final Map<ISourceLocation, TextDocumentState> files;
-    private final ColumnMaps columns;
 
     /** extension to language */
     private final Map<String, String> registeredExtensions = new ConcurrentHashMap<>();
@@ -214,8 +209,6 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         URIResolverRegistry.getInstance();
 
         this.exec = exec;
-        this.files = new ConcurrentHashMap<>();
-        this.columns = new ColumnMaps(this::getContents);
         if (dedicatedLanguage == null) {
             this.dedicatedLanguageName = "";
             this.dedicatedLanguage = null;
@@ -225,31 +218,6 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             this.dedicatedLanguage = dedicatedLanguage;
         }
         FallbackResolver.getInstance().registerTextDocumentService(this);
-    }
-
-    @Override
-    public ColumnMaps getColumnMaps() {
-        return columns;
-    }
-
-    @Override
-    public LineColumnOffsetMap getColumnMap(ISourceLocation file) {
-        return columns.get(file);
-    }
-
-    public String getContents(ISourceLocation file) {
-        file = file.top();
-        TextDocumentState ideState = files.get(file);
-        if (ideState != null) {
-            return ideState.getCurrentContent().get();
-        }
-        try (Reader src = URIResolverRegistry.getInstance().getCharacterReader(file)) {
-            return IOUtils.toString(src);
-        }
-        catch (IOException e) {
-            logger.error("Error opening file {} to get contents", file, e);
-            return "";
-        }
     }
 
     private CapabilityRegistration availableCapabilities() {
@@ -359,7 +327,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public void didClose(DidCloseTextDocumentParams params) {
         logger.debug("Did Close file: {}", params.getTextDocument());
         var loc = Locations.toLoc(params.getTextDocument());
-        if (files.remove(loc) == null) {
+        if (!removeFile(loc)) {
             throw new ResponseErrorException(unknownFileError(loc, params));
         }
         facts(loc).close(loc);
@@ -411,14 +379,14 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     private void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
         logger.trace("New contents for {}", doc);
         TextDocumentState file = getFile(Locations.toLoc(doc));
-        columns.clear(file.getLocation());
+        updateFile(file.getLocation());
         handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
     }
 
     private void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync) {
         diagnosticsAsync.thenAccept(diagnostics -> {
             List<Diagnostic> parseErrors = diagnostics.get().stream()
-                .map(diagnostic -> diagnostic.instantiate(columns))
+                .map(diagnostic -> diagnostic.instantiate(getColumnMaps()))
                 .collect(Collectors.toList());
 
             logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, file.getLocation());
@@ -459,7 +427,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                 if (loc.equals(URIUtil.unknownLocation())) {
                     throw new ResponseErrorException(new ResponseError(ResponseErrorCode.RequestFailed, "Rename not possible", pos));
                 }
-                return Either3.forFirst(Locations.toRange(loc, columns));
+                return Either3.forFirst(Locations.toRange(loc, getColumnMaps()));
             });
     }
 
@@ -476,7 +444,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     @Override
     public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
         logger.trace("rename for: {}, new name: {}", params.getTextDocument().getUri(), params.getNewName());
-        ISourceLocation loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getPosition(), columns);
+        ISourceLocation loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getPosition(), getColumnMaps());
         ILanguageContributions contribs = contributions(loc);
         return getFile(loc)
                 .getCurrentTreeAsync(true)
@@ -496,7 +464,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                 .thenApply(tuple -> {
                     IList documentEdits = (IList) tuple.get(0);
                     showMessages(availableClient(), (ISet) tuple.get(1));
-                    return DocumentChanges.translateDocumentChanges(documentEdits, columns);
+                    return DocumentChanges.translateDocumentChanges(documentEdits, getColumnMaps());
                 })
                 .get();
     }
@@ -567,7 +535,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                         return;
                     }
 
-                    WorkspaceEdit changes = DocumentChanges.translateDocumentChanges(edits, columns);
+                    WorkspaceEdit changes = DocumentChanges.translateDocumentChanges(edits, getColumnMaps());
                     client.applyEdit(new ApplyWorkspaceEditParams(changes, "Rename files")).thenAccept(editResponse -> {
                         if (!editResponse.isApplied()) {
                             throw new RuntimeException("didRenameFiles resulted in a list of edits but applying them failed"
@@ -647,7 +615,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         var atEnd = KeywordParameter.get("atEnd", tKW, false);
 
         // translate to lsp
-        var result = new InlayHint(Locations.toPosition(loc, columns, atEnd), Either.forLeft(label.trim()));
+        var result = new InlayHint(Locations.toPosition(loc, getColumnMaps(), atEnd), Either.forLeft(label.trim()));
         result.setKind(kind.getName().equals("type") ? InlayHintKind.Type : InlayHintKind.Parameter);
         result.setPaddingLeft(label.startsWith(" "));
         result.setPaddingRight(label.endsWith(" "));
@@ -662,7 +630,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         ISourceLocation loc = (ISourceLocation) t.get(0);
         IConstructor command = (IConstructor) t.get(1);
 
-        return new CodeLens(Locations.toRange(loc, columns), CodeActions.constructorToCommand(dedicatedLanguageName, languageName, command), null);
+        return new CodeLens(Locations.toRange(loc, getColumnMaps()), CodeActions.constructorToCommand(dedicatedLanguageName, languageName, command), null);
     }
 
     private static <T> T last(List<T> l) {
@@ -711,18 +679,17 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         return fact;
     }
 
-    private TextDocumentState open(TextDocumentItem doc, long timestamp) {
-        return files.computeIfAbsent(Locations.toLoc(doc),
-            l -> new TextDocumentState(contributions(l)::parsing, l, doc.getVersion(), doc.getText(), timestamp, exec));
-    }
-
-    private TextDocumentState getFile(ISourceLocation loc) {
-        loc = loc.top();
-        TextDocumentState file = files.get(loc);
-        if (file == null) {
+    @Override
+    protected TextDocumentState getFile(@UnknownInitialization ParametricTextDocumentService this, ISourceLocation loc) {
+        try {
+            return super.getFile(loc);
+        } catch (FileNotFoundException e) {
             throw new ResponseErrorException(unknownFileError(loc, loc));
         }
-        return file;
+    }
+
+    private TextDocumentState open(TextDocumentItem doc, long timestamp) {
+        return openFile(doc, contributions(Locations.toLoc(doc))::parsing, timestamp, exec);
     }
 
     public void shutdown() {
@@ -771,7 +738,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             .thenApply(Versioned::get)
             .thenApply(contrib::documentSymbol)
             .thenCompose(InterruptibleFuture::get)
-            .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, columns.get(file.getLocation())))
+            .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, getColumnMap(file.getLocation())))
             , Collections::emptyList);
     }
 
@@ -779,7 +746,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
         logger.debug("codeAction: {}", params);
 
-        var location = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getRange().getStart(), columns);
+        var location = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getRange().getStart(), getColumnMaps());
         final ILanguageContributions contribs = contributions(location);
 
         // first we make a future stream for filtering out the "fixes" that were optionally sent along with earlier diagnostics
@@ -890,17 +857,17 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         return recoverExceptions(file.getCurrentTreeAsync(true)
                 .thenApply(Versioned::get)
                 .thenCompose(t -> CompletableFutureUtils.reduce(params.getPositions().stream()
-                    .map(p -> Locations.setPosition(loc, p, columns))
+                    .map(p -> Locations.setPosition(loc, p, getColumnMaps()))
                     .map(p -> computeSelection
                         .thenCompose(compute -> compute.apply(TreeSearch.computeFocusList(t, p.getBeginLine(), p.getBeginColumn())))
-                        .thenApply(selection -> SelectionRanges.toSelectionRange(p, selection, columns)))
+                        .thenApply(selection -> SelectionRanges.toSelectionRange(p, selection, getColumnMaps())))
                     .collect(Collectors.toUnmodifiableList()), exec)),
             Collections::emptyList);
     }
 
     @Override
     public CompletableFuture<List<CallHierarchyItem>> prepareCallHierarchy(CallHierarchyPrepareParams params) {
-        final var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getPosition(), columns);
+        final var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getPosition(), getColumnMaps());
         final var contrib = contributions(loc);
         final var file = getFile(loc);
 
@@ -913,7 +880,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                         var ch = new CallHierarchy(exec);
                         return items.stream()
                             .map(IConstructor.class::cast)
-                            .map(ci -> ch.toLSP(ci, columns))
+                            .map(ci -> ch.toLSP(ci, getColumnMaps()))
                             .collect(Collectors.toList());
                     })), Collections::emptyList);
     }
@@ -921,7 +888,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     private <T> CompletableFuture<List<T>> incomingOutgoingCalls(BiFunction<CallHierarchyItem, List<Range>, T> constructor, CallHierarchyItem source, CallHierarchy.Direction direction) {
         final var contrib = contributions(Locations.toLoc(source.getUri()));
         var ch = new CallHierarchy(exec);
-        return ch.toRascal(source, contrib::parseCallHierarchyData, columns)
+        return ch.toRascal(source, contrib::parseCallHierarchyData, getColumnMaps())
             .thenCompose(sourceItem -> contrib.incomingOutgoingCalls(sourceItem, ch.direction(direction)).get())
             .thenApply(callRel -> {
                 // we need to maintain the order
@@ -930,10 +897,10 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                     var ciItem = (IConstructor)((ITuple)entry).get(0);
                     var sites = orderedEdges.computeIfAbsent(ciItem, _k -> new ArrayList<>());
                     var callSite = (ISourceLocation)((ITuple)entry).get(1);
-                    sites.add(Locations.toRange(callSite, columns));
+                    sites.add(Locations.toRange(callSite, getColumnMaps()));
                 }
                 return orderedEdges.entrySet().stream()
-                    .map(entry -> constructor.apply(ch.toLSP(entry.getKey(), columns), entry.getValue()))
+                    .map(entry -> constructor.apply(ch.toLSP(entry.getKey(), getColumnMaps()), entry.getValue()))
                     .collect(Collectors.toList());
             });
     }
@@ -952,7 +919,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams params) {
         logger.debug("Completion: {} at {} with {}", params.getTextDocument(), params.getPosition(), params.getContext());
 
-        var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getPosition(), columns);
+        var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getPosition(), getColumnMaps());
         var contrib = contributions(loc);
         var file = getFile(loc);
 
@@ -963,7 +930,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
                 var focus = TreeSearch.computeFocusList(t, loc.getBeginLine(), loc.getBeginColumn());
                 var cursorOffset = loc.getBeginColumn() - TreeAdapter.getLocation((ITree) focus.get(0)).getBeginColumn();
                 return contrib.completion(focus, VF.integer(cursorOffset), completion.triggerKindToRascal(params.getContext())).get()
-                    .thenApply(ci -> completion.toLSP(this, ci, dedicatedLanguageName, contrib.getName(), loc.getBeginLine(), columns.get(loc)));
+                    .thenApply(ci -> completion.toLSP(this, ci, dedicatedLanguageName, contrib.getName(), loc.getBeginLine(), getColumnMaps().get(loc)));
             })
             .thenApply(Either::forLeft), () -> Either.forLeft(Collections.emptyList()));
     }
@@ -976,7 +943,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
             t -> new LanguageContributionsMultiplexer(lang.getName(), exec)
         );
         var fact = facts.computeIfAbsent(lang.getName(), t ->
-            new ParametricFileFacts(exec, columns, multiplexer)
+            new ParametricFileFacts(exec, getColumnMaps(), multiplexer)
         );
 
         var parserConfig = lang.getPrecompiledParser();
@@ -1014,7 +981,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
 
         // If we opened any files with this extension before, now associate them with contributions
         var extensions = Arrays.asList(lang.getExtensions());
-        for (var f : files.keySet()) {
+        for (var f : getOpenFiles()) {
             if (extensions.contains(extension(f))) {
                 updateFileState(lang, f);
             }
@@ -1045,7 +1012,7 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
         logger.trace("File of language {} - updating state: {}", lang.getName(), f);
         // Since we cannot know what happened to this file before we were called, we need to be careful about races.
         // It might have been closed in the meantime, so we compute the new value if the key still exists, based on the current value.
-        var state = files.computeIfPresent(f, (loc, currentState) -> currentState.changeParser(contributions(loc)::parsing));
+        var state = updateFileState(f, contributions(f)::parsing);
         if (state == null) {
             logger.debug("Updating the parser of {} failed, since it was closed.", f);
             return;
@@ -1114,22 +1081,8 @@ public class ParametricTextDocumentService implements IBaseTextDocumentService, 
     }
 
     @Override
-    public boolean isManagingFile(ISourceLocation file) {
-        return files.containsKey(file.top());
-    }
-
-    @Override
-    public @Nullable TextDocumentState getDocumentState(ISourceLocation file) {
-        return files.get(file.top());
-    }
-
-    @Override
     public void cancelProgress(String progressId) {
         contributions.values().forEach(plex ->
             plex.cancelProgress(progressId));
-    }
-
-    private ResponseError unknownFileError(ISourceLocation loc, Object data) {
-        return new ResponseError(ResponseErrorCode.RequestFailed, "Unknown file: " + loc, data);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -333,9 +333,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     public void didClose(DidCloseTextDocumentParams params) {
         logger.debug("Did Close file: {}", params.getTextDocument());
         var loc = Locations.toLoc(params.getTextDocument());
-        if (!removeFile(loc)) {
-            throw new ResponseErrorException(unknownFileError(loc, params));
-        }
+        closeFile(loc);
         facts(loc).close(loc);
         // If the closed file no longer exists (e.g., if an untitled file is closed without ever having been saved),
         // we mimic a delete event to ensure all diagnostics are cleared.
@@ -962,7 +960,8 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         var extensions = Arrays.asList(lang.getExtensions());
         for (var f : getOpenFiles()) {
             if (extensions.contains(extension(f))) {
-                updateFileState(lang, f);
+                logger.trace("File of language {} - updating state: {}", lang.getName(), f);
+                refreshFileState(f);
             }
         }
     }
@@ -986,12 +985,11 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         }).collect(Collectors.toSet());
     }
 
-    private void updateFileState(LanguageParameter lang, ISourceLocation f) {
+    private void refreshFileState(ISourceLocation f) {
         f = f.top();
-        logger.trace("File of language {} - updating state: {}", lang.getName(), f);
         // Since we cannot know what happened to this file before we were called, we need to be careful about races.
         // It might have been closed in the meantime, so we compute the new value if the key still exists, based on the current value.
-        var state = updateFileState(f, contributions(f)::parsing);
+        var state = changeParser(f, contributions(f)::parsing);
         if (state == null) {
             logger.debug("Updating the parser of {} failed, since it was closed.", f);
             return;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -71,7 +71,6 @@ import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.CreateFilesParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DeleteFilesParams;
-import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
@@ -135,6 +134,7 @@ import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
 import org.rascalmpl.vscode.lsp.TextDocumentStateManager;
+import org.rascalmpl.vscode.lsp.model.DiagnosticsReporter;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.CapabilityRegistration;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.CompletionCapability;
@@ -146,7 +146,6 @@ import org.rascalmpl.vscode.lsp.parametric.model.ParametricSummary.SummaryLookup
 import org.rascalmpl.vscode.lsp.rascal.conversion.CallHierarchy;
 import org.rascalmpl.vscode.lsp.rascal.conversion.CodeActions;
 import org.rascalmpl.vscode.lsp.rascal.conversion.Completion;
-import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentSymbols;
 import org.rascalmpl.vscode.lsp.rascal.conversion.FoldingRanges;
@@ -294,8 +293,9 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         }
     }
 
-    private void reportDiagnostics(ISourceLocation file, Versioned<List<Diagnostics.Template>> diagnostics, List<Diagnostic> parseErrors) {
-        facts(file).reportParseErrors(file, diagnostics.version(), parseErrors);
+    @Override
+    protected DiagnosticsReporter getDiagnosticsReporter(ISourceLocation file) {
+        return facts(file);
     }
 
     // LSP interface methods
@@ -305,7 +305,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         var timestamp = System.currentTimeMillis();
         logger.debug("Did Open file: {}", params.getTextDocument());
         TextDocumentState file = open(params.getTextDocument(), timestamp);
-        handleParsingErrors(file, file.getCurrentDiagnosticsAsync(), this::reportDiagnostics);
+        handleParsingErrors(file, file.getCurrentDiagnosticsAsync());
         triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
     }
 
@@ -314,7 +314,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         var timestamp = System.currentTimeMillis();
         logger.debug("Did Change file: {}", params.getTextDocument().getUri());
         try {
-            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp, this::reportDiagnostics);
+            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
             triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
         } catch (FileNotFoundException ignored) {
             throw new ResponseErrorException(unknownFileError(params.getTextDocument(), params));
@@ -995,7 +995,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             return;
         }
         // Update open editor
-        handleParsingErrors(state, state.getCurrentDiagnosticsAsync(), this::reportDiagnostics);
+        handleParsingErrors(state, state.getCurrentDiagnosticsAsync());
         triggerAnalyzer(f, state.getCurrentContent().version(), NORMAL_DEBOUNCE);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -661,7 +661,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     }
 
     private TextDocumentState open(TextDocumentItem doc, long timestamp) {
-        return openFile(doc, contributions(Locations.toLoc(doc))::parsing, timestamp, exec);
+        return openFile(doc, l -> contributions(l)::parsing, timestamp, exec);
     }
 
     public void shutdown() {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -49,7 +49,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -203,7 +202,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             tf.abstractDataType(typeStore, "FileSystemChange"), "renamed", tf.sourceLocationType(), "from",
             tf.sourceLocationType(), "to");
 
-    @SuppressWarnings({"initialization", "methodref.receiver.bound"}) // this::getContents
     public ParametricTextDocumentService(ExecutorService exec, @Nullable LanguageParameter dedicatedLanguage) {
         // The following call ensures that URIResolverRegistry is initialized before FallbackResolver is accessed
         URIResolverRegistry.getInstance();
@@ -667,15 +665,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         }
 
         return fact;
-    }
-
-    @Override
-    protected TextDocumentState getFile(@UnknownInitialization ParametricTextDocumentService this, ISourceLocation loc) {
-        try {
-            return super.getFile(loc);
-        } catch (FileNotFoundException e) {
-            throw new ResponseErrorException(unknownFileError(loc, loc));
-        }
     }
 
     private TextDocumentState open(TextDocumentItem doc, long timestamp) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -296,6 +296,10 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         }
     }
 
+    private void reportDiagnostics(ISourceLocation file, Versioned<List<Diagnostics.Template>> diagnostics, List<Diagnostic> parseErrors) {
+        facts(file).reportParseErrors(file, diagnostics.version(), parseErrors);
+    }
+
     // LSP interface methods
 
     @Override
@@ -303,7 +307,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         var timestamp = System.currentTimeMillis();
         logger.debug("Did Open file: {}", params.getTextDocument());
         TextDocumentState file = open(params.getTextDocument(), timestamp);
-        handleParsingErrors(file, file.getCurrentDiagnosticsAsync());
+        handleParsingErrors(file, file.getCurrentDiagnosticsAsync(), this::reportDiagnostics);
         triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
     }
 
@@ -311,8 +315,12 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     public void didChange(DidChangeTextDocumentParams params) {
         var timestamp = System.currentTimeMillis();
         logger.debug("Did Change file: {}", params.getTextDocument().getUri());
-        updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
-        triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
+        try {
+            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp, this::reportDiagnostics);
+            triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
+        } catch (FileNotFoundException ignored) {
+            throw new ResponseErrorException(unknownFileError(params.getTextDocument(), params));
+        }
     }
 
     @Override
@@ -374,24 +382,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         var fileFacts = facts(location);
         fileFacts.invalidateBuilder(location);
         fileFacts.calculateBuilder(location, getFile(location).getCurrentTreeAsync(true));
-    }
-
-    private void updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
-        logger.trace("New contents for {}", doc);
-        TextDocumentState file = getFile(Locations.toLoc(doc));
-        updateFile(file.getLocation());
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
-    }
-
-    private void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync) {
-        diagnosticsAsync.thenAccept(diagnostics -> {
-            List<Diagnostic> parseErrors = diagnostics.get().stream()
-                .map(diagnostic -> diagnostic.instantiate(getColumnMaps()))
-                .collect(Collectors.toList());
-
-            logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, file.getLocation());
-            facts(file.getLocation()).reportParseErrors(file.getLocation(), diagnostics.version(), parseErrors);
-        });
     }
 
     @Override
@@ -1018,7 +1008,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             return;
         }
         // Update open editor
-        handleParsingErrors(state, state.getCurrentDiagnosticsAsync());
+        handleParsingErrors(state, state.getCurrentDiagnosticsAsync(), this::reportDiagnostics);
         triggerAnalyzer(f, state.getCurrentContent().version(), NORMAL_DEBOUNCE);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/model/ParametricFileFacts.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -50,6 +49,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.parsetrees.ITree;
+import org.rascalmpl.vscode.lsp.model.DiagnosticsReporter;
 import org.rascalmpl.vscode.lsp.parametric.ILanguageContributions;
 import org.rascalmpl.vscode.lsp.parametric.model.ParametricSummary.SummaryLookup;
 import org.rascalmpl.vscode.lsp.util.Lists;
@@ -59,7 +59,7 @@ import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
 
-public class ParametricFileFacts {
+public class ParametricFileFacts implements DiagnosticsReporter {
     private static final Logger logger = LogManager.getLogger(ParametricFileFacts.class);
 
     private final Executor exec;
@@ -109,8 +109,9 @@ public class ParametricFileFacts {
         this.client = client;
     }
 
-    public void reportParseErrors(ISourceLocation file, int version, List<Diagnostic> msgs) {
-        getFile(file).reportParseErrors(version, msgs);
+    @Override
+    public void reportParseErrors(ISourceLocation file, Versioned<List<Diagnostic>> msgs) {
+        getFile(file).reportParseErrors(msgs);
     }
 
     private FileFact getFile(ISourceLocation file) {
@@ -168,11 +169,11 @@ public class ParametricFileFacts {
         void close();
         void calculateAnalyzer(CompletableFuture<Versioned<ITree>> tree, int version, Duration delay);
         void calculateBuilder(CompletableFuture<Versioned<ITree>> tree);
-        void reportParseErrors(int version, List<Diagnostic> messages);
+        void reportParseErrors(Versioned<List<Diagnostic>> messages);
         void clearDiagnostics();
         <T> CompletableFuture<List<T>> lookupInSummaries(SummaryLookup<T> lookup, Versioned<ITree> tree, Position cursor);
     }
-    
+
     @SuppressWarnings("java:S3077") // Reads/writes to fields of this class happen sequentially
     private class ActualFileFact implements FileFact {
         private final ISourceLocation file;
@@ -200,9 +201,8 @@ public class ParametricFileFacts {
             this.file = file;
         }
 
-        private <T> void reportDiagnostics(AtomicReference<Versioned<T>> current, int version, T messages) {
-            var maybeNewer = new Versioned<>(version, messages);
-            if (Versioned.replaceIfNewer(current, maybeNewer)) {
+        private <T> void reportDiagnostics(AtomicReference<Versioned<T>> current, Versioned<T> messages) {
+            if (Versioned.replaceIfNewer(current, messages)) {
                 sendDiagnostics();
             }
         }
@@ -302,7 +302,7 @@ public class ParametricFileFacts {
                     .thenApply(f -> f.createFullSummary(file, tree))
                     .thenCompose(Function.identity());
                 ParametricSummary.getMessages(summary, exec)
-                    .thenAcceptIfUninterrupted(ms -> reportDiagnostics(analyzerDiagnostics, version, ms));
+                    .thenAcceptIfUninterrupted(ms -> reportDiagnostics(analyzerDiagnostics, new Versioned<>(version, ms)));
                 return summary;
             });
         }
@@ -342,13 +342,13 @@ public class ParametricFileFacts {
             var builderMessages = ParametricSummary.getMessages(latestBuilderBuild, exec);
             analyzerMessages.thenAcceptBothIfUninterrupted(builderMessages, (aMessages, bMessages) -> {
                 bMessages.removeAll(aMessages);
-                tree.thenAccept(t -> reportDiagnostics(builderDiagnostics, t.version(), bMessages));
+                tree.thenAccept(t -> reportDiagnostics(builderDiagnostics, new Versioned<>(t.version(), bMessages)));
             });
         }
 
         @Override
-        public void reportParseErrors(int version, List<Diagnostic> messages) {
-            reportDiagnostics(parserDiagnostics, version, messages);
+        public void reportParseErrors(Versioned<List<Diagnostic>> messages) {
+            reportDiagnostics(parserDiagnostics, messages);
         }
 
         @Override
@@ -469,7 +469,7 @@ public class ParametricFileFacts {
         }
 
         @Override
-        public void reportParseErrors(int version, List<Diagnostic> messages) {
+        public void reportParseErrors(Versioned<List<Diagnostic>> messages) {
             // NOP
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -29,6 +29,7 @@ package org.rascalmpl.vscode.lsp.rascal;
 import static org.rascalmpl.vscode.lsp.util.EvaluatorUtil.makeFutureEvaluator;
 import static org.rascalmpl.vscode.lsp.util.EvaluatorUtil.runEvaluator;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URISyntaxException;
@@ -240,11 +241,11 @@ public class RascalLanguageServices {
             ISourceLocation resolvedLocation = Locations.toClientLocation((ISourceLocation) t[0]);
             try {
                 // although we cannot type-check modules with errors, we prefer to get the errors here instead of retrying the parse and still failing after this try-block
-                var tree = rascalTextDocumentService.getFile(resolvedLocation).getCurrentTreeAsync(true).get();
+                var tree = rascalTextDocumentService.getEditorState(resolvedLocation).getCurrentTreeAsync(true).get();
                 if (tree != null) {
                     return tree.get();
                 }
-            } catch (ResponseErrorException | ExecutionException e1) {
+            } catch (FileNotFoundException | ExecutionException e1) {
                 // File is not open in the IDE | Parse threw an exception
                 // In either case, fall through and try a direct parse
             } catch (InterruptedException e1) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -246,9 +246,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
     public void didClose(DidCloseTextDocumentParams params) {
         logger.debug("Close: {}", params.getTextDocument());
         var loc = Locations.toLoc(params.getTextDocument());
-        if (!removeFile(loc)) {
-            throw new ResponseErrorException(new ResponseError(ResponseErrorCode.InternalError, "Unknown file: " + loc, params));
-        }
+        closeFile(loc);
         if (facts != null) {
             facts.close(loc);
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -494,7 +494,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
     }
 
     private TextDocumentState open(TextDocumentItem doc, long timestamp) {
-        return openFile(doc, availableRascalServices()::parseSourceFile, timestamp, exec);
+        return openFile(doc, l -> availableRascalServices()::parseSourceFile, timestamp, exec);
     }
 
     private TextDocumentState getFile(TextDocumentIdentifier doc) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -512,6 +512,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         return getFile(Locations.toLoc(doc));
     }
 
+    @Override
     protected TextDocumentState getFile(@UnknownInitialization RascalTextDocumentService this, ISourceLocation loc) {
         try {
             return super.getFile(loc);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -26,7 +26,6 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
-import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -234,11 +233,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
     public void didChange(DidChangeTextDocumentParams params) {
         var timestamp = System.currentTimeMillis();
         logger.trace("Change: {}", params.getTextDocument());
-        try {
-            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
-        } catch (FileNotFoundException ignored) {
-            throw new ResponseErrorException(unknownFileError(params.getTextDocument(), params));
-        }
+        updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -54,7 +54,6 @@ import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CreateFilesParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DeleteFilesParams;
-import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
@@ -113,10 +112,10 @@ import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
 import org.rascalmpl.vscode.lsp.TextDocumentStateManager;
+import org.rascalmpl.vscode.lsp.model.DiagnosticsReporter;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
 import org.rascalmpl.vscode.lsp.rascal.RascalLanguageServices.CodeLensSuggestion;
 import org.rascalmpl.vscode.lsp.rascal.conversion.CodeActions;
-import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentSymbols;
 import org.rascalmpl.vscode.lsp.rascal.conversion.FoldingRanges;
@@ -228,7 +227,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         var timestamp = System.currentTimeMillis();
         logger.debug("Open: {}", params.getTextDocument());
         TextDocumentState file = open(params.getTextDocument(), timestamp);
-        handleParsingErrors(file, file.getCurrentDiagnosticsAsync(), this::reportDiagnostics);
+        handleParsingErrors(file, file.getCurrentDiagnosticsAsync());
     }
 
     @Override
@@ -236,7 +235,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         var timestamp = System.currentTimeMillis();
         logger.trace("Change: {}", params.getTextDocument());
         try {
-            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp, this::reportDiagnostics);
+            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
         } catch (FileNotFoundException ignored) {
             throw new ResponseErrorException(unknownFileError(params.getTextDocument(), params));
         }
@@ -277,10 +276,9 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         }
     }
 
-    private void reportDiagnostics(ISourceLocation file, Versioned<List<Diagnostics.Template>> diagnostics, List<Diagnostic> parseErrors) {
-        if (facts != null) {
-            facts.reportParseErrors(file, parseErrors);
-        }
+    @Override
+    protected DiagnosticsReporter getDiagnosticsReporter(ISourceLocation ignored) {
+        return facts;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -278,7 +278,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
 
     @Override
     protected DiagnosticsReporter getDiagnosticsReporter(ISourceLocation ignored) {
-        return facts;
+        return availableFacts();
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -152,7 +151,6 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
     private @MonotonicNonNull FileFacts facts;
     private @MonotonicNonNull BaseWorkspaceService workspaceService;
 
-    @SuppressWarnings({"initialization", "methodref.receiver.bound"}) // this::getContents
     public RascalTextDocumentService(ExecutorService exec) {
         // The following call ensures that URIResolverRegistry is initialized before FallbackResolver is accessed
         URIResolverRegistry.getInstance();
@@ -510,15 +508,6 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
 
     private TextDocumentState getFile(TextDocumentIdentifier doc) {
         return getFile(Locations.toLoc(doc));
-    }
-
-    @Override
-    protected TextDocumentState getFile(@UnknownInitialization RascalTextDocumentService this, ISourceLocation loc) {
-        try {
-            return super.getFile(loc);
-        } catch (FileNotFoundException e) {
-            throw new ResponseErrorException(unknownFileError(loc, loc));
-        }
     }
 
     public void shutdown() {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -26,15 +26,12 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
-import java.io.IOException;
-import java.io.Reader;
+import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -43,6 +40,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -106,11 +104,8 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
-import org.rascalmpl.library.Prelude;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
-import org.rascalmpl.util.locations.ColumnMaps;
-import org.rascalmpl.util.locations.LineColumnOffsetMap;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
@@ -119,6 +114,7 @@ import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
+import org.rascalmpl.vscode.lsp.TextDocumentStateManager;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
 import org.rascalmpl.vscode.lsp.rascal.RascalLanguageServices.CodeLensSuggestion;
 import org.rascalmpl.vscode.lsp.rascal.conversion.CodeActions;
@@ -144,7 +140,7 @@ import io.usethesource.vallang.IString;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
 
-public class RascalTextDocumentService implements IBaseTextDocumentService, LanguageClientAware {
+public class RascalTextDocumentService extends TextDocumentStateManager implements IBaseTextDocumentService, LanguageClientAware {
     private static final IValueFactory VF = IRascalValueFactory.getInstance();
     private static final Logger logger = LogManager.getLogger(RascalTextDocumentService.class);
 
@@ -154,8 +150,6 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     private final SemanticTokenizer tokenizer = new SemanticTokenizer(true);
     private @MonotonicNonNull LanguageClient client;
 
-    private final Map<ISourceLocation, TextDocumentState> documents;
-    private final ColumnMaps columns;
     private @MonotonicNonNull FileFacts facts;
     private @MonotonicNonNull BaseWorkspaceService workspaceService;
 
@@ -165,8 +159,6 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         URIResolverRegistry.getInstance();
 
         this.exec = exec;
-        this.documents = new ConcurrentHashMap<>();
-        this.columns = new ColumnMaps(this::getContents);
         FallbackResolver.getInstance().registerTextDocumentService(this);
     }
 
@@ -199,37 +191,6 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return workspaceService;
     }
 
-    @Override
-    public ColumnMaps getColumnMaps() {
-        return columns;
-    }
-
-    @Override
-    public LineColumnOffsetMap getColumnMap(ISourceLocation file) {
-        return columns.get(file);
-    }
-
-    public String getContents(ISourceLocation file) {
-        file = file.top();
-        TextDocumentState ideState = documents.get(file);
-        if (ideState != null) {
-            return ideState.getCurrentContent().get();
-        }
-
-        if (!URIResolverRegistry.getInstance().isFile(file)) {
-            logger.error("Trying to get the contents of a directory: {}", file);
-            return "";
-        }
-
-        try (Reader src = URIResolverRegistry.getInstance().getCharacterReader(file)) {
-            return Prelude.consumeInputStream(src);
-        }
-        catch (IOException e) {
-            logger.error("Error opening file {} to get contents", file, e);
-            return "";
-        }
-    }
-
     public void initializeServerCapabilities(ClientCapabilities clientCapabilities, ServerCapabilities result) {
         result.setDefinitionProvider(true);
         result.setTextDocumentSync(TextDocumentSyncKind.Full);
@@ -254,7 +215,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public void connect(LanguageClient client) {
         this.client = client;
         this.rascalServices = new RascalLanguageServices(this, availableWorkspaceServices(), (IBaseLanguageClient) client, exec);
-        this.facts = new FileFacts(exec, rascalServices, client, columns);
+        this.facts = new FileFacts(exec, rascalServices, client, getColumnMaps());
     }
 
     @Override
@@ -284,7 +245,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     public void didClose(DidCloseTextDocumentParams params) {
         logger.debug("Close: {}", params.getTextDocument());
         var loc = Locations.toLoc(params.getTextDocument());
-        if (documents.remove(loc) == null) {
+        if (!removeFile(loc)) {
             throw new ResponseErrorException(new ResponseError(ResponseErrorCode.InternalError, "Unknown file: " + loc, params));
         }
         if (facts != null) {
@@ -320,7 +281,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     private TextDocumentState updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
         TextDocumentState file = getFile(doc);
         logger.trace("New contents for {}", doc);
-        columns.clear(file.getLocation());
+        updateFile(file.getLocation());
         handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
         return file;
     }
@@ -328,7 +289,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     private void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync) {
         diagnosticsAsync.thenAccept(diagnostics -> {
             List<Diagnostic> parseErrors = diagnostics.get().stream()
-                .map(diagnostic -> diagnostic.instantiate(columns))
+                .map(diagnostic -> diagnostic.instantiate(getColumnMaps()))
                 .collect(Collectors.toList());
 
             logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, file.getLocation());
@@ -361,7 +322,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return recoverExceptions(file.getLastTreeAsync(true)
             .thenApply(Versioned::get)
             .thenCompose(tr -> availableRascalServices().getDocumentSymbols(tr).get())
-            .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, columns.get(file.getLocation())))
+            .thenApply(documentSymbols -> DocumentSymbols.toLSP(documentSymbols, getColumnMap(file.getLocation())))
             );
     }
 
@@ -408,11 +369,11 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return recoverExceptions(file.getCurrentTreeAsync(false)
             .thenApply(Versioned::get)
             .thenApply(tr -> {
-                ISourceLocation rascalCursorPos = Locations.setPosition(file.getLocation(), params.getPosition(), columns);
+                ISourceLocation rascalCursorPos = Locations.setPosition(file.getLocation(), params.getPosition(), getColumnMaps());
                 IList focus = TreeSearch.computeFocusList(tr, rascalCursorPos.getBeginLine(), rascalCursorPos.getBeginColumn());
                 return findQualifiedNameUnderCursor(focus);
             })
-            .thenApply(cur -> Locations.toRange(TreeAdapter.getLocation(cur), columns))
+            .thenApply(cur -> Locations.toRange(TreeAdapter.getLocation(cur), getColumnMaps()))
             .thenApply(Either3::forFirst), () -> null);
     }
 
@@ -430,7 +391,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 return t;
             })
             .thenCompose(tr -> {
-                ISourceLocation rascalCursorPos = Locations.setPosition(file.getLocation(), params.getPosition(), columns);
+                ISourceLocation rascalCursorPos = Locations.setPosition(file.getLocation(), params.getPosition(), getColumnMaps());
                 var focus = TreeSearch.computeFocusList(tr, rascalCursorPos.getBeginLine(), rascalCursorPos.getBeginColumn());
                 var cursorTree = findQualifiedNameUnderCursor(focus);
                 var workspaceFolders = availableWorkspaceServices().workspaceFolders()
@@ -441,7 +402,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
             })
             .thenApply(t -> {
                 showMessages((ISet) t.get(1));
-                return DocumentChanges.translateDocumentChanges((IList) t.get(0), columns);
+                return DocumentChanges.translateDocumentChanges((IList) t.get(0), getColumnMaps());
             });
     }
 
@@ -556,20 +517,19 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
     }
 
     private TextDocumentState open(TextDocumentItem doc, long timestamp) {
-        return documents.computeIfAbsent(Locations.toLoc(doc),
-            l -> new TextDocumentState(availableRascalServices()::parseSourceFile, l, doc.getVersion(), doc.getText(), timestamp, exec));
+        return openFile(doc, availableRascalServices()::parseSourceFile, timestamp, exec);
     }
 
     private TextDocumentState getFile(TextDocumentIdentifier doc) {
         return getFile(Locations.toLoc(doc));
     }
 
-    protected TextDocumentState getFile(ISourceLocation loc) {
-        TextDocumentState file = documents.get(loc);
-        if (file == null) {
-            throw new ResponseErrorException(new ResponseError(-1, "Unknown file: " + loc, loc));
+    protected TextDocumentState getFile(@UnknownInitialization RascalTextDocumentService this, ISourceLocation loc) {
+        try {
+            return super.getFile(loc);
+        } catch (FileNotFoundException e) {
+            throw new ResponseErrorException(unknownFileError(loc, loc));
         }
-        return file;
     }
 
     public void shutdown() {
@@ -611,11 +571,11 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
         return recoverExceptions(file.getCurrentTreeAsync(true)
             .thenApply(Versioned::get)
             .thenApply(tr -> params.getPositions().stream()
-                .map(p -> Locations.setPosition(file.getLocation(), p, columns))
+                .map(p -> Locations.setPosition(file.getLocation(), p, getColumnMaps()))
                 .map(p -> {
                     var focus = TreeSearch.computeFocusList(tr, p.getBeginLine(), p.getBeginColumn());
                     var locs = SelectionRanges.uniqueTreeLocations(focus);
-                    return SelectionRanges.toSelectionRange(p, locs, columns);
+                    return SelectionRanges.toSelectionRange(p, locs, getColumnMaps());
                 })
                 .collect(Collectors.toList())));
     }
@@ -693,7 +653,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
                 .getCurrentTreeAsync(true)
                 .thenApply(Versioned::get)
                 .thenCompose((ITree tree) -> {
-                    var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getRange().getStart(), columns);
+                    var loc = Locations.setPosition(Locations.toLoc(params.getTextDocument()), params.getRange().getStart(), getColumnMaps());
                     return computeCodeActions(loc.getBeginLine(), loc.getBeginColumn(), tree, availableFacts().getPathConfig(loc));
                 })
                 .thenApply(IList::stream)
@@ -713,7 +673,7 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     private CodeLens makeRunCodeLens(CodeLensSuggestion detected) {
         return new CodeLens(
-            Locations.toRange(detected.getLine(), columns),
+            Locations.toRange(detected.getLine(), getColumnMaps()),
             new Command(detected.getShortName(), detected.getCommandName(), detected.getArguments()),
             null
         );
@@ -737,16 +697,6 @@ public class RascalTextDocumentService implements IBaseTextDocumentService, Lang
 
     private static <T> CompletableFuture<List<T>> recoverExceptions(CompletableFuture<List<T>> future) {
         return recoverExceptions(future, Collections::emptyList);
-    }
-
-    @Override
-    public boolean isManagingFile(ISourceLocation file) {
-        return documents.containsKey(file.top());
-    }
-
-    @Override
-    public @Nullable TextDocumentState getDocumentState(ISourceLocation file) {
-        return documents.get(file.top());
     }
 
     public FileFacts getFileFacts() {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -94,7 +94,6 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
@@ -231,14 +230,18 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         var timestamp = System.currentTimeMillis();
         logger.debug("Open: {}", params.getTextDocument());
         TextDocumentState file = open(params.getTextDocument(), timestamp);
-        handleParsingErrors(file, file.getCurrentDiagnosticsAsync());
+        handleParsingErrors(file, file.getCurrentDiagnosticsAsync(), this::reportDiagnostics);
     }
 
     @Override
     public void didChange(DidChangeTextDocumentParams params) {
         var timestamp = System.currentTimeMillis();
         logger.trace("Change: {}", params.getTextDocument());
-        updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp);
+        try {
+            updateContents(params.getTextDocument(), last(params.getContentChanges()).getText(), timestamp, this::reportDiagnostics);
+        } catch (FileNotFoundException ignored) {
+            throw new ResponseErrorException(unknownFileError(params.getTextDocument(), params));
+        }
     }
 
     @Override
@@ -278,25 +281,10 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         }
     }
 
-    private TextDocumentState updateContents(VersionedTextDocumentIdentifier doc, String newContents, long timestamp) {
-        TextDocumentState file = getFile(doc);
-        logger.trace("New contents for {}", doc);
-        updateFile(file.getLocation());
-        handleParsingErrors(file, file.update(doc.getVersion(), newContents, timestamp));
-        return file;
-    }
-
-    private void handleParsingErrors(TextDocumentState file, CompletableFuture<Versioned<List<Diagnostics.Template>>> diagnosticsAsync) {
-        diagnosticsAsync.thenAccept(diagnostics -> {
-            List<Diagnostic> parseErrors = diagnostics.get().stream()
-                .map(diagnostic -> diagnostic.instantiate(getColumnMaps()))
-                .collect(Collectors.toList());
-
-            logger.trace("Finished parsing tree, reporting new parse errors: {} for: {}", parseErrors, file.getLocation());
-            if (facts != null) {
-                facts.reportParseErrors(file.getLocation(), parseErrors);
-            }
-        });
+    private void reportDiagnostics(ISourceLocation file, Versioned<List<Diagnostics.Template>> diagnostics, List<Diagnostic> parseErrors) {
+        if (facts != null) {
+            facts.reportParseErrors(file, parseErrors);
+        }
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -149,7 +149,7 @@ public class FileFacts implements DiagnosticsReporter {
     private class ActualFileFact implements FileFact {
         private final ISourceLocation file;
         private final LazyUpdateableReference<InterruptibleFuture<@Nullable SummaryBridge>> summary;
-        private volatile AtomicReference<Versioned<List<Diagnostic>>> parseMessages = Versioned.atomic(-1, Collections.emptyList());
+        private AtomicReference<Versioned<List<Diagnostic>>> parseMessages = Versioned.atomic(-1, Collections.emptyList());
         private volatile List<Diagnostic> typeCheckerMessages = Collections.emptyList();
         private final ReplaceableFuture<Map<ISourceLocation, List<Diagnostic>>> typeCheckResults;
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -41,9 +42,11 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.util.locations.ColumnMaps;
+import org.rascalmpl.vscode.lsp.model.DiagnosticsReporter;
 import org.rascalmpl.vscode.lsp.rascal.RascalLanguageServices;
 import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.Lists;
+import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
 import org.rascalmpl.vscode.lsp.util.concurrent.InterruptibleFuture;
 import org.rascalmpl.vscode.lsp.util.concurrent.LazyUpdateableReference;
@@ -53,7 +56,7 @@ import org.rascalmpl.vscode.lsp.util.locations.Locations;
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.ISourceLocation;
 
-public class FileFacts {
+public class FileFacts implements DiagnosticsReporter {
     private static final Logger logger = LogManager.getLogger(FileFacts.class);
     private final Executor exec;
     private final RascalLanguageServices rascal;
@@ -70,7 +73,7 @@ public class FileFacts {
         this.cm = cm;
         this.confs = new PathConfigs(exec, new PathConfigDiagnostics(client, cm));
         this.nopFact = new FileFact() {
-            @Override public void reportParseErrors(List<Diagnostic> msgs) { /* NOP */}
+            @Override public void reportParseErrors(Versioned<List<Diagnostic>> msgs) { /* NOP */}
             @Override public void reportTypeCheckerErrors(List<Diagnostic> msgs) { /* NOP */ }
             @Override public void invalidate() { /* NOP */ }
             @Override public void close() { /* NOP */ }
@@ -95,7 +98,8 @@ public class FileFacts {
         return getFile(file).getSummary();
     }
 
-    public void reportParseErrors(ISourceLocation file, List<Diagnostic> msgs) {
+    @Override
+    public void reportParseErrors(ISourceLocation file, Versioned<List<Diagnostic>> msgs) {
         getFile(file).reportParseErrors(msgs);
     }
 
@@ -134,7 +138,7 @@ public class FileFacts {
     }
 
     private interface FileFact {
-        void reportParseErrors(List<Diagnostic> msgs);
+        void reportParseErrors(Versioned<List<Diagnostic>> msgs);
         void reportTypeCheckerErrors(List<Diagnostic> msgs);
         CompletableFuture<@Nullable SummaryBridge> getSummary();
         void invalidate();
@@ -145,7 +149,7 @@ public class FileFacts {
     private class ActualFileFact implements FileFact {
         private final ISourceLocation file;
         private final LazyUpdateableReference<InterruptibleFuture<@Nullable SummaryBridge>> summary;
-        private volatile List<Diagnostic> parseMessages = Collections.emptyList();
+        private volatile AtomicReference<Versioned<List<Diagnostic>>> parseMessages = Versioned.atomic(-1, Collections.emptyList());
         private volatile List<Diagnostic> typeCheckerMessages = Collections.emptyList();
         private final ReplaceableFuture<Map<ISourceLocation, List<Diagnostic>>> typeCheckResults;
 
@@ -165,9 +169,10 @@ public class FileFacts {
         }
 
         @Override
-        public void reportParseErrors(List<Diagnostic> msgs) {
-            parseMessages = msgs;
-            sendDiagnostics();
+        public void reportParseErrors(Versioned<List<Diagnostic>> msgs) {
+            if (Versioned.replaceIfNewer(parseMessages, msgs)) {
+                sendDiagnostics();
+            }
         }
 
         @Override
@@ -184,7 +189,7 @@ public class FileFacts {
             logger.trace("Sending diagnostics for: {}", file);
             client.publishDiagnostics(new PublishDiagnosticsParams(
                 Locations.toUri(file).toString(),
-                Lists.union(typeCheckerMessages, parseMessages)));
+                Lists.union(typeCheckerMessages, parseMessages.get().get())));
         }
 
         @Override
@@ -204,7 +209,7 @@ public class FileFacts {
 
         @Override
         public void close() {
-            if ((parseMessages.isEmpty() && typeCheckerMessages.isEmpty()) || !URIResolverRegistry.getInstance().exists(file)) {
+            if ((parseMessages.get().get().isEmpty() && typeCheckerMessages.isEmpty()) || !URIResolverRegistry.getInstance().exists(file)) {
                 // If there are no messages for this file or the file has been deleted, can we remove it
                 // else VS Code comes back and we've dropped the messages in our internal data
                 files.remove(file);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/FallbackResolver.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/FallbackResolver.java
@@ -28,6 +28,7 @@ package org.rascalmpl.vscode.lsp.uri;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -325,10 +326,9 @@ public class FallbackResolver implements ISourceLocationInputOutput, ISourceLoca
 
     public TextDocumentState getDocumentState(ISourceLocation file) throws IOException {
         for (var service : textDocumentServices) {
-            var state = service.getDocumentState(file);
-            if (state != null) {
-                return state;
-            }
+            try {
+                return service.getEditorState(file);
+            } catch (FileNotFoundException ignored) { /* try the next service */}
         }
         throw new IOException("File is not managed by lsp");
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Versioned.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Versioned.java
@@ -27,6 +27,7 @@
 package org.rascalmpl.vscode.lsp.util;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
 public class Versioned<T> {
@@ -76,5 +77,9 @@ public class Versioned<T> {
                 return false;
             }
         }
+    }
+
+    public <U> Versioned<U> map(Function<? super T, ? extends U> func) {
+        return new Versioned<U>(this.version, func.apply(this.object), this.timestamp);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Versioned.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/Versioned.java
@@ -80,6 +80,6 @@ public class Versioned<T> {
     }
 
     public <U> Versioned<U> map(Function<? super T, ? extends U> func) {
-        return new Versioned<U>(this.version, func.apply(this.object), this.timestamp);
+        return new Versioned<>(this.version, func.apply(this.object), this.timestamp);
     }
 }


### PR DESCRIPTION
Factor out management of open text document contents, reducing the amount of shared code between Rascal and language-parametric LSP implementations. This work also server as preparation for #1010, which will need the same document management on yet another class.