### PR TITLE
Test IDE services from DSLs and REPL

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/IBaseTextDocumentService.java
@@ -27,6 +27,7 @@
 package org.rascalmpl.vscode.lsp;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -53,6 +54,7 @@ public interface IBaseTextDocumentService extends TextDocumentService, ITextDocu
     void unregisterLanguage(LanguageParameter lang);
 
     CompletableFuture<IValue> executeCommand(String languageName, String command);
+    Collection<String> extensions();
 
     void didCreateFiles(CreateFilesParams params);
     void didRenameFiles(RenameFilesParams params, List<WorkspaceFolder> workspaceFolders);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -186,4 +186,9 @@ public class LSPIDEServices implements IDEServices {
         languageClient.showMessage(Message.toMessageParams(message));
     }
 
+    @Override
+    public void logMessage(IConstructor msg) {
+        languageClient.logMessage(Message.toMessageParams(msg));
+    }
+
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -44,6 +44,7 @@ import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
+import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IMap;
@@ -179,20 +180,20 @@ public class LSPIDEServices implements IDEServices {
         return monitor;
     }
 
-    /*
     @Override
     public void showMessage(IConstructor message) {
         // Not overriden; tends to cause deadlocks
         // https://github.com/usethesource/rascal-language-servers/issues/185
-        languageClient.showMessage(Message.toMessageParams(message));
+        // languageClient.showMessage(Message.toMessageParams(message));
+        IDEServices.super.showMessage(message);
     }
 
     @Override
     public void logMessage(IConstructor msg) {
         // Not overriden; tends to cause deadlocks
         // https://github.com/usethesource/rascal-language-servers/issues/185
-        languageClient.logMessage(Message.toMessageParams(msg));
+        // languageClient.logMessage(Message.toMessageParams(msg));
+        IDEServices.super.logMessage(msg);
     }
-    */
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -42,10 +42,8 @@ import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
-import org.rascalmpl.vscode.lsp.rascal.conversion.Message;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
-import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IMap;
@@ -181,6 +179,7 @@ public class LSPIDEServices implements IDEServices {
         return monitor;
     }
 
