### PR TITLE
Using lsp4j v1.0.0

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -36,7 +36,6 @@
     <junit.version>4.13.2</junit.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <log4j2.version>2.26.0</log4j2.version>
-    <lsp4j.version>0.24.0</lsp4j.version>
     <mockito.version>5.23.0</mockito.version>
     <sonar.organization>usethesource</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -64,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC2</version>
+      <version>0.43.0-RC3</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>
@@ -76,7 +75,7 @@
     <dependency>
       <groupId>org.eclipse.lsp4j</groupId>
       <artifactId>org.eclipse.lsp4j</artifactId>
-      <version>${lsp4j.version}</version>
+      <version>1.0.0</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -103,11 +102,6 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-layout-template-json</artifactId>
       <version>${log4j2.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.lsp4j</groupId>
-      <artifactId>org.eclipse.lsp4j.debug</artifactId>
-      <version>${lsp4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/DocumentChanges.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/DocumentChanges.java
@@ -38,6 +38,7 @@ import org.eclipse.lsp4j.CreateFile;
 import org.eclipse.lsp4j.DeleteFile;
 import org.eclipse.lsp4j.RenameFile;
 import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
@@ -93,9 +94,15 @@ public class DocumentChanges {
                 case RascalADTs.FileSystemChangeFields.CHANGED:
                     // TODO: file document identifier version is unknown here. that may be problematic
                     // have to extend the entire/all LSP API with this information _per_ file?
+
+                    var edits = translateTextEdits((IList) edit.get(RascalADTs.FileSystemChangeFields.EDITS), anno, columns, changeAnnotations)
+                        .stream()
+                        .map(Either::<TextEdit, SnippetTextEdit>forLeft)
+                        .collect(Collectors.toList());
+
                     result.add(Either.forLeft(
                         new TextDocumentEdit(new VersionedTextDocumentIdentifier(getFileURI(edit, RascalADTs.FileSystemChangeFields.FILE), null),
-                            translateTextEdits((IList) edit.get(RascalADTs.FileSystemChangeFields.EDITS), anno, columns, changeAnnotations))));
+                            edits)));
                     break;
             }
         }

--- a/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/DocumentChangesTest.java
+++ b/rascal-lsp/src/test/java/engineering/swat/rascal/lsp/util/DocumentChangesTest.java
@@ -38,8 +38,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.AnnotatedTextEdit;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Test;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.values.IRascalValueFactory;
@@ -158,8 +160,18 @@ public class DocumentChangesTest {
 
     // Utility methods
 
+    private void assertNotAnnotated(Either<TextEdit, SnippetTextEdit> e) {
+        assertTrue("Snippet not supported in tests yet", e.isLeft());
+        assertNotAnnotated(e.getLeft());
+    }
+
     private void assertNotAnnotated(TextEdit e) {
         assertFalse(String.format("Edit that replaces '%s' should not be annotated", e.getNewText()), e instanceof AnnotatedTextEdit);
+    }
+
+    private void assertAnnotated(Either<TextEdit, SnippetTextEdit> e, String label, String description, boolean needsConfirmation, WorkspaceEdit wsEdit) {
+        assertTrue("Snippet not supported in tests yet", e.isLeft());
+        assertAnnotated(e.getLeft(), label, description, needsConfirmation, wsEdit);
     }
 
     private void assertAnnotated(TextEdit e, String label, String description, boolean needsConfirmation, WorkspaceEdit wsEdit) {
@@ -182,7 +194,7 @@ public class DocumentChangesTest {
             var expected = expectedEdits.remove(docEdit.getTextDocument().getUri());
             assertNotNull("Unexpected TextDocumentEdit for " + docEdit.getTextDocument().getUri(), expected);
             assertEquals(expected.length, docEdit.getEdits().size());
-            assertArrayEquals(expected, docEdit.getEdits().stream().map(TextEdit::getNewText).collect(Collectors.toList()).toArray());
+            assertArrayEquals(expected, docEdit.getEdits().stream().map(Either::getLeft).map(TextEdit::getNewText).collect(Collectors.toList()).toArray());
         }
         assertTrue(String.format("Expected edits for %s, but got none", expectedEdits.keySet()), expectedEdits.isEmpty());
     }


### PR DESCRIPTION
Now that rascal is released with lsp4j 1.0.0 for DAP, we can also switch to that for this project.