### PR TITLE
Incorporated changes to the remote IDEServices API

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC3</version>
+      <version>0.43.0-RC4</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
@@ -120,7 +120,7 @@ public class RemoteIDEServicesServer implements IRemoteIDEServices {
         var authority = req.getAuthority().getValue();
         var mapping = req.getMapping();
         logger.trace("registerLocations({}, {}, {})", scheme, authority, mapping);
-        return CompletableFuture.runAsync(() -> 
+        return CompletableFuture.runAsync(() ->
             URIResolverRegistry.getInstance().registerLogical(new LogicalMapResolver(scheme, authority, mapping)), exec);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesServer.java
@@ -27,13 +27,13 @@
 package org.rascalmpl.vscode.lsp.terminal;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -41,8 +41,18 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.ideservices.IRemoteIDEServices;
+import org.rascalmpl.ideservices.jsonrpc.ApplyDocumentsEditsRequest;
+import org.rascalmpl.ideservices.jsonrpc.BrowseRequest;
+import org.rascalmpl.ideservices.jsonrpc.EditRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterDebugServerPortRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterDiagnosticsRequest;
+import org.rascalmpl.ideservices.jsonrpc.RegisterLocationsRequest;
+import org.rascalmpl.ideservices.jsonrpc.StartDebuggingSessionRequest;
+import org.rascalmpl.ideservices.jsonrpc.UnregisterDiagnosticsRequest;
 import org.rascalmpl.uri.LogicalMapResolver;
 import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.remote.jsonrpc.ISourceLocationRequest;
+import org.rascalmpl.uri.remote.jsonrpc.SourceLocationResponse;
 import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
@@ -50,9 +60,7 @@ import org.rascalmpl.vscode.lsp.rascal.conversion.DocumentChanges;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
-import io.usethesource.vallang.IInteger;
 import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IString;
 
 /**
  * Server implementation of (remote) IDEServices, running within rascal-lsp
@@ -71,56 +79,56 @@ public class RemoteIDEServicesServer implements IRemoteIDEServices {
     }
 
     @Override
-    public CompletableFuture<Void> edit(ISourceLocation loc, int viewColumn) {
+    public CompletableFuture<Void> edit(EditRequest req) {
+        var loc = req.getLocation();
         logger.trace("edit({})", loc);
         return CompletableFuture.runAsync(() -> {
             var physical = Locations.toClientLocation(loc);
             var range = loc.hasOffsetLength() ? Locations.toRange(physical, docService.getColumnMaps()) : null;
-            languageClient.editDocument(Locations.toUri(physical), range, viewColumn);
+            languageClient.editDocument(Locations.toUri(physical), range, req.getViewColumn());
         }, exec);
     }
 
     @Override
-    public CompletableFuture<Void> browse(URI uri, IString title, IInteger viewColumn) {
+    public CompletableFuture<Void> browse(BrowseRequest req) {
+        var uri = req.getUri();
         logger.trace("browse({})", uri);
-        return CompletableFuture.runAsync(() -> languageClient.showContent(uri, title, viewColumn), exec);
+        return CompletableFuture.runAsync(() -> languageClient.showContent(uri, req.getTitle(), req.getViewColumn()), exec);
     }
 
     @Override
-    public CompletableFuture<ISourceLocation> resolveProjectLocation(ISourceLocation loc) {
+    public CompletableFuture<SourceLocationResponse> resolveProjectLocation(ISourceLocationRequest req) {
+        var loc = req.getLocation();
         logger.trace("resolveProjectLocation({})", loc);
         try {
-            return CompletableFutureUtils.completedFuture(Locations.toClientLocation(URIResolverRegistry.getInstance().logicalToPhysical(loc)), exec);
+            return CompletableFutureUtils.completedFuture(new SourceLocationResponse(URIResolverRegistry.getInstance().logicalToPhysical(loc)), exec);
         } catch (IOException e) {
-            return CompletableFutureUtils.completedFuture(loc, exec);
+            return CompletableFutureUtils.completedFuture(new SourceLocationResponse(loc), exec);
         }
     }
 
     @Override
-    public CompletableFuture<Void> applyDocumentsEdits(DocumentEditsParameter edits) {
-        logger.trace("applyDocumentsEdits({})", edits);
+    public CompletableFuture<Void> applyDocumentsEdits(ApplyDocumentsEditsRequest req) {
+        logger.trace("applyDocumentsEdits({})", req);
         return CompletableFuture.runAsync(() ->
-            languageClient.applyEdit(new ApplyWorkspaceEditParams(DocumentChanges.translateDocumentChanges(edits.getEdits(), docService.getColumnMaps()))), exec);
+            languageClient.applyEdit(new ApplyWorkspaceEditParams(DocumentChanges.translateDocumentChanges(req.getEdits(), docService.getColumnMaps()))), exec);
     }
 
     @Override
-    public CompletableFuture<Void> registerLocations(IString scheme, IString authority, ISourceLocation[][] mapping) {
-        logger.trace("registerLocaions({}, {}, {})", scheme, authority, mapping);
-        return CompletableFuture.runAsync(() ->
-            URIResolverRegistry.getInstance().registerLogical(
-                new LogicalMapResolver(
-                    scheme.getValue(),
-                    authority.getValue(),
-                    IRemoteIDEServices.locArrayToMapLocLoc(mapping)
-                )
-            ), exec);
+    public CompletableFuture<Void> registerLocations(RegisterLocationsRequest req) {
+        var scheme = req.getScheme().getValue();
+        var authority = req.getAuthority().getValue();
+        var mapping = req.getMapping();
+        logger.trace("registerLocations({}, {}, {})", scheme, authority, mapping);
+        return CompletableFuture.runAsync(() -> 
+            URIResolverRegistry.getInstance().registerLogical(new LogicalMapResolver(scheme, authority, mapping)), exec);
     }
 
     @Override
-    public CompletableFuture<Void> registerDiagnostics(RegisterDiagnosticsParameters param) {
-        logger.trace("registerDiagnostics({})", param);
+    public CompletableFuture<Void> registerDiagnostics(RegisterDiagnosticsRequest req) {
+        logger.trace("registerDiagnostics({})", req);
         return CompletableFuture.runAsync(() -> {
-            Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(param.getMessages(), docService.getColumnMaps());
+            Map<ISourceLocation, List<Diagnostic>> translated = Diagnostics.translateMessages(req.getMessages(), docService.getColumnMaps());
 
             for (Entry<ISourceLocation, List<Diagnostic>> entry : translated.entrySet()) {
                 languageClient.publishDiagnostics(new PublishDiagnosticsParams(Locations.toUri(entry.getKey()).toString(), entry.getValue()));
@@ -129,7 +137,8 @@ public class RemoteIDEServicesServer implements IRemoteIDEServices {
     }
 
     @Override
-    public CompletableFuture<Void> unregisterDiagnostics(ISourceLocation[] locs) {
+    public CompletableFuture<Void> unregisterDiagnostics(UnregisterDiagnosticsRequest req) {
+        var locs = req.getLocations();
         logger.trace("unregisterDiagnostics({})", (Object[]) locs);
         return CompletableFuture.runAsync(() -> {
             for (ISourceLocation loc : locs) {
@@ -140,13 +149,16 @@ public class RemoteIDEServicesServer implements IRemoteIDEServices {
     }
 
     @Override
-    public CompletableFuture<Void> startDebuggingSession(int serverPort) {
+    public CompletableFuture<Void> startDebuggingSession(StartDebuggingSessionRequest req) {
+        var serverPort = req.getServerPort();
         logger.trace("startDebuggingSession({})", serverPort);
         return CompletableFuture.runAsync(() -> languageClient.startDebuggingSession(serverPort), exec);
     }
 
     @Override
-    public CompletableFuture<Void> registerDebugServerPort(int processID, int serverPort) {
+    public CompletableFuture<Void> registerDebugServerPort(RegisterDebugServerPortRequest req) {
+        var processID = req.getProcessID();
+        var serverPort = req.getServerPort();
         logger.trace("registerDebugServerPort({}, {})", processID, serverPort);
         return CompletableFuture.runAsync(() -> languageClient.registerDebugServerPort(processID, serverPort), exec);
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesThread.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/terminal/RemoteIDEServicesThread.java
@@ -39,6 +39,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.ideservices.GsonUtils;
 import org.rascalmpl.ideservices.IDEServices;
+import org.rascalmpl.ideservices.RemoteIDEServices;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.IDEServicesConfiguration;
 
@@ -74,7 +75,7 @@ public class RemoteIDEServicesThread extends Thread {
                         .setRemoteInterface(IDEServices.class)
                         .setInput(connection.getInputStream())
                         .setOutput(connection.getOutputStream())
-                        .configureGson(GsonUtils.complexAsBase64String())
+                        .configureGson(GsonUtils.complexAsBase64String(RemoteIDEServices.ts))
                         .setExecutorService(exec)
                         .setExceptionHandler(e -> {
                             logger.error(e);


### PR DESCRIPTION
This PR incorporates the changes to the `RemoteIDEServices` API introduced in https://github.com/usethesource/rascal/pull/2794.

This PR should not be merged until a new RC of Rascal is available.