+    /*
     @Override
     public void showMessage(IConstructor message) {
         languageClient.showMessage(Message.toMessageParams(message));
@@ -190,5 +189,6 @@ public class LSPIDEServices implements IDEServices {
     public void logMessage(IConstructor msg) {
         languageClient.logMessage(Message.toMessageParams(msg));
     }
+    */
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -124,7 +124,7 @@ public class LSPIDEServices implements IDEServices {
 
     @Override
     public void registerDiagnostics(IList messages) {
-        Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(messages, docService.getColumnMaps());
+        Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(messages, docService.extensions(), docService.getColumnMaps());
 
         for (Entry<ISourceLocation, List<Diagnostic>> entry : translated.entrySet()) {
             var uri = Locations.toUri(entry.getKey()).toString();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -42,8 +42,10 @@ import org.rascalmpl.ideservices.IDEServices;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
+import org.rascalmpl.vscode.lsp.rascal.conversion.Message;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
+import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.IMap;
@@ -177,6 +179,11 @@ public class LSPIDEServices implements IDEServices {
 
     public IRascalMonitor getMonitor() {
         return monitor;
+    }
+
+    @Override
+    public void showMessage(IConstructor message) {
+        languageClient.showMessage(Message.toMessageParams(message));
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -182,11 +182,15 @@ public class LSPIDEServices implements IDEServices {
     /*
     @Override
     public void showMessage(IConstructor message) {
+        // Not overriden; tends to cause deadlocks
+        // https://github.com/usethesource/rascal-language-servers/issues/185
         languageClient.showMessage(Message.toMessageParams(message));
     }
 
     @Override
     public void logMessage(IConstructor msg) {
+        // Not overriden; tends to cause deadlocks
+        // https://github.com/usethesource/rascal-language-servers/issues/185
         languageClient.logMessage(Message.toMessageParams(msg));
     }
     */

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/LSPIDEServices.java
@@ -182,7 +182,7 @@ public class LSPIDEServices implements IDEServices {
 
     @Override
     public void showMessage(IConstructor message) {
-        // Not overriden; tends to cause deadlocks
+        // Not overriden; there are indications that this causes deadlocks
         // https://github.com/usethesource/rascal-language-servers/issues/185
         // languageClient.showMessage(Message.toMessageParams(message));
         IDEServices.super.showMessage(message);
@@ -190,7 +190,7 @@ public class LSPIDEServices implements IDEServices {
 
     @Override
     public void logMessage(IConstructor msg) {
-        // Not overriden; tends to cause deadlocks
+        // Not overriden; there are indications that this causes deadlocks
         // https://github.com/usethesource/rascal-language-servers/issues/185
         // languageClient.logMessage(Message.toMessageParams(msg));
         IDEServices.super.logMessage(msg);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -148,6 +148,7 @@ import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentSymbols;
 import org.rascalmpl.vscode.lsp.rascal.conversion.FoldingRanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.KeywordParameter;
+import org.rascalmpl.vscode.lsp.rascal.conversion.Message;
 import org.rascalmpl.vscode.lsp.rascal.conversion.SelectionRanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.SemanticTokenizer;
 import org.rascalmpl.vscode.lsp.uri.LSPOpenFileRedirector;
@@ -466,33 +467,8 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         }
 
         for (var msg : messages) {
-            client.showMessage(setMessageParams((IConstructor) msg));
+            client.showMessage(Message.toMessageParams((IConstructor) msg));
         }
-    }
-
-    private static MessageParams setMessageParams(IConstructor message) {
-        var params = new MessageParams();
-        switch (message.getName()) {
-            case "warning": {
-                params.setType(MessageType.Warning);
-                break;
-            }
-            case "info": {
-                params.setType(MessageType.Info);
-                break;
-            }
-            default: params.setType(MessageType.Log);
-        }
-
-        var msgText = ((IString) message.get("msg")).getValue();
-        if (message.has("at")) {
-            var at = Locations.toUri((ISourceLocation) message.get("at"));
-            params.setMessage(String.format("%s (at %s)", msgText, at));
-        } else {
-            params.setMessage(msgText);
-        }
-
-        return params;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -655,6 +655,12 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         return URIUtil.getExtension(doc);
     }
 
+    @Override
+    @SuppressWarnings("java:S1905") // cast necessary for CF
+    public Collection<String> extensions() {
+        return (Collection<String>) registeredExtensions.keySet();
+    }
+
     private ParametricFileFacts facts(ISourceLocation doc) {
         ParametricFileFacts fact = facts.get(language(doc));
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -26,6 +26,7 @@
  */
 package org.rascalmpl.vscode.lsp.rascal;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -214,6 +215,11 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
     public void initialized() {
         // reserved for future use
         // e.g. dynamic registration of capabilities
+    }
+
+    @Override
+    public Collection<String> extensions() {
+        return Set.of("rsc");
     }
 
     // LSP interface methods

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -134,7 +134,6 @@ import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.IList;
 import io.usethesource.vallang.ISet;
 import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IString;
 import io.usethesource.vallang.IValue;
 import io.usethesource.vallang.IValueFactory;
 
@@ -393,34 +392,6 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
                 availableClient().showMessage(Message.toMessageParams((IConstructor) msg));
             }
         });
-    }
-
-    private MessageParams setMessageParams(IConstructor message) {
-        var params = new MessageParams();
-        switch (message.getName()) {
-            case "error": {
-                params.setType(MessageType.Error);
-                break;
-            }
-            case "warning": {
-                params.setType(MessageType.Warning);
-                break;
-            }
-            case "info": {
-                params.setType(MessageType.Info);
-                break;
-            }
-            default: params.setType(MessageType.Log);
-        }
-
-        var msgText = ((IString) message.get("msg")).getValue();
-        if (message.has("at")) {
-            var at = Locations.toUri((ISourceLocation) message.get("at"));
-            params.setMessage(String.format("%s (at %s)", msgText, at));
-        } else {
-            params.setMessage(msgText);
-        }
-        return params;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -119,6 +119,7 @@ import org.rascalmpl.vscode.lsp.rascal.conversion.CodeActions;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentSymbols;
 import org.rascalmpl.vscode.lsp.rascal.conversion.FoldingRanges;
+import org.rascalmpl.vscode.lsp.rascal.conversion.Message;
 import org.rascalmpl.vscode.lsp.rascal.conversion.SelectionRanges;
 import org.rascalmpl.vscode.lsp.rascal.conversion.SemanticTokenizer;
 import org.rascalmpl.vscode.lsp.rascal.model.FileFacts;
@@ -389,7 +390,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
     private void showMessages(ISet messages) {
         exec.submit(() -> {
             for (var msg : messages) {
-                availableClient().showMessage(setMessageParams((IConstructor) msg));
+                availableClient().showMessage(Message.toMessageParams((IConstructor) msg));
             }
         });
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Diagnostics.java
@@ -27,6 +27,7 @@
 package org.rascalmpl.vscode.lsp.rascal.conversion;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -239,9 +240,9 @@ public class Diagnostics {
         return Locations.toRange(loc, cm);
     }
 
-    public static Map<ISourceLocation, List<Diagnostic>> translateMessages(Map<ISourceLocation, ISet> messagesPerModule, ColumnMaps cm) {
+    public static Map<ISourceLocation, List<Diagnostic>> translateMessages(Map<ISourceLocation, ISet> messagesPerModule, Collection<String> validExtensions, ColumnMaps cm) {
         return messagesPerModule.entrySet().stream()
-            .filter(kv -> isValidLocation(kv.getKey(), kv.getValue()))
+            .filter(kv -> isValidLocation(kv.getKey(), kv.getValue(), validExtensions))
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
                 kv -> translateDiagnostics(kv.getValue(), cm)
@@ -256,11 +257,11 @@ public class Diagnostics {
             .collect(Collectors.toList());
     }
 
-    public static Map<ISourceLocation, List<Diagnostic>> translateMessages(ICollection<?> messages, ColumnMaps cm) {
+    public static Map<ISourceLocation, List<Diagnostic>> translateMessages(ICollection<?> messages, Collection<String> validExtensions, ColumnMaps cm) {
         return messages.stream()
             .filter(IConstructor.class::isInstance)
             .map(IConstructor.class::cast)
-            .filter(Diagnostics::hasValidLocation)
+            .filter(m -> hasValidLocation(m, validExtensions))
             .map(d -> Pair.of(getMessageLocation(d), translateDiagnostic(d, cm)))
             .collect(Collectors.groupingBy(Pair::getLeft, Collectors.mapping(Pair::getRight, Collectors.toList())));
     }
@@ -273,16 +274,16 @@ public class Diagnostics {
         return ((IString) msg.get("msg")).getValue();
     }
 
-    private static boolean hasValidLocation(IConstructor d) {
-        return isValidLocation(getMessageLocation(d), d);
+    private static boolean hasValidLocation(IConstructor d, Collection<String> validExtensions) {
+        return isValidLocation(getMessageLocation(d), d, validExtensions);
     }
 
-    private static boolean isValidLocation(ISourceLocation loc, IValue m) {
+    private static boolean isValidLocation(ISourceLocation loc, IValue m, Collection<String> validExtensions) {
         if (loc == null || loc.getScheme().equals("unknown")) {
             logger.trace("Dropping diagnostic due to incorrect location on message: {}", m);
             return false;
         }
-        if (loc.getPath().endsWith(".rsc")) {
+        if (validExtensions.stream().anyMatch(ext -> loc.getPath().endsWith("." + ext))) {
             return true;
         }
         if (loc.getPath().endsWith("/RASCAL.MF")) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Diagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Diagnostics.java
@@ -31,9 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,12 +73,6 @@ public class Diagnostics {
     }
 
     private Diagnostics() {/* hide implicit public constructor */ }
-
-    public static <K, V> Map<K, List<V>> groupByKey(Stream<Entry<K, V>> diagnostics) {
-        return diagnostics.collect(
-            Collectors.groupingBy(Entry::getKey,
-                Collectors.mapping(Entry::getValue, Collectors.toCollection(ArrayList::new))));
-    }
 
     /**
      * Template for a diagnostic, to be instantiated using column maps. This
@@ -209,7 +201,7 @@ public class Diagnostics {
         return result;
     }
 
-    public static Diagnostic translateDiagnostic(IConstructor d, Range range, ColumnMaps otherFiles) {
+    private static Diagnostic translateDiagnostic(IConstructor d, Range range, ColumnMaps otherFiles) {
         Diagnostic result = new Diagnostic();
         result.setSeverity(translateSeverity(d));
         result.setMessage(getMessageString(d));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Message.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Message.java
@@ -44,6 +44,10 @@ public class Message {
     public static MessageParams toMessageParams(IConstructor message) {
         var params = new MessageParams();
         switch (message.getName()) {
+            case "error": {
+                params.setType(MessageType.Error);
+                break;
+            }
             case "warning": {
                 params.setType(MessageType.Warning);
                 break;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Message.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/Message.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.vscode.lsp.rascal.conversion;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
+
+import io.usethesource.vallang.IConstructor;
+import io.usethesource.vallang.ISourceLocation;
+import io.usethesource.vallang.IString;
+
+/**
+ * Translates Rascal data-type representation of messages to the LSP representation.
+ */
+public class Message {
+
+    private Message() { /* hide implicit constructor */ }
+
+    public static MessageParams toMessageParams(IConstructor message) {
+        var params = new MessageParams();
+        switch (message.getName()) {
+            case "warning": {
+                params.setType(MessageType.Warning);
+                break;
+            }
+            case "info": {
+                params.setType(MessageType.Info);
+                break;
+            }
+            default: params.setType(MessageType.Log);
+        }
+
+        var msgText = ((IString) message.get("msg")).getValue();
+        if (message.has("at")) {
+            var at = Locations.toUri((ISourceLocation) message.get("at"));
+            params.setMessage(String.format("%s (at %s)", msgText, at));
+        } else {
+            params.setMessage(msgText);
+        }
+
+        return params;
+    }
+
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/FileFacts.java
@@ -29,6 +29,7 @@ package org.rascalmpl.vscode.lsp.rascal.model;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -203,7 +204,7 @@ public class FileFacts implements DiagnosticsReporter {
             typeCheckerMessages.clear();
             this.typeCheckResults.replace(
                 rascal.compileFile(file, confs.lookupConfig(file), exec)
-                    .thenApply(m -> Diagnostics.translateMessages(m, cm))
+                    .thenApply(m -> Diagnostics.translateMessages(m, Set.of("rsc"), cm))
             ).thenAccept(m -> m.forEach((f, msgs) -> getFile(f).reportTypeCheckerErrors(msgs)));
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnostics.java
@@ -27,6 +27,7 @@
 package org.rascalmpl.vscode.lsp.rascal.model;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -59,9 +60,9 @@ import io.usethesource.vallang.ISourceLocation;
         this.cm = cm;
     }
 
-    public void publishDiagnostics(ISourceLocation project, IList messages) {
+    public void publishDiagnostics(ISourceLocation project, IList messages, Collection<String> validExtensions) {
         // Gather messages per file
-        publishDiagnostics(project, Diagnostics.translateMessages(messages, cm));
+        publishDiagnostics(project, Diagnostics.translateMessages(messages, validExtensions, cm));
     }
 
     public void clearDiagnostics(ISourceLocation project) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -33,6 +33,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -232,7 +233,7 @@ public class PathConfigs {
             var pathConfig = PathConfig.fromSourceProjectRascalManifest(projectRoot, RascalConfigMode.COMPILER, true);
             logger.debug("Path config for {}: {}", projectRoot, pathConfig);
             // Publish diagnostics in a background thread
-            executor.execute(() -> diagnostics.publishDiagnostics(projectRoot, pathConfig.getMessages()));
+            executor.execute(() -> diagnostics.publishDiagnostics(projectRoot, pathConfig.getMessages(), Set.of("rsc")));
             return Pair.of(pathConfig, time);
         }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
@@ -120,7 +120,7 @@ public class RemoteIDEServicesServer implements IRemoteIDEServices {
     public CompletableFuture<Void> registerDiagnostics(RegisterDiagnosticsParameters param) {
         logger.trace("registerDiagnostics({})", param);
         return CompletableFuture.runAsync(() -> {
-            Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(param.getMessages(), docService.getColumnMaps());
+            Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(param.getMessages(), docService.extensions(), docService.getColumnMaps());
 
             for (Entry<ISourceLocation, List<Diagnostic>> entry : translated.entrySet()) {
                 languageClient.publishDiagnostics(new PublishDiagnosticsParams(Locations.toUri(entry.getKey()).toString(), entry.getValue()));

--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -164,11 +164,11 @@ set[loc] picoDefinitionService([*_, Id use, *_, start[Program] input]) = { def.s
 list[CodeAction] prepareNotDefinedFixes(loc src,  rel[str, loc] defs)
     = [CodeAction::action(title="Change to <existing<0>>", edits=[changed(src.top, [replace(src, existing<0>)])]) | existing <- defs];
 
-@synopsis{Finds a declaration that the cursor is on and proposes to remove it.}
+@synopsis{Finds a declaration that the cursor is on and proposes to remove it or add a TODO to it.}
 list[CodeAction] picoCodeActionService([*_, IdType x, *_, start[Program] program])
     = [CodeAction::action(command=removeDecl(program, x, title="remove <x>"))];
 
-default list[CodeAction] picoCodeActionService(Focus _focus) = [];
+default list[CodeAction] picoCodeActionService(Focus focus) = [];
 
 @synsopsis{Defines example commands that can be triggered by the user (from a code lens, from a diagnostic, or just from the cursor position)}
 data Command

--- a/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/demo/lang/pico/LanguageServer.rsc
@@ -168,7 +168,7 @@ list[CodeAction] prepareNotDefinedFixes(loc src,  rel[str, loc] defs)
 list[CodeAction] picoCodeActionService([*_, IdType x, *_, start[Program] program])
     = [CodeAction::action(command=removeDecl(program, x, title="remove <x>"))];
 
-default list[CodeAction] picoCodeActionService(Focus focus) = [];
+default list[CodeAction] picoCodeActionService(Focus _focus) = [];
 
 @synsopsis{Defines example commands that can be triggered by the user (from a code lens, from a diagnostic, or just from the cursor position)}
 data Command

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -95,11 +95,11 @@ lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
         <input.src, browseRascalSite(title="Browse Rascal site")>,
-        <input.src, editPico(input.src.top, title="Edit another file")>/*,
+        <input.src, editPico(input.src.top, title="Edit another file")>,
         <input.src, addTodo(input.src, title="Register TODO")>,
         <input.src, removeTodo(input.src, title="Unregister TODO")>,
         <input.src, showWarning("Test warning", input.src, title="Show warning")>,
-        <input.src, showContents("Some text", title="Show some text")>*/
+        <input.src, showContents("Some text", title="Show some text")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -100,8 +100,8 @@ lrel[loc, Command] testingCodeLensService(start[Program] input)
         <lineOffset(input.src, 1), browseRascalSite(title="Browse Rascal site")>,
         <lineOffset(input.src, 1), editPico(input.src.top, title="Edit another file")>,
         <lineOffset(input.src, 1), addTodo(input.src, title="Register TODO")>,
-        <lineOffset(input.src, 2), removeTodo(input.src, title="Unregister TODO")>,
-        <lineOffset(input.src, 2), showWarning("Test warning", input.src, title="Show warning")>,
+        <lineOffset(input.src, 1), removeTodo(input.src, title="Unregister TODO")>,
+        <lineOffset(input.src, 1), showWarning("Test warning", input.src, title="Show warning")>,
         <lineOffset(input.src, 2), showContents("Some text", title="Show some text")>
     ];
 

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -36,6 +36,7 @@ import Node;
 data Command
   = testValueEncoding()
   | browseRascalSite()
+  | editPico(loc uri)
   | addTodo(loc at)
   | removeTodo(loc at)
   ;
@@ -59,6 +60,12 @@ value testingExecutionService(browseRascalSite()) {
     return ("result": true);
 }
 
+@synopsis{Command handler from the ((editPico)) command}
+value picoExecutionService(editPico(loc uri)) {
+    edit(uri[file = uri.file == "calls.pico" ? "testing.pico" : "calls.pico"]);
+    return ("result": true);
+}
+
 @synopsis{Command handler from the ((registerDiagnostics)) command}
 value testingExecutionService(addTodo(loc at)) {
     registerDiagnostics([info("TODO", at)]);
@@ -75,6 +82,7 @@ lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
         <input.src, browseRascalSite(title="Browse Rascal site")>,
+        <input.src, editPico(input.src.top, title="Edit another file")>,
         <input.src, addTodo(input.src, title="Register TODO")>,
         <input.src, removeTodo(input.src, title="Unregister TODO")>
     ];

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -40,6 +40,7 @@ data Command
   | addTodo(loc at)
   | removeTodo(loc at)
   | showWarning(str message, loc at)
+  | showContents(str contents)
   ;
 
 @synopsis{Command handler to test JSON serialization of various Rascal value types.}
@@ -85,6 +86,11 @@ value picoExecutionService(showWarning(str msg, loc at)) {
     return ("result": true);
 }
 
+value picoExecutionService(showContents(str contents)) {
+    showInteractiveContent(plainText(contents));
+    return ("result" : true);
+}
+
 lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
@@ -92,7 +98,8 @@ lrel[loc, Command] testingCodeLensService(start[Program] input)
         <input.src, editPico(input.src.top, title="Edit another file")>,
         <input.src, addTodo(input.src, title="Register TODO")>,
         <input.src, removeTodo(input.src, title="Unregister TODO")>,
-        <input.src, showWarning("Test warning", input.src, title="Show warning")>
+        <input.src, showWarning("Test warning", input.src, title="Show warning")>,
+        <input.src, showContents("Some text", title="Show some text")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -102,7 +102,7 @@ lrel[loc, Command] testingCodeLensService(start[Program] input)
         <lineOffset(input.src, 1), addTodo(input.src, title="Register TODO")>,
         <lineOffset(input.src, 1), removeTodo(input.src, title="Unregister TODO")>,
         <lineOffset(input.src, 1), showWarning("Test warning", input.src, title="Show warning")>,
-        <lineOffset(input.src, 2), showContents("Some text", title="Show some text")>
+        <lineOffset(input.src, 1), showContents("Some text", title="Show some text")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -95,11 +95,11 @@ lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
         <input.src, browseRascalSite(title="Browse Rascal site")>,
-        <input.src, editPico(input.src.top, title="Edit another file")>,
+        <input.src, editPico(input.src.top, title="Edit another file")>/*,
         <input.src, addTodo(input.src, title="Register TODO")>,
         <input.src, removeTodo(input.src, title="Unregister TODO")>,
         <input.src, showWarning("Test warning", input.src, title="Show warning")>,
-        <input.src, showContents("Some text", title="Show some text")>
+        <input.src, showContents("Some text", title="Show some text")>*/
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -81,6 +81,7 @@ value picoExecutionService(removeTodo(loc at)) {
 
 value picoExecutionService(showWarning(str msg, loc at)) {
     showMessage(warning(msg, at));
+    logMessage(error("LOG " + msg, at));
     return ("result": true);
 }
 

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -91,18 +91,19 @@ value picoExecutionService(showContents(str contents)) {
     return ("result" : true);
 }
 
-private loc lineOffset(loc src, int off)
-    = src[begin = <src.begin.line + off, src.begin.column>];
+private loc declOffset(start[Program] input, int off)
+    = input.top.decls.decls[off].src;
 
 lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
+    // Since
     + [
-        <lineOffset(input.src, 1), browseRascalSite(title="Browse Rascal site")>,
-        <lineOffset(input.src, 1), editPico(input.src.top, title="Edit another file")>,
-        <lineOffset(input.src, 1), addTodo(input.src, title="Register TODO")>,
-        <lineOffset(input.src, 1), removeTodo(input.src, title="Unregister TODO")>,
-        <lineOffset(input.src, 1), showWarning("Test warning", input.src, title="Show warning")>,
-        <lineOffset(input.src, 1), showContents("Some text", title="Show some text")>
+        <declOffset(input, 0), browseRascalSite(title="Browse Rascal site")>,
+        <declOffset(input, 0), editPico(input.src.top, title="Edit another file")>,
+        <declOffset(input, 0), addTodo(input.src, title="Register TODO")>,
+        <declOffset(input, 0), removeTodo(input.src, title="Unregister TODO")>,
+        <declOffset(input, 0), showWarning("Test warning", input.src, title="Show warning")>,
+        <declOffset(input, 0), showContents("Some text", title="Show some text")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -37,6 +37,7 @@ data Command
   = testValueEncoding()
   | browseRascalSite()
   | addTodo(loc at)
+  | removeTodo(loc at)
   ;
 
 @synopsis{Command handler to test JSON serialization of various Rascal value types.}
@@ -64,11 +65,18 @@ value testingExecutionService(addTodo(loc at)) {
     return ("result": true);
 }
 
+@synopsis{Command handler from the ((unregisterDiagnostics)) command}
+value picoExecutionService(removeTodo(loc at)) {
+    unregisterDiagnostics([at]);
+    return ("result": true);
+}
+
 lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
         <input.src, browseRascalSite(title="Browse Rascal site")>,
-        <input.src, addTodo(input.src, title="Register TODO")>
+        <input.src, addTodo(input.src, title="Register TODO")>,
+        <input.src, removeTodo(input.src, title="Unregister TODO")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -39,6 +39,7 @@ data Command
   | editPico(loc uri)
   | addTodo(loc at)
   | removeTodo(loc at)
+  | showWarning(str message, loc at)
   ;
 
 @synopsis{Command handler to test JSON serialization of various Rascal value types.}
@@ -78,13 +79,19 @@ value picoExecutionService(removeTodo(loc at)) {
     return ("result": true);
 }
 
+value picoExecutionService(showWarning(str msg, loc at)) {
+    showMessage(warning(msg, at));
+    return ("result": true);
+}
+
 lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
         <input.src, browseRascalSite(title="Browse Rascal site")>,
         <input.src, editPico(input.src.top, title="Edit another file")>,
         <input.src, addTodo(input.src, title="Register TODO")>,
-        <input.src, removeTodo(input.src, title="Unregister TODO")>
+        <input.src, removeTodo(input.src, title="Unregister TODO")>,
+        <input.src, showWarning("Test warning", input.src, title="Show warning")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -91,15 +91,18 @@ value picoExecutionService(showContents(str contents)) {
     return ("result" : true);
 }
 
+private loc lineOffset(loc src, int off)
+    = src[begin = <src.begin.line + off, src.begin.column>];
+
 lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
-        <input.src, browseRascalSite(title="Browse Rascal site")>,
-        <input.src, editPico(input.src.top, title="Edit another file")>,
-        <input.src, addTodo(input.src, title="Register TODO")>,
-        <input.src, removeTodo(input.src, title="Unregister TODO")>,
-        <input.src, showWarning("Test warning", input.src, title="Show warning")>,
-        <input.src, showContents("Some text", title="Show some text")>
+        <lineOffset(input.src, 1), browseRascalSite(title="Browse Rascal site")>,
+        <lineOffset(input.src, 1), editPico(input.src.top, title="Edit another file")>,
+        <lineOffset(input.src, 1), addTodo(input.src, title="Register TODO")>,
+        <lineOffset(input.src, 2), removeTodo(input.src, title="Unregister TODO")>,
+        <lineOffset(input.src, 2), showWarning("Test warning", input.src, title="Show warning")>,
+        <lineOffset(input.src, 2), showContents("Some text", title="Show some text")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -33,7 +33,10 @@ import Node;
 
 // JSON serialization
 
-data Command = testValueEncoding();
+data Command
+  = testValueEncoding()
+  | browseRascalSite()
+  ;
 
 @synopsis{Command handler to test JSON serialization of various Rascal value types.}
 value testingExecutionService(testValueEncoding()) = (
@@ -48,6 +51,18 @@ value testingExecutionService(testValueEncoding()) = (
     ]
 );
 
+@synopsis{Command handler from the ((browseRascal)) command}
+value testingExecutionService(browseRascalSite()) {
+    browse(|https://www.rascal-mpl.org|, title="Rascal MPL");
+    return ("result": true);
+}
+
+lrel[loc, Command] testingCodeLensService(start[Program] input)
+    = picoCodeLenseService(input)
+    + [
+        <input.src, browseRascalSite(title="Browse Rascal site")>
+    ];
+
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)
     = replacements + {c | c <- contributions, getName(c) notin byName}
     when byName := {getName(r) | r <- replacements};
@@ -55,7 +70,8 @@ private set[LanguageService] amendContributions(set[LanguageService] contributio
 set[LanguageService] testingLanguageServer(bool allowRecovery)
     = amendContributions(picoLanguageServer(), {
         parsing(picoParser(allowRecovery), usesSpecialCaseHighlighting = false),
-        execution(picoExecutionService + testingExecutionService)
+        execution(picoExecutionService + testingExecutionService),
+        codeLens(testingCodeLensService)
     });
 
 set[LanguageService] testingLanguageServerSlowSummary(bool allowRecovery)

--- a/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
+++ b/rascal-lsp/src/main/rascal/library/testing/lang/pico/LanguageServer.rsc
@@ -36,6 +36,7 @@ import Node;
 data Command
   = testValueEncoding()
   | browseRascalSite()
+  | addTodo(loc at)
   ;
 
 @synopsis{Command handler to test JSON serialization of various Rascal value types.}
@@ -57,10 +58,17 @@ value testingExecutionService(browseRascalSite()) {
     return ("result": true);
 }
 
+@synopsis{Command handler from the ((registerDiagnostics)) command}
+value testingExecutionService(addTodo(loc at)) {
+    registerDiagnostics([info("TODO", at)]);
+    return ("result": true);
+}
+
 lrel[loc, Command] testingCodeLensService(start[Program] input)
     = picoCodeLenseService(input)
     + [
-        <input.src, browseRascalSite(title="Browse Rascal site")>
+        <input.src, browseRascalSite(title="Browse Rascal site")>,
+        <input.src, addTodo(input.src, title="Register TODO")>
     ];
 
 private set[LanguageService] amendContributions(set[LanguageService] contributions, set[LanguageService] replacements)

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigDiagnosticsTest.java
@@ -26,6 +26,18 @@
  */
 package org.rascalmpl.vscode.lsp.rascal.model;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Set;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Position;
@@ -37,20 +49,12 @@ import org.junit.Test;
 import org.rascalmpl.library.Messages;
 import org.rascalmpl.library.Prelude;
 import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
-import org.rascalmpl.util.locations.ColumnMaps;
 
 import io.usethesource.vallang.IConstructor;
 import io.usethesource.vallang.ISourceLocation;
-
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
 
 public class PathConfigDiagnosticsTest {
     private static final IRascalValueFactory VF = IRascalValueFactory.getInstance();
@@ -131,38 +135,38 @@ public class PathConfigDiagnosticsTest {
 
     @Test
     public void testPublishFresh() {
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1)));
     }
 
     @Test
     public void testPublishMultiProject() {
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
         // Expect the diagnostics for project A
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1)));
 
-        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)));
+        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)), Set.of());
         // Expect the diagnostics for both projects
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1), diag(4, 7, MSG2)));
     }
 
     @Test
     public void testDeleteOursButRetainTheirs() {
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1)));
 
-        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)));
+        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)), Set.of());
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(3, 7, MSG1), diag(4, 7, MSG2)));
 
         reset(mockedClient);
-        sut.publishDiagnostics(projectA, VF.list());
+        sut.publishDiagnostics(projectA, VF.list(), Set.of());
         verify(mockedClient).publishDiagnostics(params(pomAUrl, diag(4, 7, MSG2)));
     }
 
     @Test
     public void testClearDiagnostics() {
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
-        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
+        sut.publishDiagnostics(projectB, VF.list(msg(POM_A, MSG2, 5, 7)), Set.of());
 
         reset(mockedClient);
         sut.clearDiagnostics(projectA);
@@ -171,18 +175,18 @@ public class PathConfigDiagnosticsTest {
 
     @Test
     public void testDontPublishUnchangedDiags() {
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
         reset(mockedClient);
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
         verify(mockedClient, never()).publishDiagnostics(any());
     }
 
     @Test
     public void testMultiFileDiags() {
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)));
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_B, MSG2, 5, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_A, MSG1, 4, 7)), Set.of());
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_B, MSG2, 5, 7)), Set.of());
         reset(mockedClient);
