### PR TITLE
added action to upgrade annotations to keyword parameters

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC1</version>
+      <version>0.43.0-RC3</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC3</version>
+      <version>0.43.0-RC4-SNAPSHOT</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC3</version>
+      <version>0.43.0-RC1</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC4-SNAPSHOT</version>
+      <version>0.43.0-RC6</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
@@ -29,6 +29,7 @@ POSSIBILITY OF SUCH DAMAGE.
 module lang::rascal::lsp::Actions
 
 import lang::rascal::\syntax::Rascal;
+import lang::rascal::upgrade::UpgradeAnnotationsToKeywordParameters;
 import util::LanguageServer;
 import analysis::diff::edits::TextEdits;
 import ParseTree;
@@ -46,6 +47,7 @@ The commands must be evaluated by ((evaluateRascalCommand))
 data Command
     = visualImportGraphCommand(PathConfig pcfg)
     | sortImportsAndExtends(Header h)
+    | upgradeAnnotationsToKeywordFields(PathConfig pcfg)
     ;
 
 @synopsis{Detects (on-demand) source actions to register with specific places near the current cursor}
@@ -64,6 +66,13 @@ list[CodeAction] rascalCodeActions(Focus focus, PathConfig pcfg=pathConfig()) {
         result += [action(command=visualImportGraphCommand(pcfg), title="Visualize project import graph")]
                +  [action(command=sortImportsAndExtends(h), title="Sort imports and extends")]
                ;
+    }
+
+    if ([*_, (Declaration) `<Tags _> <Visibility _> anno <Type _> <Type _> @ <Name _>;`, *_] := focus
+       || [*_, (Expression) `<Expression _>[@ <Name _> = <Expression _>]`, *_] := focus
+       || [*_, (Expression) `<Expression _>@<Name _>`, *_] := focus
+       || [*_, (Assignable) `<Assignable _>@<Name _>`, *_ ]) {
+        result += [action(command=upgradeAnnotationsToKeywordFields(pcfg), title="Upgrade all annotations to keyword fields in this project (annotation syntax is no longer supported).")];
     }
 
     return result;
@@ -152,5 +161,10 @@ value evaluateRascalCommand(sortImportsAndExtends(Header h)) {
                 '<}>"[..-2];
 
     applyDocumentsEdits([changed(h.src.top, [replace(h.imports.src, newHeader)])]);
+    return ("result":true);
+}
+
+value evaluateRascalCommand(upgradeAnnotationsToKeywordFields(PathConfig pcfg)) {
+    applyDocumentsEdits(editsPathConfig(pcfg));
     return ("result":true);
 }

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
@@ -47,8 +47,10 @@ The commands must be evaluated by ((evaluateRascalCommand))
 data Command
     = visualImportGraphCommand(PathConfig pcfg)
     | sortImportsAndExtends(Header h)
-    | upgradeAnnotationsToKeywordFields(PathConfig pcfg)
+    | upgradeAnnotations(PathConfig pcfg)
     ;
