### PR TITLE
Refactor workspace notifications

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -58,6 +58,8 @@ import org.rascalmpl.vscode.lsp.util.Nullables;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
+import io.usethesource.vallang.ISourceLocation;
+
 public abstract class BaseWorkspaceService implements WorkspaceService, LanguageClientAware {
     private static final Logger logger = LogManager.getLogger(BaseWorkspaceService.class);
 
@@ -77,7 +79,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         this.exec = exec;
     }
 
-    private IBaseTextDocumentService availableDocumentService() {
+    protected IBaseTextDocumentService availableDocumentService() {
         if (documentService == null) {
             throw new IllegalStateException("Document service has not been constructed yet");
         }
@@ -136,7 +138,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         if (removed != null) {
             workspaceFolders.removeAll(removed);
             for (WorkspaceFolder folder : removed) {
-                availableDocumentService().projectRemoved(folder.getName(), Locations.toLoc(folder.getUri()));
+                projectRemoved(folder.getName(), Locations.toLoc(folder.getUri()));
             }
         }
 
@@ -147,6 +149,10 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
                 availableDocumentService().projectAdded(folder.getName(), Locations.toLoc(folder.getUri()));
             }
         }
+    }
+
+    protected void projectRemoved(String name, ISourceLocation loc) {
+        // Nothing to do by default
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -138,7 +138,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         if (removed != null) {
             workspaceFolders.removeAll(removed);
             for (WorkspaceFolder folder : removed) {
-                projectRemoved(folder.getName(), Locations.toLoc(folder.getUri()));
+                projectRemoved(Locations.toLoc(folder.getUri()));
             }
         }
 
@@ -148,7 +148,7 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         }
     }
 
-    protected void projectRemoved(String name, ISourceLocation loc) {
+    protected void projectRemoved(ISourceLocation loc) {
         // Nothing to do by default
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/BaseWorkspaceService.java
@@ -145,9 +145,6 @@ public abstract class BaseWorkspaceService implements WorkspaceService, Language
         var added = params.getEvent().getAdded();
         if (added != null) {
             workspaceFolders.addAll(added);
-            for (WorkspaceFolder folder : added) {
-                availableDocumentService().projectAdded(folder.getName(), Locations.toLoc(folder.getUri()));
-            }
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -54,7 +54,6 @@ public interface IBaseTextDocumentService extends TextDocumentService, ITextDocu
     void unregisterLanguage(LanguageParameter lang);
 
     void projectAdded(String name, ISourceLocation projectRoot);
-    void projectRemoved(String name, ISourceLocation projectRoot);
 
     CompletableFuture<IValue> executeCommand(String languageName, String command);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.rascalmpl.vscode.lsp.parametric.LanguageRegistry.LanguageParameter;
 
-import io.usethesource.vallang.ISourceLocation;
 import io.usethesource.vallang.IValue;
 
 public interface IBaseTextDocumentService extends TextDocumentService, ITextDocumentStateManager {
@@ -52,8 +51,6 @@ public interface IBaseTextDocumentService extends TextDocumentService, ITextDocu
     void initialized();
     void registerLanguage(LanguageParameter lang);
     void unregisterLanguage(LanguageParameter lang);
-
-    void projectAdded(String name, ISourceLocation projectRoot);
 
     CompletableFuture<IValue> executeCommand(String languageName, String command);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -1034,11 +1034,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     }
 
     @Override
-    public void projectAdded(String name, ISourceLocation projectRoot) {
-        // No need to do anything
-    }
-
-    @Override
     public CompletableFuture<IValue> executeCommand(String languageName, String command) {
         ILanguageContributions contribs = contributions.get(languageName);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -1039,11 +1039,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     }
 
     @Override
-    public void projectRemoved(String name, ISourceLocation projectRoot) {
-        // No need to do anything
-    }
-
-    @Override
     public CompletableFuture<IValue> executeCommand(String languageName, String command) {
         ILanguageContributions contribs = contributions.get(languageName);
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -582,8 +582,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         // No need to do anything
     }
 
-    @Override
-    public void projectRemoved(String name, ISourceLocation projectRoot) {
+    /*package*/ void projectRemoved(String name, ISourceLocation projectRoot) {
         if (facts != null) {
             facts.projectRemoved(projectRoot);
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -577,11 +577,6 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         throw new UnsupportedOperationException("registering language is a feature of the language parametric server, not of the Rascal server");
     }
 
-    @Override
-    public void projectAdded(String name, ISourceLocation projectRoot) {
-        // No need to do anything
-    }
-
     /*package*/ void projectRemoved(String name, ISourceLocation projectRoot) {
         if (facts != null) {
             facts.projectRemoved(projectRoot);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -577,7 +577,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         throw new UnsupportedOperationException("registering language is a feature of the language parametric server, not of the Rascal server");
     }
 
-    /*package*/ void projectRemoved(String name, ISourceLocation projectRoot) {
+    /*package*/ void projectRemoved(ISourceLocation projectRoot) {
         if (facts != null) {
             facts.projectRemoved(projectRoot);
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -45,6 +45,8 @@ import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.util.Nullables;
 
+import io.usethesource.vallang.ISourceLocation;
+
 public class RascalWorkspaceService extends BaseWorkspaceService {
 
     RascalWorkspaceService(ExecutorService exec) {
@@ -74,6 +76,11 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
         if (Nullables.has(clientCap.getWorkspace(), WorkspaceClientCapabilities::getFileOperations, FileOperationsWorkspaceCapabilities::getDidDelete)) {
             fileOperationCapabilities.setDidDelete(whichFiles);
         }
+    }
+
+    @Override
+    protected void projectRemoved(String name, ISourceLocation loc) {
+        ((RascalTextDocumentService) availableDocumentService()).projectRemoved(name, loc);
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalWorkspaceService.java
@@ -79,8 +79,8 @@ public class RascalWorkspaceService extends BaseWorkspaceService {
     }
 
     @Override
-    protected void projectRemoved(String name, ISourceLocation loc) {
-        ((RascalTextDocumentService) availableDocumentService()).projectRemoved(name, loc);
+    protected void projectRemoved(ISourceLocation loc) {
+        ((RascalTextDocumentService) availableDocumentService()).projectRemoved(loc);
     }
 
 }


### PR DESCRIPTION
This PR removes an empty function and refactors workspace changes to reduce the size of `IBaseTextDocumentService`, simplifying the implementation of document services (like in #1068).