-        sut.publishDiagnostics(projectA, VF.list(msg(POM_B, MSG1, 5, 7)));
+        sut.publishDiagnostics(projectA, VF.list(msg(POM_B, MSG1, 5, 7)), Set.of());
         verify(mockedClient).publishDiagnostics(params(pomBUrl, diag(4, 7, MSG1)));
     }
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -222,7 +222,7 @@ end
     it("code lens works", async function() {
         if (errorRecovery) { this.skip(); }
         const editor = await ide.openModule(TestWorkspace.picoFile);
-        await ide.clickCodeLens(editor, "Rename variables a to b.", Delays.verySlow, "Rename lens should be available");
+        await ide.clickCodeLens(editor, "Rename variables a to b.", Delays.verySlow);
         await ide.assertLineBecomes(editor, 9, "b := 2;", "a variable should be changed to b");
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -377,7 +377,7 @@ end
         await ide.clickCodeLens(editor, "Edit another file");
         await driver.wait(async () => {
             const currentTitle = await (await bench.getEditorView().getActiveTab())?.getTitle();
-            return currentTitle === initialTitle;
+            return currentTitle !== initialTitle;
         }, Delays.normal, "Another editor should open");
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, MarkerType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { InputBox, MarkerType, NotificationType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -404,8 +404,21 @@ end
         }, Delays.slow, "TODO should be unregistered");
     });
 
