### PR TITLE
Upload logs as artifact on failed test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,6 +129,15 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
+      - name: Upload logs
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: logs-${{ matrix.os }}
+          path: ./rascal-vscode-extension/uitests/settings/logs/**/usethesource.rascalmpl/*.log
+          retention-days: 5
+          if-no-files-found: error
+
       - name: "cleanup before cache"
         shell: bash
         if: always()


### PR DESCRIPTION
Upload the logs from the VS Code log output channels on UI test failure.