+
+private str annoFixTitle = "Upgrade all annotations to keyword fields in this project (annotation syntax is no longer supported).";
 
 @synopsis{Detects (on-demand) source actions to register with specific places near the current cursor}
 list[CodeAction] rascalCodeActions(Focus focus, PathConfig pcfg=pathConfig()) {
@@ -58,25 +60,54 @@ list[CodeAction] rascalCodeActions(Focus focus, PathConfig pcfg=pathConfig()) {
         result += addLicenseAction(top, pcfg);
     }
 
-    if ([*_, Toplevel t, *_] := focus) {
-        result += toplevelCodeActions(t);
-    }
-
-    if ([*_, Header h, *_] := focus) {
-        result += [action(command=visualImportGraphCommand(pcfg), title="Visualize project import graph")]
-               +  [action(command=sortImportsAndExtends(h), title="Sort imports and extends")]
-               ;
-    }
-
-    if ([*_, (Declaration) `<Tags _> <Visibility _> anno <Type _> <Type _> @ <Name _>;`, *_] := focus
-       || [*_, (Expression) `<Expression _>[@ <Name _> = <Expression _>]`, *_] := focus
-       || [*_, (Expression) `<Expression _>@<Name _>`, *_] := focus
-       || [*_, (Assignable) `<Assignable _>@<Name _>`, *_ ]) {
-        result += [action(command=upgradeAnnotationsToKeywordFields(pcfg), title="Upgrade all annotations to keyword fields in this project (annotation syntax is no longer supported).")];
+    for (Tree elem <- focus) {
+        switch(elem) {
+            case Toplevel t:
+                result += toplevelCodeActions(t);
+            case Header h:
+                result += [
+                    action(command=visualImportGraphCommand(pcfg), title="Visualize project import graph"),
+                    action(command=sortImportsAndExtends(h), title="Sort imports and extends")
+                ];
+            case Tree other:
+                if (isFixableAnnoSyntax(other)) {
+                    result += [action(command=upgradeAnnotations(pcfg), title=annoFixTitle)];
+                }
+        }
     }
 
     return result;
 }
+
+@synopsis{Identifies all uses of annotation syntax and annotation library functions.}
+bool isFixableAnnoSyntax((Declaration) `<Tags _> <Visibility _> anno <Type _> <Type _> @ <Name _>;`)
+    = true;
+
+bool isFixableAnnoSyntax((Expression)`<Expression _>[@ <Name _> = <Expression _>]`)
+    = true;
+
+bool isFixableAnnoSyntax((Expression) `<Expression _>@<Name _>`)
+    = true;
+
+bool isFixableAnnoSyntax((Assignable) `<Assignable _>@<Name _>`)
+    = true;
+
+bool isFixableAnnoSyntax((Expression) `delAnnotations(<Expression _>)`)
+    = true;
+
+bool isFixableAnnoSyntax((Expression) `delAnnotationsRec(<Expression _>)`)
+    = true;
+
+bool isFixableAnnoSyntax((Expression) `delAnnotation(<Expression _>, <Expression _>)`)
+    = true;
+
+bool isFixableAnnoSyntax((Expression) `delAnnotation(<Expression _>, <Expression _>)`)
+    = true;
+
+bool isFixableAnnoSyntax((Catch) `catch NoSuchAnnotation(<Pattern _>) : <Statement _>`)
+    = true;
+
+default bool isFixableAnnoSyntax(Tree _) = false;
 
 @synopsis{Add a license header if there isn't one.}
 list[CodeAction] addLicenseAction(start[Module] \module, PathConfig pcfg) {
@@ -164,7 +195,7 @@ value evaluateRascalCommand(sortImportsAndExtends(Header h)) {
     return ("result":true);
 }
 
-value evaluateRascalCommand(upgradeAnnotationsToKeywordFields(PathConfig pcfg)) {
+value evaluateRascalCommand(upgradeAnnotations(PathConfig pcfg)) {
     applyDocumentsEdits(editsPathConfig(pcfg));
     return ("result":true);
 }

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -206,6 +206,7 @@ describe('IDE', function () {
         expect(editorText).to.contain("i - 1");
         expect(editorText).to.contain("i -2");
     });
+    /*
 
     it("renaming files works", async() => {
         const newDir = path.join(TestWorkspace.libProject, "src", "main", "rascal", "lib");
@@ -272,5 +273,24 @@ describe('IDE', function () {
         await editor.setTextAtLine(2, "Project-Name: test-project");
         await editor.save();
         await driver.wait(until.stalenessOf(element), Delays.verySlow, "Error did not disapear");
+    });
+    */
+
+    it("anno quickfix works", async () => {
+        const editor = await ide.openModule(TestWorkspace.importeeFile);
+        await editor.typeTextAt(3, 1, "data X = y();\n");
+        await editor.typeTextAt(4, 1, "anno int X@old;\n");
+        await editor.typeTextAt(5, 1, "int calc(X x) = x@old;");
+        await editor.save();
+        await ide.hasWarningSquiggly(editor, Delays.slow, "On a annotation we should have a warning that they are deprecated");
+
+        await editor.moveCursor(5,19); // at the `\loc` part
+        await ide.triggerFirstCodeAction(editor, "Upgrade all annotations");
+        await ide.assertLineBecomes(editor, 4, "data X(int old = 0);", "annotations become a KW parameter", Delays.slow);
+        await ide.assertLineBecomes(editor, 5, "int calc(X x) = x.old;", "annotation should become a field deref", Delays.fast);
+
+        await editor.save();
+        await ide.hasNoWarningSquiggly(editor, Delays.slow, "Annotation should no longer be an error");
+
     });
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -28,10 +28,10 @@
 import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { TextEditor, ViewSection, VSBrowser, WebDriver, Workbench, until } from 'vscode-extension-tester';
+import { TextEditor, until, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
 import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
 
-const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile, TestWorkspace.manifest];
+const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile, TestWorkspace.manifest, TestWorkspace.importeeFile, TestWorkspace.importerFile];
 
 describe('IDE', function () {
     let browser: VSBrowser;
@@ -206,7 +206,6 @@ describe('IDE', function () {
         expect(editorText).to.contain("i - 1");
         expect(editorText).to.contain("i -2");
     });
-    /*
 
     it("renaming files works", async() => {
         const newDir = path.join(TestWorkspace.libProject, "src", "main", "rascal", "lib");
@@ -274,14 +273,14 @@ describe('IDE', function () {
         await editor.save();
         await driver.wait(until.stalenessOf(element), Delays.verySlow, "Error did not disapear");
     });
-    */
 
     it("anno quickfix works", async () => {
         const editor = await ide.openModule(TestWorkspace.importeeFile);
         await editor.typeTextAt(3, 1, "data X = y();\n");
         await editor.typeTextAt(4, 1, "anno int X@old;\n");
         await editor.typeTextAt(5, 1, "int calc(X x) = x@old;");
-        await editor.save();
+        await triggerTypeChecker(editor, TestWorkspace.importeeTpl, true);
+
         await ide.hasWarningSquiggly(editor, Delays.slow, "On a annotation we should have a warning that they are deprecated");
 
         await editor.moveCursor(5,19); // at the `\loc` part
@@ -289,8 +288,8 @@ describe('IDE', function () {
         await ide.assertLineBecomes(editor, 4, "data X(int old = 0);", "annotations become a KW parameter", Delays.slow);
         await ide.assertLineBecomes(editor, 5, "int calc(X x) = x.old;", "annotation should become a field deref", Delays.fast);
 
-        await editor.save();
-        await ide.hasNoWarningSquiggly(editor, Delays.slow, "Annotation should no longer be an error");
+        await triggerTypeChecker(editor, TestWorkspace.importeeTpl, true);
 
+        await ide.checkNoDiagnosticsAnymore();
     });
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -64,7 +64,9 @@ export class TestWorkspace {
     public static readonly manifest = path.join(this.testProject, "META-INF", "RASCAL.MF");
 
     public static readonly importerFile = path.join(src(this.testProject), 'Importer.rsc');
+    public static readonly importerTpl = path.join(target(this.testProject),'$Importer.tpl');
     public static readonly importeeFile = path.join(src(this.testProject), 'Importee.rsc');
+    public static readonly importeeTpl = path.join(target(this.testProject),'$Importee.tpl');
 
     public static readonly picoFile = path.join(src(this.testProject, 'pico'), 'testing.pico');
     public static readonly picoNewFile = path.join(src(this.testProject, 'pico'), 'testing.pico-new');
@@ -190,22 +192,6 @@ function scopedElementLocated(scope:WebElement, selector: Locator): WebElementCo
     });
 }
 
-
-function noElementFound(scope: WebElement, selector: Locator) : WebElementCondition {
-    return new WebElementCondition("Could not find locator", async (_driver) => {
-        try {
-            const result = await scope.findElement(selector);
-            if (result) {
-                return null;
-            }
-            return scope;
-        } catch (_ignored) {
-            return null;
-        }
-    });
-
-}
-
 function scopedElementLocatedCountTimes(scope:WebElement, selector: Locator, minCount: number): WebElementCondition {
     return new WebElementCondition("locating element in scope occuring at least ${minCount} times", async (_driver) => {
         try {
@@ -258,6 +244,10 @@ export class IDEOperations {
         await ignoreFails(center?.close());
 
         // There should be no more error diagnostics
+        await this.checkNoDiagnosticsAnymore();
+    }
+
+    async checkNoDiagnosticsAnymore() {
         const bottomBar = new Workbench().getBottomBar();
         const problemsView = await bottomBar.openProblemsView();
         const allVisibleMarkers = await problemsView.getAllVisibleMarkers(MarkerType.Error);
@@ -279,16 +269,8 @@ export class IDEOperations {
         return this.driver.wait(until.elementLocated(By.className("squiggly-warning")), timeout, message);
     }
 
-    hasNoWarningSquiggly(editor: TextEditor, timeout = Delays.normal, message = "Missing warning squiggly"): Promise<WebElement> {
-        return this.driver.wait(noElementFound(editor, By.className("squiggly-warning")), timeout, message);
-    }
-
     hasErrorSquiggly(_editor: TextEditor, timeout = Delays.normal, message = "Missing error squiggly"): Promise<WebElement> {
         return this.driver.wait(until.elementLocated(By.className("squiggly-error")), timeout, message, 50);
-    }
-
-    hasNoErrorSquiggly(editor: TextEditor, timeout = Delays.normal, message = "Missing error squiggly"): Promise<WebElement> {
-        return this.driver.wait(noElementFound(editor, By.className("squiggly-error")), timeout, message, 50);
     }
 
     hasRecoveredErrors(editor: TextEditor, errorCount: number, timeout = Delays.normal, message = "Missing recovered parse errors"): Promise<WebElement> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -190,6 +190,22 @@ function scopedElementLocated(scope:WebElement, selector: Locator): WebElementCo
     });
 }
 
+
+function noElementFound(scope: WebElement, selector: Locator) : WebElementCondition {
+    return new WebElementCondition("Could not find locator", async (_driver) => {
+        try {
+            const result = await scope.findElement(selector);
+            if (result) {
+                return null;
+            }
+            return scope;
+        } catch (_ignored) {
+            return null;
+        }
+    });
+
+}
+
 function scopedElementLocatedCountTimes(scope:WebElement, selector: Locator, minCount: number): WebElementCondition {
     return new WebElementCondition("locating element in scope occuring at least ${minCount} times", async (_driver) => {
         try {
@@ -263,8 +279,16 @@ export class IDEOperations {
         return this.driver.wait(until.elementLocated(By.className("squiggly-warning")), timeout, message);
     }
 
+    hasNoWarningSquiggly(editor: TextEditor, timeout = Delays.normal, message = "Missing warning squiggly"): Promise<WebElement> {
+        return this.driver.wait(noElementFound(editor, By.className("squiggly-warning")), timeout, message);
+    }
+
     hasErrorSquiggly(_editor: TextEditor, timeout = Delays.normal, message = "Missing error squiggly"): Promise<WebElement> {
         return this.driver.wait(until.elementLocated(By.className("squiggly-error")), timeout, message, 50);
+    }
+
+    hasNoErrorSquiggly(editor: TextEditor, timeout = Delays.normal, message = "Missing error squiggly"): Promise<WebElement> {
+        return this.driver.wait(noElementFound(editor, By.className("squiggly-error")), timeout, message, 50);
     }
 
     hasRecoveredErrors(editor: TextEditor, errorCount: number, timeout = Delays.normal, message = "Missing recovered parse errors"): Promise<WebElement> {
@@ -361,7 +385,7 @@ export class IDEOperations {
      * indeed becomes the first menu item.
      *
      * @param editor
-     * @param actionLabel
+     * @param actionLabel (can be a partial part of the label)
      */
     async triggerFirstCodeAction(editor: TextEditor, actionLabel:string) {
         const inputarea = await editor.findElement(By.className('inputarea'));

--- a/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
+++ b/rascal-vscode-extension/src/ux/VsCodeSettingsFixer.ts
@@ -34,10 +34,11 @@ const SETTINGS_FILE = "settings.json";
 const SETTINGS_GLOB = posix.join("**", VSCODE_DIR, SETTINGS_FILE);
 
 const SEARCH_EXCLUDE_SETTING_KEY = "search.exclude";
-const EXCLUDE_ENTRY = `"/target/": true,`;
+const EXCLUDE_PATH = "/target/";
+const EXCLUDE_PATH_ALT = "target";
 const SEARCH_EXCLUDE_SETTING = `
     "${SEARCH_EXCLUDE_SETTING_KEY}": {
-        ${EXCLUDE_ENTRY}
+        "${EXCLUDE_PATH}": true,
     },
 `;
 const DEFAULT_SETTINGS = `{
@@ -138,8 +139,10 @@ async function createSettingsDiagnostic(projectRoot: vscode.Uri): Promise<{uri: 
     const settingsDoc = await vscode.workspace.openTextDocument(buildSettingsPath(projectRoot));
     const settings = jsonc.parseTree(settingsDoc.getText());
     if (settings) {
-        const target = jsonc.findNodeAtLocation(settings, [SEARCH_EXCLUDE_SETTING_KEY, "/target/"]);
-        if (target && jsonc.getNodeValue(target) === true) {
+        if (isTrue(settings, SEARCH_EXCLUDE_SETTING_KEY, EXCLUDE_PATH)) {
+            return;
+        }
+        if (isTrue(settings, SEARCH_EXCLUDE_SETTING_KEY, EXCLUDE_PATH_ALT)) {
             return;
         }
     }
@@ -148,6 +151,12 @@ async function createSettingsDiagnostic(projectRoot: vscode.Uri): Promise<{uri: 
     d.code = FixKind.fixTargetExclude;
     return {uri: settingsDoc.uri, diag: d};
 }
+
+function isTrue(settings: jsonc.Node, ...key: jsonc.Segment[]) {
+    const target = jsonc.findNodeAtLocation(settings, key);
+    return target && jsonc.getNodeValue(target) === true;
+}
+
 
 async function hasFile(projectRoot: vscode.Uri, findPath: (u: vscode.Uri) => vscode.Uri) {
     try {
@@ -195,7 +204,7 @@ class FixSettingsActions implements vscode.CodeActionProvider {
 
     private fixTargetExclude(settingsDoc: vscode.TextDocument, diag: vscode.Diagnostic): vscode.CodeAction {
         const d = new vscode.CodeAction("Exclude target from search", vscode.CodeActionKind.QuickFix);
-        const edits = jsonc.modify(settingsDoc.getText(), [SEARCH_EXCLUDE_SETTING_KEY, "/target/"], true, {formattingOptions: {keepLines: true}});
+        const edits = jsonc.modify(settingsDoc.getText(), [SEARCH_EXCLUDE_SETTING_KEY, EXCLUDE_PATH], true, {formattingOptions: {keepLines: true}});
         d.edit = new vscode.WorkspaceEdit();
         d.edit.set(settingsDoc.uri, this.convertEdits(settingsDoc, edits));
         d.diagnostics = [diag];

--- a/rascal-vscode-extension/test-workspace/test-lib/.vscode/settings.json
+++ b/rascal-vscode-extension/test-workspace/test-lib/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "search.exclude": {
+        "/target/": true
+    },
+}

--- a/rascal-vscode-extension/test-workspace/test-project/.vscode/settings.json
+++ b/rascal-vscode-extension/test-workspace/test-project/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "search.exclude": {
+        "/target/": true
+    },
+}


### PR DESCRIPTION
Work done for this PR:
* [x] link a version of Rascal with the upgrade function in the library
* [x] test the use of treeDiff on such a large scale
* [x] test the interaction with the progress bar and monitor warnings

The big thing was the first real application of treeDiff. I re-played the patch on all libraries and that seems ok.

There is only one usability issue that remains: all files which are changes are opened by the VScode client in an unsaved state. This goes for files which were already open, _and_ for files which were closed before starting the quickfix.

@DavyLandman this can be problematic, especially if the files are not visible in the tabs list.

I did some research and the LSP's `workspaces/applyEdit` feature is not causing this side-effect. It could be that one of our implementations or the LSP4J has this unintended side-effect. If you have time, I'd like to look at this together.