+    it("shows messages", async function() {
+        if (errorRecovery) { this.skip(); } // this does not depend on error recovery
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        await ide.clickCodeLens(editor, "Show warning");
+
+        await driver.wait(async () => {
+            const center = await bench.openNotificationsCenter();
+            const notifications = await center.getNotifications(NotificationType.Warning);
+            const messages = await Promise.all(notifications.map(n => n.getMessage()));
+            return messages.find(m => m.startsWith("Test warning"));
+        }, Delays.normal, "Test warning dialog should show");
+    });
+
     // TODO showInteractiveContent
-    // TODO showMessage
     // TODO logMessage
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, MarkerType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { InputBox, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -380,7 +380,7 @@ end
             return currentTitle !== initialTitle;
         }, Delays.normal, "Another editor should open");
     });
-
+    /*
     it("(un)registers diagnostics", async function() {
         if (errorRecovery) { this.skip(); } // this does not depend on error recovery
 
@@ -404,7 +404,6 @@ end
         }, Delays.slow, "TODO should be unregistered");
     });
 
-    /*
     it("shows messages", async function() {
         if (errorRecovery) { this.skip(); } // this does not depend on error recovery
 
@@ -431,7 +430,6 @@ end
             return contents.split("\n")[-1]?.indexOf("LOG") !== -1;
         }, Delays.normal, "Line should be logged");
     });
-    */
 
     it("shows interactive content", async function() {
         if (errorRecovery) { this.skip(); }
@@ -442,5 +440,6 @@ end
             return "*static content*" === await (await bench.getEditorView().getActiveTab())?.getTitle();
         }, Delays.normal, "Static content should be shown");
     });
+    */
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -222,7 +222,7 @@ end
     it("code lens works", async function() {
         if (errorRecovery) { this.skip(); }
         const editor = await ide.openModule(TestWorkspace.picoFile);
-        await ide.clickCodeLens(editor, "Rename variables a to b.", Delays.verySlow);
+        await ide.clickCodeLens(editor, "Rename variables a to b.", Delays.verySlow, "Rename lens should be available");
         await ide.assertLineBecomes(editor, 9, "b := 2;", "a variable should be changed to b");
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -431,6 +431,14 @@ end
         }, Delays.normal, "Line should be logged");
     });
 
-    // TODO showInteractiveContent
+    it("shows interactive content", async function() {
+        if (errorRecovery) { this.skip(); }
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        await ide.clickCodeLens(editor, "Show some text");
+        await driver.wait(async () => {
+            return "*static content*" === await (await bench.getEditorView().getActiveTab())?.getTitle();
+        }, Delays.normal, "Static content should be shown");
+    });
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -259,6 +259,7 @@ end
     it("renaming files works", async function() {
         if (errorRecovery) { this.skip(); }
         const newDir = path.join(TestWorkspace.testProject, "src", "main", "pico", "rename-test");
+        await fs.rm(newDir, {recursive: true, force: true});
         const fromFile = path.join(newDir, "testing.pico");
         const toDir = path.join(newDir, "dest");
         await fs.mkdir(toDir, {recursive: true});

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { InputBox, MarkerType, NotificationType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -380,7 +380,7 @@ end
             return currentTitle !== initialTitle;
         }, Delays.normal, "Another editor should open");
     });
-    /*
+
     it("(un)registers diagnostics", async function() {
         if (errorRecovery) { this.skip(); } // this does not depend on error recovery
 
@@ -440,6 +440,5 @@ end
             return "*static content*" === await (await bench.getEditorView().getActiveTab())?.getTitle();
         }, Delays.normal, "Static content should be shown");
     });
-    */
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, MarkerType, NotificationType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { InputBox, MarkerType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -409,12 +409,11 @@ end
 
         const editor = await ide.openModule(TestWorkspace.picoFile);
         await ide.clickCodeLens(editor, "Show warning");
-
         await driver.wait(async () => {
-            const center = await bench.openNotificationsCenter();
-            const notifications = await center.getNotifications(NotificationType.Warning);
-            const messages = await Promise.all(notifications.map(n => n.getMessage()));
-            return messages.find(m => m.startsWith("Test warning"));
+            const output = await bench.getBottomBar().openOutputView();
+            await output.selectChannel("Language Parametric Rascal Language Server");
+            const contents = await output.getText();
+            return contents.split("\n")[-1]?.indexOf("Test warning") !== -1;
         }, Delays.normal, "Test warning dialog should show");
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -380,7 +380,7 @@ end
             const markers = await problemsView.getAllVisibleMarkers(MarkerType.Any);
             const labels = await Promise.all(markers.map(async m => await m.getLabel()));
             return labels.includes("TODO");
-        }, Delays.normal, "TODO should be registered");
+        }, Delays.slow, "TODO should be registered");
 
         await ide.clickCodeLens(editor, "Unregister TODO");
         await driver.wait(async () => {
@@ -389,7 +389,7 @@ end
             const markers = await problemsView.getAllVisibleMarkers(MarkerType.Any);
             const labels = await Promise.all(markers.map(async m => await m.getLabel()));
             return !labels.includes("TODO");
-        }, Delays.normal, "TODO should be unregistered");
+        }, Delays.slow, "TODO should be unregistered");
     });
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -365,7 +365,7 @@ end
         await ide.clickCodeLens(editor, "Browse Rascal site");
         await driver.wait(async () => {
             const view = new WebView();
-            return (await ignoreFails(view.getTitle()) === "Rascal MPL") ? editor : undefined;
+            return await ignoreFails(view.getTitle()) === "Rascal MPL";
         }, Delays.normal, "Browser for rascal-mpl.org should open");
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, MarkerType, NotificationType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { InputBox, MarkerType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -404,6 +404,7 @@ end
         }, Delays.slow, "TODO should be unregistered");
     });
 
+    /*
     it("shows messages", async function() {
         if (errorRecovery) { this.skip(); } // this does not depend on error recovery
 
@@ -430,6 +431,7 @@ end
             return contents.split("\n")[-1]?.indexOf("LOG") !== -1;
         }, Delays.normal, "Line should be logged");
     });
+    */
 
     it("shows interactive content", async function() {
         if (errorRecovery) { this.skip(); }

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -418,7 +418,19 @@ end
         }, Delays.normal, "Test warning dialog should show");
     });
 
+    it("logs messages", async function() {
+        if (errorRecovery) { this.skip(); }
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        await ide.clickCodeLens(editor, "Show warning");
+        await driver.wait(async () => {
+            const output = await bench.getBottomBar().openOutputView();
+            await output.selectChannel("Language Parametric Rascal Language Server");
+            const contents = await output.getText();
+            return contents.split("\n")[-1]?.indexOf("LOG") !== -1;
+        }, Delays.normal, "Line should be logged");
+    });
+
     // TODO showInteractiveContent
-    // TODO logMessage
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, SideBarView, TextEditor, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { InputBox, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -357,4 +357,16 @@ end
         const actualJson = await resultEditor!.getText();
         expect(JSON.parse(actualJson)).to.deep.equal(JSON.parse(expectedJson));
     });
+
+    it("browses interactively", async function() {
+        if (errorRecovery) { this.skip(); } // this does not depend on error recovery
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        await ide.clickCodeLens(editor, "Browse Rascal site");
+        await driver.wait(async () => {
+            const view = new WebView();
+            return (await ignoreFails(view.getTitle()) === "Rascal MPL") ? editor : undefined;
+        }, Delays.normal, "Browser for rascal-mpl.org should open");
+    });
+
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -404,4 +404,8 @@ end
         }, Delays.slow, "TODO should be unregistered");
     });
 
+    // TODO showInteractiveContent
+    // TODO showMessage
+    // TODO logMessage
+
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -369,7 +369,7 @@ end
         }, Delays.normal, "Browser for rascal-mpl.org should open");
     });
 
-    it("registers diagnostics", async function() {
+    it("(un)registers diagnostics", async function() {
         if (errorRecovery) { this.skip(); } // this does not depend on error recovery
 
         const editor = await ide.openModule(TestWorkspace.picoFile);
@@ -381,6 +381,15 @@ end
             const labels = await Promise.all(markers.map(async m => await m.getLabel()));
             return labels.includes("TODO");
         }, Delays.normal, "TODO should be registered");
+
+        await ide.clickCodeLens(editor, "Unregister TODO");
+        await driver.wait(async () => {
+            const bottomBar = new Workbench().getBottomBar();
+            const problemsView = await bottomBar.openProblemsView();
+            const markers = await problemsView.getAllVisibleMarkers(MarkerType.Any);
+            const labels = await Promise.all(markers.map(async m => await m.getLabel()));
+            return !labels.includes("TODO");
+        }, Delays.normal, "TODO should be unregistered");
     });
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { InputBox, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { InputBox, MarkerType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, sleep, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
@@ -367,6 +367,20 @@ end
             const view = new WebView();
             return (await ignoreFails(view.getTitle()) === "Rascal MPL") ? editor : undefined;
         }, Delays.normal, "Browser for rascal-mpl.org should open");
+    });
+
+    it("registers diagnostics", async function() {
+        if (errorRecovery) { this.skip(); } // this does not depend on error recovery
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        await ide.clickCodeLens(editor, "Register TODO");
+        await driver.wait(async () => {
+            const bottomBar = new Workbench().getBottomBar();
+            const problemsView = await bottomBar.openProblemsView();
+            const markers = await problemsView.getAllVisibleMarkers(MarkerType.Any);
+            const labels = await Promise.all(markers.map(async m => await m.getLabel()));
+            return labels.includes("TODO");
+        }, Delays.normal, "TODO should be registered");
     });
 
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -369,6 +369,18 @@ end
         }, Delays.normal, "Browser for rascal-mpl.org should open");
     });
 
+    it("opens editors", async function() {
+        if (errorRecovery) { this.skip(); } // this does not depend on error recovery
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        const initialTitle = await (await bench.getEditorView().getActiveTab())?.getTitle();
+        await ide.clickCodeLens(editor, "Edit another file");
+        await driver.wait(async () => {
+            const currentTitle = await (await bench.getEditorView().getActiveTab())?.getTitle();
+            return currentTitle === initialTitle;
+        }, Delays.normal, "Another editor should open");
+    });
+
     it("(un)registers diagnostics", async function() {
         if (errorRecovery) { this.skip(); } // this does not depend on error recovery
 

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -413,7 +413,7 @@ end
             const output = await bench.getBottomBar().openOutputView();
             await output.selectChannel("Language Parametric Rascal Language Server");
             const contents = await output.getText();
-            return contents.split("\n")[-1]?.indexOf("Test warning") !== -1;
+            return contents.split("\n")[-1]?.indexOf(": Test warning") !== -1;
         }, Delays.normal, "Test warning dialog should show");
     });
 
@@ -426,7 +426,7 @@ end
             const output = await bench.getBottomBar().openOutputView();
             await output.selectChannel("Language Parametric Rascal Language Server");
             const contents = await output.getText();
-            return contents.split("\n")[-1]?.indexOf("LOG") !== -1;
+            return contents.split("\n")[-1]?.indexOf(": LOG Test warning") !== -1;
         }, Delays.normal, "Line should be logged");
     });
 

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -145,7 +145,6 @@ describe('REPL', function () {
     it("(un)registers diagnostics", async() => {
         const file = "project://test-project/src/main/pico/testing.pico";
         const repl = await runIdeService(`registerDiagnostics([info("TODO", |${file}|)]);`);
-        console.log(repl.lastOutput);
         checkMessageOutput(repl, file, "TODO", "info");
 
         await repl.execute(`unregisterDiagnostics([|${file}|]);`);

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -26,8 +26,8 @@
  */
 
 import { expect } from 'chai';
-import { VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
-import { TestWorkspace, RascalREPL, Delays, IDEOperations, printRascalOutputOnFailure } from './utils';
+import { TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, TestWorkspace } from './utils';
 
 describe('REPL', function () {
     let browser: VSBrowser;
@@ -108,4 +108,62 @@ describe('REPL', function () {
         await repl.execute(`readFile(${baseLoc}test.txt|)`);
         expect(repl.lastOutput).contains('Hello World', 'File contents should be there');
     });
+
+    async function runIdeService(command: string): Promise<RascalREPL> {
+        const repl = new RascalREPL(bench, driver);
+        await repl.start();
+        await repl.execute("import util::IDEServices;");
+        await repl.execute(command);
+        return repl;
+    }
+
+    it("browses interactively", async() => {
+        await runIdeService('browse(|https://www.rascal-mpl.org|, title="Rascal MPL");');
+        await driver.wait(async () => {
+            const view = new WebView();
+            return await ignoreFails(view.getTitle()) === "Rascal MPL";
+        }, Delays.normal, "Browser for rascal-mpl.org should open");
+    });
+
+    it("opens editors", async() => {
+        const file = "project://test-project/src/main/pico/testing.pico";
+        await runIdeService(`edit(|${file}|);`);
+        await driver.wait(async () => {
+            const editor = new TextEditor();
+            return "testing.pico" === await editor.getTitle();
+        }, Delays.normal, "Another editor should open");
+    });
+
+    function checkMessageOutput(repl: RascalREPL, uri: string, message: string, severity: string) {
+        expect(repl.lastOutput).to.equal(`[${severity.toUpperCase()}] |${uri}|: ${message}\nok`);
+    }
+
+    it("(un)registers diagnostics", async() => {
+        const file = "project://test-project/src/main/pico/testing.pico";
+        const repl = await runIdeService(`registerDiagnostics([info("TODO", |${file}|)]);`);
+        console.log(repl.lastOutput);
+        checkMessageOutput(repl, file, "TODO", "info");
+
+        await repl.execute(`unregisterDiagnostics([|${file}|]);`);
+    });
+
+    it("shows messages", async() => {
+        const file = "project://test-project/src/main/pico/testing.pico";
+        const repl = await runIdeService(`showMessage(warning("Test warning", |${file}|));`);
+        checkMessageOutput(repl, file, "Test warning", "warning");
+    });
+
+    it("logs messages", async() => {
+        const file = "project://test-project/src/main/pico/testing.pico";
+        const repl = await runIdeService(`logMessage(error("Test warning", |${file}|));`);
+        checkMessageOutput(repl, file, "Test warning", "error");
+    });
+
+    it("shows interactive content", async function() {
+        await runIdeService('showInteractiveContent(plainText("Some text"));');
+        await driver.wait(async () => {
+            return "*static content*" === await (await bench.getEditorView().getActiveTab())?.getTitle();
+        }, Delays.normal, "Static content should be shown");
+    });
+
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -47,10 +47,6 @@ describe('REPL', function () {
         await ide.load();
         await ide.cleanup();
         await browser.waitForWorkbench();
-
-        // Commands need to be on a single line for our output capturing to work properly.
-        // Create some space for longer commands.
-        await bench.executeCommand('zoomOut');
     });
 
     afterEach(async function () {
@@ -113,16 +109,23 @@ describe('REPL', function () {
         expect(repl.lastOutput).contains('Hello World', 'File contents should be there');
     });
 
-    async function runIdeService(command: string): Promise<RascalREPL> {
+    async function runIdeService(command: (file: string) => string): Promise<RascalREPL>;
+    async function runIdeService(command: (file: string) => string, file: string): Promise<RascalREPL>;
+    async function runIdeService(command: (file: string) => string, file?: string): Promise<RascalREPL> {
         const repl = new RascalREPL(bench, driver);
         await repl.start();
         await repl.execute("import util::IDEServices;");
-        await repl.execute(command);
+        if (file) {
+            await repl.execute(`loc f = |${file}|;`);
+            await repl.execute(command("f"));
+        } else {
+            await repl.execute(command(""));
+        }
         return repl;
     }
 
     it("browses interactively", async() => {
-        await runIdeService('browse(|https://www.rascal-mpl.org|, title="Rascal MPL");');
+        await runIdeService(() => 'browse(|https://www.rascal-mpl.org|, title="Rascal MPL");');
         await driver.wait(async () => {
             const view = new WebView();
             return await ignoreFails(view.getTitle()) === "Rascal MPL";
@@ -130,8 +133,7 @@ describe('REPL', function () {
     });
 
     it("opens editors", async() => {
-        const file = "project://test-project/src/main/pico/testing.pico";
-        await runIdeService(`edit(|${file}|);`);
+        await runIdeService(f => `edit(${f});`, "project://test-project/src/main/pico/testing.pico");
         await driver.wait(async () => {
             const editor = new TextEditor();
             return "testing.pico" === await editor.getTitle();
@@ -144,7 +146,7 @@ describe('REPL', function () {
 
     it("(un)registers diagnostics", async() => {
         const file = "project://test-project/src/main/pico/testing.pico";
-        const repl = await runIdeService(`registerDiagnostics([info("TODO", |${file}|)]);`);
+        const repl = await runIdeService(f => `registerDiagnostics([info("TODO", ${f})]);`, file);
         checkMessageOutput(repl, file, "TODO", "info");
 
         await repl.execute(`unregisterDiagnostics([|${file}|]);`);
@@ -152,18 +154,18 @@ describe('REPL', function () {
 
     it("shows messages", async() => {
         const file = "project://test-project/src/main/pico/testing.pico";
-        const repl = await runIdeService(`showMessage(warning("Test warning", |${file}|));`);
+        const repl = await runIdeService(f => `showMessage(warning("Test warning", ${f}));`, file);
         checkMessageOutput(repl, file, "Test warning", "warning");
     });
 
     it("logs messages", async() => {
         const file = "project://test-project/src/main/pico/testing.pico";
-        const repl = await runIdeService(`logMessage(error("Test warning", |${file}|));`);
+        const repl = await runIdeService(f => `logMessage(error("Test warning", ${f}));`, file);
         checkMessageOutput(repl, file, "Test warning", "error");
     });
 
     it("shows interactive content", async function() {
-        await runIdeService('showInteractiveContent(plainText("Some text"));');
+        await runIdeService(() => 'showInteractiveContent(plainText("Some text"));');
         await driver.wait(async () => {
             return "*static content*" === await (await bench.getEditorView().getActiveTab())?.getTitle();
         }, Delays.normal, "Static content should be shown");

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -47,6 +47,10 @@ describe('REPL', function () {
         await ide.load();
         await ide.cleanup();
         await browser.waitForWorkbench();
+
+        // Commands need to be on a single line for our output capturing to work properly.
+        // Create some space for longer commands.
+        await bench.executeCommand('zoomOut');
     });
 
     afterEach(async function () {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -439,24 +439,15 @@ export class IDEOperations {
 
     async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow): Promise<void> {
         const lens = await this.driver.wait(async () => {
-            const lenses = await editor.getCodeLenses();
-            console.log("All lenses:");
-            console.log(await Promise.all(lenses.map(l => l.getLocatorInfo())));
-            for (const lens of lenses) {
-                try {
-                    const title = await lens.getText();
-                    const match = title.match(name);
-                    if (match && match.length > 0 && await lens.isDisplayed()) {
-                        return lens;
-                    }
-                } catch (e: unknown) {
-                    continue;
-                }
+            const lens = await editor.getCodeLens(name);
+            if (lens?.isDisplayed()) {
+                console.log(`Found code lens: ${name}`);
+                return lens;
             }
             return undefined;
         }, timeout, `Cannot find code lens '${name}'`);
 
-        await lens!.click();
+        await lens!.safeClick();
     }
 
     statusContains(needle: string): () => Promise<boolean> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -437,17 +437,16 @@ export class IDEOperations {
         }
     }
 
-    async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow): Promise<void> {
-        const lens = await this.driver.wait(async () => {
-            const lens = await editor.getCodeLens(name);
-            if (lens?.isDisplayed()) {
-                console.log(`Found code lens: ${name}`);
-                return lens;
+    async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow, message = `Cannot click code lens: ${name}`): Promise<void> {
+        await this.driver.wait(async () => {
+            try {
+                const lens = await editor.getCodeLens(name);
+                await lens!.click();
+                return true;
+            } catch (_e) {
+                return false;
             }
-            return undefined;
-        }, timeout, `Cannot find code lens '${name}'`);
-
-        await lens!.safeClick();
+        }, timeout, message);
     }
 
     statusContains(needle: string): () => Promise<boolean> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -250,7 +250,7 @@ export class IDEOperations {
 
     assertLineBecomes(editor: TextEditor, lineNumber: number, lineContents: string, msg: string, wait = Delays.verySlow) : Promise<boolean> {
         return this.driver.wait(async () => {
-            const currentContent = (await editor.getTextAtLine(lineNumber)).trim();
+            const currentContent = (await ignoreFails(editor.getTextAtLine(lineNumber)))?.trim();
             return currentContent === lineContents;
         }, wait, msg, 100);
     }

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -439,15 +439,24 @@ export class IDEOperations {
 
     async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow): Promise<void> {
         const lens = await this.driver.wait(async () => {
-            const lens = await editor.getCodeLens(name);
-            if (lens?.isDisplayed()) {
-                console.log(`Found code lens: ${name}`);
-                return lens;
+            const lenses = await editor.getCodeLenses();
+            console.log("All lenses:");
+            console.log(await Promise.all(lenses.map(l => l.getLocatorInfo())));
+            for (const lens of lenses) {
+                try {
+                    const title = await lens.getText();
+                    const match = title.match(name);
+                    if (match && match.length > 0 && await lens.isDisplayed()) {
+                        return lens;
+                    }
+                } catch (e: unknown) {
+                    continue;
+                }
             }
             return undefined;
         }, timeout, `Cannot find code lens '${name}'`);
 
-        await lens!.safeClick();
+        await lens!.click();
     }
 
     statusContains(needle: string): () => Promise<boolean> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -437,21 +437,17 @@ export class IDEOperations {
         }
     }
 
-    async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow, message = `Cannot click code lens: ${name}`): Promise<void> {
-        await this.driver.wait(async () => {
-            try {
-                console.log(`Finding code lens: ${name}`);
-                const lens = await editor.getCodeLens(name);
-                console.log("Clicking it");
-                await lens!.safeClick();
-                console.log("Success!");
-                return true;
-            } catch (_e) {
-                console.error("Error while clicking code lens");
-                console.error(_e);
-                return false;
+    async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow): Promise<void> {
+        const lens = await this.driver.wait(async () => {
+            const lens = await editor.getCodeLens(name);
+            if (lens?.isDisplayed()) {
+                console.log(`Found code lens: ${name}`);
+                return lens;
             }
-        }, timeout, message);
+            return undefined;
+        }, timeout, `Cannot find code lens '${name}'`);
+
+        await lens!.safeClick();
     }
 
     statusContains(needle: string): () => Promise<boolean> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -440,10 +440,15 @@ export class IDEOperations {
     async clickCodeLens(editor: TextEditor, name: string, timeout = Delays.slow, message = `Cannot click code lens: ${name}`): Promise<void> {
         await this.driver.wait(async () => {
             try {
+                console.log(`Finding code lens: ${name}`);
                 const lens = await editor.getCodeLens(name);
-                await lens!.click();
+                console.log("Clicking it");
+                await lens!.safeClick();
+                console.log("Success!");
                 return true;
             } catch (_e) {
+                console.error("Error while clicking code lens");
+                console.error(_e);
                 return false;
             }
         }, timeout, message);


### PR DESCRIPTION
This PR adds tests for all functions in `util::IDEServices`. The tests call these functions
- from DSL contributions;
- from the REPL.

This PR also implements/fixes IDE services that were missing for DSLs.