### PR TITLE
Add support for VFS capabilities and fix REPL hyperlinks not opening anymore

### DIFF
--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -59,11 +59,12 @@
       <url>https://releases.usethesource.io/maven/</url>
     </pluginRepository>
   </pluginRepositories>
+
   <dependencies>
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC5</version>
+      <version>0.43.0-RC6</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/pom.xml
+++ b/rascal-lsp/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal</artifactId>
-      <version>0.43.0-RC3</version>
+      <version>0.43.0-RC5</version>
     </dependency>
     <!-- Rascal tests require JUnit 4 -->
     <dependency>

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileResolver.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileResolver.java
@@ -42,6 +42,9 @@ import io.usethesource.vallang.ISourceLocation;
 
 public class LSPOpenFileResolver implements ISourceLocationInput {
 
+    public static final String LSP_OPEN_SCHEME = "lsp";
+    private static final String LSP_SCHEME_PREFIX = LSP_OPEN_SCHEME + "+";
+
     private TextDocumentState getEditorState(ISourceLocation uri) throws IOException {
         return LSPOpenFileRedirector.getInstance().getDocumentState(stripLspPrefix(uri));
     }
@@ -77,9 +80,9 @@ public class LSPOpenFileResolver implements ISourceLocationInput {
     }
 
     public static ISourceLocation stripLspPrefix(ISourceLocation uri) {
-        if (uri.getScheme().startsWith("lsp+")) {
+        if (uri.getScheme().startsWith(LSP_SCHEME_PREFIX)) {
             try {
-                return URIUtil.changeScheme(uri, uri.getScheme().substring("lsp+".length()));
+                return URIUtil.changeScheme(uri, uri.getScheme().substring(LSP_SCHEME_PREFIX.length()));
             } catch (URISyntaxException e) {
                 // fall through
             }
@@ -94,7 +97,7 @@ public class LSPOpenFileResolver implements ISourceLocationInput {
 
     @Override
     public String scheme() {
-        return "lsp";
+        return LSP_OPEN_SCHEME;
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
@@ -39,6 +39,7 @@ import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.UnsupportedSchemeException;
 import org.rascalmpl.uri.remote.RascalFileSystemServices;
 import org.rascalmpl.uri.remote.jsonrpc.BooleanResponse;
+import org.rascalmpl.uri.remote.jsonrpc.CapabilitiesResponse;
 import org.rascalmpl.uri.remote.jsonrpc.CopyRequest;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryListingResponse;
 import org.rascalmpl.uri.remote.jsonrpc.ISourceLocationRequest;
@@ -83,6 +84,12 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
             throw new IllegalStateException("Remote resolver registry client not set yet");
         }
         return fileSystemServices;
+    }
+
+    @Override
+    public CompletableFuture<CapabilitiesResponse> serverCapabilities() {
+        logger.trace("serverCapabilities request");
+        return services().serverCapabilities();
     }
 
     private static ISourceLocation toRascalLocation(ISourceLocation loc) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
@@ -31,6 +31,8 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.rascalmpl.uri.FileAttributes;
@@ -40,6 +42,8 @@ import org.rascalmpl.uri.UnsupportedSchemeException;
 import org.rascalmpl.uri.remote.RascalFileSystemServices;
 import org.rascalmpl.uri.remote.jsonrpc.BooleanResponse;
 import org.rascalmpl.uri.remote.jsonrpc.CapabilitiesResponse;
+import org.rascalmpl.uri.remote.jsonrpc.Capability;
+import org.rascalmpl.uri.remote.jsonrpc.CapabilityLevel;
 import org.rascalmpl.uri.remote.jsonrpc.CopyRequest;
 import org.rascalmpl.uri.remote.jsonrpc.DirectoryListingResponse;
 import org.rascalmpl.uri.remote.jsonrpc.ISourceLocationRequest;
@@ -56,6 +60,7 @@ import org.rascalmpl.uri.remote.jsonrpc.WatchRequest;
 import org.rascalmpl.uri.remote.jsonrpc.WriteFileRequest;
 import org.rascalmpl.uri.vfs.IRemoteResolverRegistryClient;
 import org.rascalmpl.uri.vfs.IRemoteResolverRegistryServer;
+import org.rascalmpl.vscode.lsp.util.Sets;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
@@ -70,6 +75,8 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
 
     @MonotonicNonNull
     private RascalFileSystemServices fileSystemServices = null;
+    @MonotonicNonNull
+    private CompletableFuture<CapabilitiesResponse> serverCapabilities = null;
 
     private <T extends SourceLocationTransformer> T transformLocations(T req) {
         return req.transformLocations(RascalFileSystemInVSCode::toRascalLocation);
@@ -77,6 +84,7 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
 
     public void connectRemoteRegistryClient(IRemoteResolverRegistryClient client) {
         fileSystemServices = new RascalFileSystemServices(client);
+        serverCapabilities = fileSystemServices.serverCapabilities();
     }
 
     private RascalFileSystemServices services() {
@@ -86,10 +94,34 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
         return fileSystemServices;
     }
 
+    private CompletableFuture<CapabilitiesResponse> capabilities() {
+        if (serverCapabilities == null) {
+            throw new IllegalStateException("Remote resolver registry client not set yet");
+        }
+        return serverCapabilities;
+
+    }
+
+    private static final Capability LOGICAL_CAPABILITY = new Capability(CapabilityLevel.PARTIAL, Locations.TRANSLATED_SCHEMES);
+
     @Override
     public CompletableFuture<CapabilitiesResponse> serverCapabilities() {
         logger.trace("serverCapabilities request");
-        return services().serverCapabilities();
+        return capabilities()
+            .thenApply(c ->
+                new CapabilitiesResponse(c.getInput(), c.getWatch(), c.getOutput(), mergeLogical(c.getLogical()), c.getGetCharset())
+            );
+    }
+
+    private Capability mergeLogical(@Nullable Capability logical) {
+        if (logical == null || logical.isUnsupported()) {
+            return LOGICAL_CAPABILITY;
+        }
+        if (logical.isFullySupported()) {
+            return logical;
+        }
+        // we have to merge partial sets
+        return new Capability(CapabilityLevel.PARTIAL, Sets.union(LOGICAL_CAPABILITY.getOnlyForSchemes(), logical.getOnlyForSchemes()));
     }
 
     private static ISourceLocation toRascalLocation(ISourceLocation loc) {
@@ -102,7 +134,15 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
     @Override
     public CompletableFuture<SourceLocationResponse> resolveLocation(ISourceLocationRequest req) {
         logger.trace("resolveLocation: {}", req.getLocation());
-        return services().resolveLocation(transformLocations(req));
+        return capabilities()
+            .thenApply(CapabilitiesResponse::getLogical)
+            .thenCompose(cap -> {
+                var transformed = transformLocations(req);
+                if (cap != null && (cap.isFullySupported() || (cap.isPartiallySupported() && cap.getOnlyForSchemes().contains(transformed.getLocation().getScheme())))) {
+                    return services().resolveLocation(transformed);
+                }
+                return CompletableFuture.completedFuture(new SourceLocationResponse(transformed.getLocation()));
+            });
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
@@ -131,6 +131,22 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
         return Locations.toClientLocation(loc);
     }
 
+
+    private static boolean isSupported(@Nullable Capability cap, ISourceLocation loc) {
+        if (cap == null || cap.isUnsupported()) {
+            return false;
+        }
+        if (cap.isFullySupported()) {
+            return true;
+        }
+        var scheme = loc.getScheme();
+        int offset = scheme.indexOf('+');
+        if (offset > 0) {
+            scheme = scheme.substring(0, offset);
+        }
+        return cap.getOnlyForSchemes().contains(scheme);
+
+    }
     @Override
     public CompletableFuture<SourceLocationResponse> resolveLocation(ISourceLocationRequest req) {
         logger.trace("resolveLocation: {}", req.getLocation());
@@ -138,7 +154,7 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
             .thenApply(CapabilitiesResponse::getLogical)
             .thenCompose(cap -> {
                 var transformed = transformLocations(req);
-                if (cap != null && (cap.isFullySupported() || (cap.isPartiallySupported() && cap.getOnlyForSchemes().contains(transformed.getLocation().getScheme())))) {
+                if (isSupported(cap, transformed.getLocation())) {
                     return services().resolveLocation(transformed);
                 }
                 return CompletableFuture.completedFuture(new SourceLocationResponse(transformed.getLocation()));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
@@ -32,7 +32,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.rascalmpl.uri.FileAttributes;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/RascalFileSystemInVSCode.java
@@ -130,31 +130,15 @@ public class RascalFileSystemInVSCode implements IRemoteResolverRegistryServer {
         return Locations.toClientLocation(loc);
     }
 
-
-    private static boolean isSupported(@Nullable Capability cap, ISourceLocation loc) {
-        if (cap == null || cap.isUnsupported()) {
-            return false;
-        }
-        if (cap.isFullySupported()) {
-            return true;
-        }
-        var scheme = loc.getScheme();
-        int offset = scheme.indexOf('+');
-        if (offset > 0) {
-            scheme = scheme.substring(0, offset);
-        }
-        return cap.getOnlyForSchemes().contains(scheme);
-
-    }
     @Override
-    public CompletableFuture<SourceLocationResponse> resolveLocation(ISourceLocationRequest req) {
-        logger.trace("resolveLocation: {}", req.getLocation());
+    public CompletableFuture<SourceLocationResponse> resolve(ISourceLocationRequest req) {
+        logger.trace("resolve: {}", req.getLocation());
         return capabilities()
             .thenApply(CapabilitiesResponse::getLogical)
             .thenCompose(cap -> {
                 var transformed = transformLocations(req);
-                if (isSupported(cap, transformed.getLocation())) {
-                    return services().resolveLocation(transformed);
+                if (cap.isSupported(transformed.getLocation())) {
+                    return services().resolve(transformed);
                 }
                 return CompletableFuture.completedFuture(new SourceLocationResponse(transformed.getLocation()));
             });

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 
 import org.rascalmpl.uri.remote.RemoteExternalResolverRegistry;
 import org.rascalmpl.vscode.lsp.uri.LSPOpenFileRedirector;
-import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 import org.rascalmpl.uri.remote.RemoteExternalResolverRegistry;
 import org.rascalmpl.vscode.lsp.uri.LSPOpenFileRedirector;
+import org.rascalmpl.vscode.lsp.util.locations.Locations;
 
 import io.usethesource.vallang.ISourceLocation;
 
@@ -43,8 +44,20 @@ public class VSCodeFileSystemInRascal extends RemoteExternalResolverRegistry {
     }
 
     @Override
+    public boolean supportsLogical(String scheme) {
+        return Locations.TRANSLATED_SCHEMES.contains(scheme) || super.supportsLogical(scheme);
+    }
+
+
+    @Override
     public ISourceLocation resolve(ISourceLocation input) throws IOException {
-        var resolved = super.resolve(input);
+        ISourceLocation resolved;
+        if (super.supportsLogical(input.getScheme())) {
+            resolved = super.resolve(input);
+        }
+        else {
+            resolved = input;
+        }
         return LSPOpenFileRedirector.getInstance().resolve(resolved == null ? input : resolved);
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
@@ -45,7 +45,7 @@ public class VSCodeFileSystemInRascal extends RemoteExternalResolverRegistry {
 
     @Override
     public boolean supportsLogical(String scheme) {
-        return Locations.TRANSLATED_SCHEMES.contains(scheme) || super.supportsLogical(scheme);
+        return true;
     }
 
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/util/locations/Locations.java
@@ -29,6 +29,7 @@ package org.rascalmpl.vscode.lsp.util.locations;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -59,10 +60,13 @@ public class Locations {
     private static final Logger logger = LogManager.getLogger(Locations.class);
     private static final IRascalValueFactory VF = IRascalValueFactory.getInstance();
 
+
     // Synthetic scheme to (un)wrap an opaque URI as/from an absolute URI.
     // Can only contain alphanumeric characters or "+", "-", ".", and should start with an alpha
     // https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
     private static final String OPAQUE_SCHEME = "opaque-lsp-";
+
+    public static final Set<String> TRANSLATED_SCHEMES = Set.of(OPAQUE_SCHEME, LSPOpenFileResolver.LSP_OPEN_SCHEME);
 
     public static ISourceLocation toClientLocation(ISourceLocation loc) {
         loc = LSPOpenFileResolver.stripLspPrefix(loc);

--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -59,7 +59,7 @@ export class RascalExtension implements vscode.Disposable {
 
         vscode.window.registerTreeDataProvider('rascalmpl-configuration-view', new RascalLibraryProvider(this.rascal.rascalClient, this.log));
         vscode.window.registerTreeDataProvider('rascalmpl-debugger-view', new RascalDebugViewProvider(this.rascal.rascalDebugClient, context));
-        vscode.window.registerTerminalLinkProvider(new RascalTerminalLinkProvider(this.rascal.rascalClient));
+        vscode.window.registerTerminalLinkProvider(new RascalTerminalLinkProvider(this.rascal.rascalVFS));
     }
 
     logger(): vscode.LogOutputChannel {

--- a/rascal-vscode-extension/src/RascalTerminalLinkProvider.ts
+++ b/rascal-vscode-extension/src/RascalTerminalLinkProvider.ts
@@ -72,7 +72,7 @@ export class RascalTerminalLinkProvider implements TerminalLinkProvider<Extended
             return vscode.commands.executeCommand("vscode.open", sloc.uri) ;
         }
 
-        const [uri, coordinates] = await (await this.client).resolveLocation(vscode.Uri.parse(sloc.uri), sloc.coordinates);
+        const [uri, coordinates] = await (await this.client).resolve(vscode.Uri.parse(sloc.uri), sloc.coordinates);
         const td = await vscode.workspace.openTextDocument(uri);
         const te = await vscode.window.showTextDocument(td);
 

--- a/rascal-vscode-extension/src/RascalTerminalLinkProvider.ts
+++ b/rascal-vscode-extension/src/RascalTerminalLinkProvider.ts
@@ -34,9 +34,7 @@ interface ExtendedLink extends TerminalLink {
 
 interface SourceLocation {
     uri: string;
-    offsetLength?: [number, number];
-    beginLineColumn?: [number, number];
-    endLineColumn?: [number, number];
+    coordinates?: IRascalCoordinates;
 }
 
 /**
@@ -74,7 +72,7 @@ export class RascalTerminalLinkProvider implements TerminalLinkProvider<Extended
             return vscode.commands.executeCommand("vscode.open", sloc.uri) ;
         }
 
-        const [uri, coordinates] = await (await this.client).resolveLocation(vscode.Uri.parse(sloc.uri), sloc);
+        const [uri, coordinates] = await (await this.client).resolveLocation(vscode.Uri.parse(sloc.uri), sloc.coordinates);
         const td = await vscode.workspace.openTextDocument(uri);
         const te = await vscode.window.showTextDocument(td);
 
@@ -118,13 +116,13 @@ function buildLocation(match: RegExpExecArray): SourceLocation {
     const linkMatch = match[0];
     const linkLength = linkMatch.indexOf('|', 2);
     const sloc = <SourceLocation>{ uri: linkMatch.substring(1, linkLength) };
-    const numbers = linkMatch.substring(linkLength).match(/\d+/g,);
+    const numbers = linkMatch.substring(linkLength).match(/[0-9]+/g,);
     if (numbers && numbers.length >= 2) {
-        sloc.offsetLength = [Number(numbers[0]), Number(numbers[1])];
+        sloc.coordinates = { offsetLength : [Number(numbers[0]), Number(numbers[1])] };
         if (numbers.length === 6) {
             // we have a full loc
-            sloc.beginLineColumn = [Number(numbers[2]), Number(numbers[3])];
-            sloc.endLineColumn = [Number(numbers[4]), Number(numbers[5])];
+            sloc.coordinates.beginLineColumn = [Number(numbers[2]), Number(numbers[3])];
+            sloc.coordinates.endLineColumn = [Number(numbers[4]), Number(numbers[5])];
         }
     }
     return sloc;

--- a/rascal-vscode-extension/src/RascalTerminalLinkProvider.ts
+++ b/rascal-vscode-extension/src/RascalTerminalLinkProvider.ts
@@ -26,7 +26,7 @@
  */
 import * as vscode from 'vscode';
 import { CancellationToken, ProviderResult, TerminalLink, TerminalLinkContext, TerminalLinkProvider } from 'vscode';
-import { BaseLanguageClient } from 'vscode-languageclient';
+import { IRascalCoordinates, RascalFileSystemInVSCode } from './fs/RascalFileSystemInVSCode';
 
 interface ExtendedLink extends TerminalLink {
     loc: SourceLocation;
@@ -44,7 +44,7 @@ interface SourceLocation {
  */
 export class RascalTerminalLinkProvider implements TerminalLinkProvider<ExtendedLink> {
 
-    constructor (private readonly client: Promise<BaseLanguageClient>) {
+    constructor (private readonly client: Promise<RascalFileSystemInVSCode>) {
     }
 
     linkDetector() {
@@ -74,45 +74,26 @@ export class RascalTerminalLinkProvider implements TerminalLinkProvider<Extended
             return vscode.commands.executeCommand("vscode.open", sloc.uri) ;
         }
 
-        const rsloc: SourceLocation = this.fromRascalLocationString(await (await this.client).sendRequest("rascal/vfs/logical/resolveLocation", this.toRascalLocationString(sloc)));
-        const td = await vscode.workspace.openTextDocument(vscode.Uri.parse(rsloc.uri));
+        const [uri, coordinates] = await (await this.client).resolveLocation(vscode.Uri.parse(sloc.uri), sloc);
+        const td = await vscode.workspace.openTextDocument(uri);
         const te = await vscode.window.showTextDocument(td);
 
-        const targetRange = translateRange(rsloc, td);
-        if (targetRange) {
-            te.revealRange(targetRange);
-            te.selection = new vscode.Selection(
-                targetRange.start.line,
-                targetRange.start.character,
-                targetRange.end.line,
-                targetRange.end.character,
-            );
-        }
-    }
-
-    toRascalLocationString(sloc: SourceLocation): string {
-        let ret = `|${sloc.uri}|`;
-        if (sloc.offsetLength) {
-            ret += `(${sloc.offsetLength[0]},${sloc.offsetLength[1]}`;
-            if (sloc.beginLineColumn) {
-                ret += `,<${sloc.beginLineColumn[0]},${sloc.beginLineColumn[1]}>`;
-                ret += `,<${sloc.endLineColumn![0]},${sloc.endLineColumn![1]}>`;
+        if (coordinates) {
+            const targetRange = translateRange(coordinates, td);
+            if (targetRange) {
+                te.revealRange(targetRange);
+                te.selection = new vscode.Selection(
+                    targetRange.start.line,
+                    targetRange.start.character,
+                    targetRange.end.line,
+                    targetRange.end.character,
+                );
             }
-            ret += ")";
         }
-        return ret;
-    }
-
-    fromRascalLocationString(loc: string): SourceLocation {
-        const match: RegExpExecArray | null = this.linkDetector().exec(loc);
-        if (match !== null) {
-            return buildLocation(match);
-        }
-        throw Error(`Invalid location ${loc}`);
     }
 }
 
-function translateRange(sloc: SourceLocation, td: vscode.TextDocument): vscode.Range | undefined {
+function translateRange(sloc: IRascalCoordinates, td: vscode.TextDocument): vscode.Range | undefined {
     if (sloc.beginLineColumn !== undefined && sloc.endLineColumn !== undefined) {
         const beginLine = sloc.beginLineColumn[0] - 1;
         const endLine = sloc.endLineColumn[0] - 1;

--- a/rascal-vscode-extension/src/extension.ts
+++ b/rascal-vscode-extension/src/extension.ts
@@ -40,12 +40,14 @@ export function activate(context: vscode.ExtensionContext) {
     const jars = context.asAbsolutePath(path.join('.', 'assets', 'jars'));
     const icon = vscode.Uri.joinPath(context.extensionUri, "assets", "images", "rascal-logo-v2.1.svg");
     const extension = new RascalExtension(context, jars, icon, deployMode);
+    const logger= extension.logger();
+    logger.info(`Starting extension deployMode: ${deployMode} testDeployMode: ${testDeployMode}`)
     context.subscriptions.push(extension);
     context.subscriptions.push(new RascalMFValidator());
     context.subscriptions.push(new VsCodeSettingsFixer());
-    context.subscriptions.push(new RascalProjectValidator(extension.logger()));
-    if (deployMode || testDeployMode) {
-        context.subscriptions.push(new TestVirtualFileSystem(extension.logger()));
+    context.subscriptions.push(new RascalProjectValidator(logger));
+    if (!deployMode || testDeployMode) {
+        context.subscriptions.push(new TestVirtualFileSystem(logger));
     }
 
     return extension.externalLanguageRegistry();

--- a/rascal-vscode-extension/src/fs/JsonRpcMessages.ts
+++ b/rascal-vscode-extension/src/fs/JsonRpcMessages.ts
@@ -119,7 +119,7 @@ export interface TimestampResponse {
 }
 
 export interface SourceLocationResponse {
-    /** can be a uri or an ISourceLocation string with offsets */
+    /** can be a plain uri or an ISourceLocation string with offsets, as in: `|uri|(coordinates)` */
     loc: ISourceLocation | undefined
 }
 

--- a/rascal-vscode-extension/src/fs/JsonRpcMessages.ts
+++ b/rascal-vscode-extension/src/fs/JsonRpcMessages.ts
@@ -130,3 +130,22 @@ export interface DirectoryEntry {
     name: string;
     types: vscode.FileType[]
 }
+
+export interface Capabilities {
+    input: Capability | undefined;
+    output: Capability | undefined;
+    watch: Capability | undefined;
+    logical: Capability | undefined;
+    getCharset: Capability | undefined;
+}
+
+export interface Capability {
+    level: CapabilityLevel;
+    onlyForSchemes: string[] | undefined;
+}
+
+export enum CapabilityLevel {
+    unsupported = 0,
+    partial = 1,
+    full = 2
+}

--- a/rascal-vscode-extension/src/fs/JsonRpcMessages.ts
+++ b/rascal-vscode-extension/src/fs/JsonRpcMessages.ts
@@ -119,8 +119,10 @@ export interface TimestampResponse {
 }
 
 export interface SourceLocationResponse {
+    /** can be a uri or an ISourceLocation string with offsets */
     loc: ISourceLocation | undefined
 }
+
 
 export interface DirectoryListingResponse {
     entries: DirectoryEntry[]

--- a/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
@@ -62,20 +62,17 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
             RascalFileSystemInVSCode.notifyWatchers(vscode.Uri.parse(event.root), this.translateFileChangeType(event.type.valueOf()), this.activeWatches, this._emitter, "RascalFileSystemInVSCode", this.logger);
         });
         this.serverCapabilities = client.sendRequest<Capabilities>("rascal/vfs/serverCapabilities");
-        this.inputClient = buildClientProxy(client, "rascal/vfs/input/", logger, this.checkWithCapabilities(c => c.input));
-        this.outputClient = buildClientProxy(client, "rascal/vfs/output/", logger, this.checkWithCapabilities(c => c.output));
-        this.watchClient = buildClientProxy(client, "rascal/vfs/watcher/", logger, this.checkWithCapabilities(c => c.watch));
-        this.logicalClient = buildClientProxy(client, "rascal/vfs/logical/", logger, this.checkWithCapabilities(c => c.logical));
+        this.inputClient = buildClientProxy(client, "rascal/vfs/input/", logger, this.capabilityChecker(c => c.input));
+        this.outputClient = buildClientProxy(client, "rascal/vfs/output/", logger, this.capabilityChecker(c => c.output));
+        this.watchClient = buildClientProxy(client, "rascal/vfs/watcher/", logger, this.capabilityChecker(c => c.watch));
+        this.logicalClient = buildClientProxy(client, "rascal/vfs/logical/", logger, this.capabilityChecker(c => c.logical));
         // note that charset is not added as VS Code does not support that over the VFS
     }
 
-    checkWithCapabilities(cap: (all: Capabilities) => Capability | undefined) {
-        return async (req: JsonRpcRequest) : Promise<boolean> => {
-            const currentCap = cap(await this.serverCapabilities);
-            if (!currentCap) {
-                return false;
-            }
-            switch (currentCap.level) {
+    async capabilityChecker(capField: (caps: Capabilities) => Capability | undefined) {
+        const cap = capField(await this.serverCapabilities) ?? <Capability>{ level: CapabilityLevel.unsupported };
+        return (req: JsonRpcRequest) : boolean => {
+            switch (cap.level) {
                 case CapabilityLevel.full: return true;
                 case CapabilityLevel.unsupported: return false;
                 case CapabilityLevel.partial: {
@@ -87,7 +84,7 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
                         uri = req.from;
                     }
                     // if there was no uri, let's assume it supported, and the server should throw an error if not the case
-                    return uri === undefined || supportedScheme(currentCap.onlyForSchemes!, uri);
+                    return uri === undefined || supportedScheme(cap.onlyForSchemes!, uri);
                 }
             }
         };
@@ -357,11 +354,11 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
     }
 }
 
-function buildClientProxy<T extends ISourceLocationInput | ISourceLocationOutput | ISourceLocationWatcher | ILogicalSourceLocationResolver>(client: BaseLanguageClient, methodPrefix: string, logger: vscode.LogOutputChannel, supportedCheck: (arg: JsonRpcRequest) => Promise<boolean>): T {
+function buildClientProxy<T extends ISourceLocationInput | ISourceLocationOutput | ISourceLocationWatcher | ILogicalSourceLocationResolver>(client: BaseLanguageClient, methodPrefix: string, logger: vscode.LogOutputChannel, supportedCheck: Promise<(arg: JsonRpcRequest) => boolean>): T {
     return new Proxy({} as T, {
         get(_ignored, fieldName: string, _self) {
             return async function(arg: JsonRpcRequest) {
-                if (!await supportedCheck(arg)) {
+                if (!(await supportedCheck)(arg)) {
                     throw new vscode.FileSystemError(`${methodPrefix + fieldName} is not supported based on the capabilities of the VFS server`);
                 }
                 try {
@@ -379,7 +376,7 @@ function uriToRequest(uri: vscode.Uri): ISourceLocationRequest {
 }
 
 
-function supportedScheme(onlyForSchemes: string[], loc: string): boolean | PromiseLike<boolean> {
+function supportedScheme(onlyForSchemes: string[], loc: string): boolean  {
     let scheme = loc.substring(0, loc.indexOf(':'));
     const plusSplit = scheme.indexOf('+');
     if (plusSplit > 0) {

--- a/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
@@ -208,7 +208,7 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
                         case CapabilityLevel.full: readOnly = false; break;
                         case CapabilityLevel.unsupported: readOnly = true; break;
                         case CapabilityLevel.partial: {
-                            readOnly = !outputCap.onlyForSchemes!.includes(s);
+                            readOnly = !supportedScheme(outputCap.onlyForSchemes!, s);
                             break;
                         }
                     }

--- a/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
@@ -337,9 +337,9 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
         });
     }
 
-    async resolveLocation(source: vscode.Uri, coordinates?: IRascalCoordinates): Promise<[vscode.Uri, IRascalCoordinates | undefined]> {
-        this.logger.debug("[RascalFileSystemInVSCode] resolveLocation: ", source);
-        const result = await this.logicalClient.resolveLocation({
+    async resolve(source: vscode.Uri, coordinates?: IRascalCoordinates): Promise<[vscode.Uri, IRascalCoordinates | undefined]> {
+        this.logger.debug("[RascalFileSystemInVSCode] resolve: ", source);
+        const result = await this.logicalClient.resolve({
             loc: RascalFileSystemInVSCode.addCoordinates(RascalFileSystemInVSCode.toRascalUri(source), coordinates),
         });
         if (!result.loc) {

--- a/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
@@ -28,9 +28,9 @@ import { randomUUID } from 'crypto';
 import path from 'path';
 import * as vscode from 'vscode';
 import { BaseLanguageClient, ResponseError } from 'vscode-languageclient';
-import { ISourceLocation, ISourceLocationChanged, ISourceLocationRequest, JsonRpcRequest } from './JsonRpcMessages';
+import { Capabilities, Capability, CapabilityLevel, ISourceLocation, ISourceLocationChanged, ISourceLocationRequest, JsonRpcRequest } from './JsonRpcMessages';
 import { RemoteIOError } from './RemoteIOError';
-import { ISourceLocationInput, ISourceLocationOutput, ISourceLocationWatcher } from './URIResolverInterfaces';
+import { ILogicalSourceLocationResolver, ISourceLocationInput, ISourceLocationOutput, ISourceLocationWatcher } from './URIResolverInterfaces';
 
 export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
     private readonly _emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
@@ -40,6 +40,8 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
     private readonly inputClient: ISourceLocationInput;
     private readonly outputClient: ISourceLocationOutput;
     private readonly watchClient: ISourceLocationWatcher;
+    private readonly logicalClient: ILogicalSourceLocationResolver;
+    private readonly serverCapabilities: Promise<Capabilities>;
 
     // Unique identifier for the current file system instance
     private readonly vfsWatchId = randomUUID();
@@ -59,9 +61,30 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
             }
             RascalFileSystemInVSCode.notifyWatchers(vscode.Uri.parse(event.root), this.translateFileChangeType(event.type.valueOf()), this.activeWatches, this._emitter, "RascalFileSystemInVSCode", this.logger);
         });
-        this.inputClient = buildClientProxy(client, "rascal/vfs/input/", logger);
-        this.outputClient = buildClientProxy(client, "rascal/vfs/output/", logger);
-        this.watchClient = buildClientProxy(client, "rascal/vfs/watcher/", logger);
+        this.serverCapabilities = client.sendRequest<Capabilities>("rascal/vfs/serverCapabilities");
+        this.inputClient = buildClientProxy(client, "rascal/vfs/input/", logger, this.checkWithCapabilities(c => c.input));
+        this.outputClient = buildClientProxy(client, "rascal/vfs/output/", logger, this.checkWithCapabilities(c => c.output));
+        this.watchClient = buildClientProxy(client, "rascal/vfs/watcher/", logger, this.checkWithCapabilities(c => c.output));
+        this.logicalClient = buildClientProxy(client, "rascal/vfs/logical/", logger, this.checkWithCapabilities(c => c.logical));
+    }
+
+    checkWithCapabilities(cap: (all: Capabilities) => Capability | undefined) {
+        return async (req: JsonRpcRequest) : Promise<boolean> => {
+            const currentCap = cap(await this.serverCapabilities);
+            if (!currentCap) {
+                return false;
+            }
+            switch (currentCap.level) {
+                case CapabilityLevel.full: return true;
+                case CapabilityLevel.unsupported: return false;
+                case CapabilityLevel.partial: {
+                    if ('loc'  in req && typeof req.loc === 'string') {
+                        return supportedScheme(currentCap.onlyForSchemes!, req.loc);
+                    }
+                    return true;
+                }
+            }
+        };
     }
 
     private translateFileChangeType(rascalFileChangeType: number): vscode.FileChangeType {
@@ -130,6 +153,23 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
         return uriString;
     }
 
+    static addCoordinates(uri: string, coordinates: IRascalCoordinates | undefined): string {
+        if (!coordinates || (!coordinates.offsetLength && (!coordinates.beginLineColumn || !coordinates.endLineColumn))) {
+            return uri;
+        }
+        let result = `|${uri}|(`;
+        if (coordinates.offsetLength) {
+            result += `${coordinates.offsetLength[0]},${coordinates.offsetLength[1]}`;
+        }
+        if (coordinates.beginLineColumn && coordinates.endLineColumn) {
+            if (!result.endsWith('(')) {
+                result += ',';
+            }
+            result += `<${coordinates.beginLineColumn[0]}, ${coordinates.beginLineColumn[1]}>,<${coordinates.endLineColumn[0]}, ${coordinates.endLineColumn[1]}>`;
+        }
+        return result +")";
+    }
+
     static getLocation(arg: vscode.Uri | JsonRpcRequest): ISourceLocation {
         if (arg instanceof vscode.Uri) {
             return RascalFileSystemInVSCode.toRascalUri(arg);
@@ -150,11 +190,13 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
         return vscode.workspace.fs.isWritableFileSystem(scheme) === undefined;
     }
 
+
     /**
      * Attempts to register all schemes.
      * @param schemes The list of schemes to register for this provider
      */
-    tryRegisterSchemes(schemes: string[]) {
+    async tryRegisterSchemes(schemes: string[]) {
+        const outputCap = (await this.serverCapabilities).output ?? { level: CapabilityLevel.unsupported, onlyForSchemes: undefined};
         schemes
             .filter(s => !this.protectedSchemes.includes(s))
             // we add support for schemes that look inside a jar
@@ -164,7 +206,17 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
             .filter(this.isUnknownFileSystem)
             .forEach(s => {
                 try {
-                    vscode.workspace.registerFileSystemProvider(s, this);
+                    let readOnly: boolean;
+                    switch (outputCap.level) {
+                        case CapabilityLevel.full: readOnly = false; break;
+                        case CapabilityLevel.unsupported: readOnly = true; break;
+                        case CapabilityLevel.partial: {
+                            readOnly = !outputCap.onlyForSchemes!.includes(s);
+                            break;
+                        }
+                    }
+
+                    vscode.workspace.registerFileSystemProvider(s, this, { isReadonly: readOnly});
                     this.logger.debug(`Rascal VFS registered scheme: ${s}`);
                 } catch (error) {
                     if (this.isUnknownFileSystem(s)) {
@@ -287,12 +339,31 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
             overwrite: options?.overwrite ?? false
         });
     }
+
+    async resolveLocation(source: vscode.Uri, coordinates?: IRascalCoordinates): Promise<[vscode.Uri, IRascalCoordinates | undefined]> {
+        this.logger.debug("[RascalFileSystemInVSCode] resolveLocation: ", source);
+        const result = await this.logicalClient.resolveLocation({
+            loc: RascalFileSystemInVSCode.addCoordinates(RascalFileSystemInVSCode.toRascalUri(source), coordinates),
+        });
+        if (!result.loc) {
+            this.logger.trace("[RascalFileSystemInVSCode] resolveClient return empty result for: ", source);
+            return [source, coordinates];
+        }
+        if (!result.loc.startsWith('|')) {
+            return [vscode.Uri.parse(result.loc), undefined];
+        }
+        return parseFullSourceLocation(result.loc);
+
+    }
 }
 
-function buildClientProxy<T extends ISourceLocationInput | ISourceLocationOutput | ISourceLocationWatcher>(client: BaseLanguageClient, methodPrefix: string, logger: vscode.LogOutputChannel): T {
+function buildClientProxy<T extends ISourceLocationInput | ISourceLocationOutput | ISourceLocationWatcher | ILogicalSourceLocationResolver>(client: BaseLanguageClient, methodPrefix: string, logger: vscode.LogOutputChannel, supportedCheck: (arg: JsonRpcRequest) => Promise<boolean>): T {
     return new Proxy({} as T, {
         get(_ignored, fieldName: string, _self) {
             return async function(arg: JsonRpcRequest) {
+                if (!await supportedCheck(arg)) {
+                    throw new vscode.FileSystemError(`${methodPrefix + fieldName} is not supported based on the capabilities of the VFS server`);
+                }
                 try {
                     return await client.sendRequest(methodPrefix + fieldName, arg);
                 } catch (r) {
@@ -305,5 +376,66 @@ function buildClientProxy<T extends ISourceLocationInput | ISourceLocationOutput
 
 function uriToRequest(uri: vscode.Uri): ISourceLocationRequest {
     return { loc: RascalFileSystemInVSCode.toRascalUri(uri) };
+}
+
+
+function supportedScheme(onlyForSchemes: string[], loc: string): boolean | PromiseLike<boolean> {
+    let scheme = loc.substring(0, loc.indexOf(':'));
+    const plusSplit = scheme.indexOf('+');
+    if (plusSplit > 0) {
+        scheme = scheme.substring(0, plusSplit);
+    }
+    return onlyForSchemes.includes(scheme);
+}
+
+
+/**
+ * Rascal coordinates in unicode codepoints (so utf32/24)
+ */
+export interface IRascalCoordinates {
+    offsetLength?: [offset: number, length: number];
+    beginLineColumn?: [line: number, column: number];
+    endLineColumn?: [line: number, column: number];
+}
+
+function asNumberPair(ar: number[]): [number, number] {
+    if (ar.length !==  2) {
+        throw new Error(`Cannot convert ${ar} to tuple pair`);
+    }
+    return [ar[0]!, ar[1]!];
+}
+
+function parseFullSourceLocation(loc: string): [vscode.Uri, IRascalCoordinates | undefined] {
+    const [uriPart, coordinates] = loc.substring(1).split('|');
+    if (!uriPart) {
+        throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation`);
+    }
+    const base = vscode.Uri.parse(uriPart);
+    if (!coordinates) {
+        return [base, undefined];
+    }
+    if (!coordinates.startsWith('(') || !coordinates.endsWith(')')) {
+        throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates`);
+    }
+    const coords = coordinates.substring(1, coordinates.length - 1).match(/\d+/g)?.map(c => parseInt(c));
+    if (!coords || coords.length < 2) {
+        throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates`);
+    }
+    switch (coords.length) {
+        case 2:
+            return [base, {offsetLength: asNumberPair(coords)}];
+        case 4:
+            return [base, {
+                beginLineColumn: asNumberPair(coords.slice(0, 2)),
+                endLineColumn: asNumberPair(coords.slice(2, 4))
+            }];
+        case 6:
+            return [base, {
+                offsetLength: asNumberPair(coords.slice(0, 2)),
+                beginLineColumn: asNumberPair(coords.slice(2, 4)),
+                endLineColumn: asNumberPair(coords.slice(4, 6))
+            }];
+    }
+    throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates (${coords})`);
 }
 

--- a/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
+++ b/rascal-vscode-extension/src/fs/RascalFileSystemInVSCode.ts
@@ -64,8 +64,9 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
         this.serverCapabilities = client.sendRequest<Capabilities>("rascal/vfs/serverCapabilities");
         this.inputClient = buildClientProxy(client, "rascal/vfs/input/", logger, this.checkWithCapabilities(c => c.input));
         this.outputClient = buildClientProxy(client, "rascal/vfs/output/", logger, this.checkWithCapabilities(c => c.output));
-        this.watchClient = buildClientProxy(client, "rascal/vfs/watcher/", logger, this.checkWithCapabilities(c => c.output));
+        this.watchClient = buildClientProxy(client, "rascal/vfs/watcher/", logger, this.checkWithCapabilities(c => c.watch));
         this.logicalClient = buildClientProxy(client, "rascal/vfs/logical/", logger, this.checkWithCapabilities(c => c.logical));
+        // note that charset is not added as VS Code does not support that over the VFS
     }
 
     checkWithCapabilities(cap: (all: Capabilities) => Capability | undefined) {
@@ -78,10 +79,15 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
                 case CapabilityLevel.full: return true;
                 case CapabilityLevel.unsupported: return false;
                 case CapabilityLevel.partial: {
-                    if ('loc'  in req && typeof req.loc === 'string') {
-                        return supportedScheme(currentCap.onlyForSchemes!, req.loc);
+                    let uri = undefined;
+                    if ('loc' in req && typeof req.loc === 'string') {
+                        uri = req.loc;
                     }
-                    return true;
+                    else if ('from' in req && typeof req.from === 'string') {
+                        uri = req.from;
+                    }
+                    // if there was no uri, let's assume it supported, and the server should throw an error if not the case
+                    return uri === undefined || supportedScheme(currentCap.onlyForSchemes!, uri);
                 }
             }
         };
@@ -154,20 +160,14 @@ export class RascalFileSystemInVSCode implements vscode.FileSystemProvider {
     }
 
     static addCoordinates(uri: string, coordinates: IRascalCoordinates | undefined): string {
-        if (!coordinates || (!coordinates.offsetLength && (!coordinates.beginLineColumn || !coordinates.endLineColumn))) {
+        if (!coordinates) {
             return uri;
         }
-        let result = `|${uri}|(`;
-        if (coordinates.offsetLength) {
-            result += `${coordinates.offsetLength[0]},${coordinates.offsetLength[1]}`;
-        }
+        let result = `|${uri}|(${coordinates.offsetLength[0]},${coordinates.offsetLength[1]}`;
         if (coordinates.beginLineColumn && coordinates.endLineColumn) {
-            if (!result.endsWith('(')) {
-                result += ',';
-            }
-            result += `<${coordinates.beginLineColumn[0]}, ${coordinates.beginLineColumn[1]}>,<${coordinates.endLineColumn[0]}, ${coordinates.endLineColumn[1]}>`;
+            result += `,<${coordinates.beginLineColumn[0]},${coordinates.beginLineColumn[1]}>,<${coordinates.endLineColumn[0]},${coordinates.endLineColumn[1]}>`;
         }
-        return result +")";
+        return result + ")";
     }
 
     static getLocation(arg: vscode.Uri | JsonRpcRequest): ISourceLocation {
@@ -393,7 +393,7 @@ function supportedScheme(onlyForSchemes: string[], loc: string): boolean | Promi
  * Rascal coordinates in unicode codepoints (so utf32/24)
  */
 export interface IRascalCoordinates {
-    offsetLength?: [offset: number, length: number];
+    offsetLength: [offset: number, length: number];
     beginLineColumn?: [line: number, column: number];
     endLineColumn?: [line: number, column: number];
 }
@@ -417,25 +417,20 @@ function parseFullSourceLocation(loc: string): [vscode.Uri, IRascalCoordinates |
     if (!coordinates.startsWith('(') || !coordinates.endsWith(')')) {
         throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates`);
     }
-    const coords = coordinates.substring(1, coordinates.length - 1).match(/\d+/g)?.map(c => parseInt(c));
+    const coords = coordinates.substring(1, coordinates.length - 1).match(/[0-9]+/g)?.map(c => parseInt(c));
     if (!coords || coords.length < 2) {
         throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates`);
     }
-    switch (coords.length) {
-        case 2:
-            return [base, {offsetLength: asNumberPair(coords)}];
-        case 4:
-            return [base, {
-                beginLineColumn: asNumberPair(coords.slice(0, 2)),
-                endLineColumn: asNumberPair(coords.slice(2, 4))
-            }];
-        case 6:
-            return [base, {
-                offsetLength: asNumberPair(coords.slice(0, 2)),
-                beginLineColumn: asNumberPair(coords.slice(2, 4)),
-                endLineColumn: asNumberPair(coords.slice(4, 6))
-            }];
+    const coord = <IRascalCoordinates>{
+        offsetLength: asNumberPair(coords.slice(0,2))
+    };
+    if (coords.length === 6) {
+        coord.beginLineColumn = asNumberPair(coords.slice(2, 4));
+        coord.endLineColumn = asNumberPair(coords.slice(4, 6));
     }
-    throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates (${coords})`);
+    else if (coords.length !== 2) {
+        throw new vscode.FileSystemError(`Can not parse ${loc} as ISourceLocation due to incorrect coordinates (${coords})`);
+    }
+    return [base, coord];
 }
 

--- a/rascal-vscode-extension/src/fs/URIResolverInterfaces.ts
+++ b/rascal-vscode-extension/src/fs/URIResolverInterfaces.ts
@@ -60,5 +60,5 @@ export interface ISourceLocationWatcher {
 }
 
 export interface ILogicalSourceLocationResolver {
-    resolveLocation(req: ISourceLocationRequest): Promise<SourceLocationResponse>
+    resolve(req: ISourceLocationRequest): Promise<SourceLocationResponse>
 }

--- a/rascal-vscode-extension/src/fs/URIResolverInterfaces.ts
+++ b/rascal-vscode-extension/src/fs/URIResolverInterfaces.ts
@@ -24,7 +24,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import { ISourceLocationRequest, LocationContentResponse, BooleanResponse, TimestampResponse, DirectoryListingResponse, NumberResponse, FileAttributes, StringResponse, WriteFileRequest, RemoveRequest, RenameRequest, CopyRequest, SetLastModifiedRequest, WatchRequest, SourceLocationResponse } from './JsonRpcMessages';
+import { ISourceLocationRequest, LocationContentResponse, BooleanResponse, TimestampResponse, DirectoryListingResponse, NumberResponse, FileAttributes, StringResponse, WriteFileRequest, RemoveRequest, RenameRequest, CopyRequest, SetLastModifiedRequest, WatchRequest, SourceLocationResponse, Capabilities } from './JsonRpcMessages';
+
+export interface ISourceLocationCommon {
+    getCharset(req: ISourceLocationRequest): Promise<StringResponse>;
+    serverCapabilities(): Promise<Capabilities>;
+}
 
 export interface ISourceLocationInput {
     readFile(req: ISourceLocationRequest): Promise<LocationContentResponse>;
@@ -37,7 +42,6 @@ export interface ISourceLocationInput {
     size(req: ISourceLocationRequest): Promise<NumberResponse>;
     stat(req: ISourceLocationRequest): Promise<FileAttributes>;
     isReadable(req: ISourceLocationRequest): Promise<BooleanResponse>;
-    getCharset(req: ISourceLocationRequest): Promise<StringResponse>;
 }
 
 export interface ISourceLocationOutput {

--- a/rascal-vscode-extension/src/fs/VSCodeFileSystemInRascal.ts
+++ b/rascal-vscode-extension/src/fs/VSCodeFileSystemInRascal.ts
@@ -29,14 +29,14 @@ import * as vscode from 'vscode';
 import { Disposable } from "vscode";
 import * as rpc from 'vscode-jsonrpc/node';
 import { JsonRpcServer } from "../util/JsonRpcServer";
-import { BooleanResponse, CopyRequest, DirectoryListingResponse, FileAttributes, ISourceLocation, ISourceLocationChanged, ISourceLocationChangeType, ISourceLocationRequest, LocationContentResponse, NumberResponse, RemoveRequest, RenameRequest, SetLastModifiedRequest, SourceLocationResponse, StringResponse, TimestampResponse, WatchRequest, WriteFileRequest } from './JsonRpcMessages';
+import { BooleanResponse, Capabilities, Capability, CapabilityLevel, CopyRequest, DirectoryListingResponse, FileAttributes, ISourceLocation, ISourceLocationChanged, ISourceLocationChangeType, ISourceLocationRequest, LocationContentResponse, NumberResponse, RemoveRequest, RenameRequest, SetLastModifiedRequest, SourceLocationResponse, StringResponse, TimestampResponse, WatchRequest, WriteFileRequest } from './JsonRpcMessages';
 import { RemoteIOError } from './RemoteIOError';
-import { ILogicalSourceLocationResolver, ISourceLocationInput, ISourceLocationOutput, ISourceLocationWatcher } from './URIResolverInterfaces';
+import { ILogicalSourceLocationResolver, ISourceLocationCommon, ISourceLocationInput, ISourceLocationOutput, ISourceLocationWatcher } from './URIResolverInterfaces';
 
 /**
  * VS Code implements this and offers it to the rascal-lsp server
  */
-interface VSCodeResolverServer extends ISourceLocationInput, ISourceLocationOutput, ISourceLocationWatcher, ILogicalSourceLocationResolver { }
+interface VSCodeResolverServer extends ISourceLocationCommon, ISourceLocationInput, ISourceLocationOutput, ISourceLocationWatcher, ILogicalSourceLocationResolver { }
 
 /**
  * Rascal side should implement this on the other side of the stream
@@ -63,6 +63,11 @@ function connectHandlers(connection: rpc.MessageConnection, handler: VSCodeResol
                 return handleWatchRequest(method, handler, arg);
             case "logical":
                 return handleLogicalRequest(method, handler, arg);
+            // common ones aren't prefixed:
+            case "getCharset":
+                return handler.getCharset(arg as ISourceLocationRequest);
+            case "serverCapabilities":
+                return handler.serverCapabilities();
         }
         logger.error(`[VSCodeFileSystemInRascal] Unexpected interface ${direction}`);
         throw new rpc.ResponseError(RemoteIOError.notSupported, `Unexpected interface ${direction}`);
@@ -139,6 +144,20 @@ export class VSCodeFileSystemInRascal extends JsonRpcServer {
     }
 }
 
+function fullySupported(): Capability {
+    return {
+        level: CapabilityLevel.full,
+        onlyForSchemes: undefined
+    };
+}
+
+function unsupported(): Capability {
+    return {
+        level: CapabilityLevel.unsupported,
+        onlyForSchemes: undefined
+    };
+}
+
 class ResolverClient implements VSCodeResolverServer, Disposable  {
     private readonly watchListener: WatchEventReceiver;
     private readonly fs: vscode.FileSystem;
@@ -154,6 +173,16 @@ class ResolverClient implements VSCodeResolverServer, Disposable  {
         }
         this.watchListener = buildWatchReceiver(connection, logger);
         connectHandlers(connection, this, this.disposables, logger);
+    }
+
+    async serverCapabilities(): Promise<Capabilities> {
+        return {
+            getCharset: fullySupported(),
+            input: fullySupported(),
+            output: fullySupported(),
+            watch: fullySupported(),
+            logical: unsupported(),
+        };
     }
 
     async asyncCatcher<T>(build: () => Thenable<T>): Promise<T> {
@@ -362,10 +391,8 @@ class ResolverClient implements VSCodeResolverServer, Disposable  {
         }
     }
 
-    async resolveLocation(req: ISourceLocationRequest): Promise<SourceLocationResponse> {
-        this.logger.debug("[VSCodeFileSystemInRascal] resolve: ", req.loc);
-        // There is currently no logical resolution of locations in VS Code
-        return { loc: undefined };
+    async resolveLocation(_req: ISourceLocationRequest): Promise<SourceLocationResponse> {
+        throw new rpc.ResponseError(RemoteIOError.notSupported, "resolving logical requests is not supported, as VS Code does not have this feature");
     }
 
     dispose() {

--- a/rascal-vscode-extension/src/fs/VSCodeFileSystemInRascal.ts
+++ b/rascal-vscode-extension/src/fs/VSCodeFileSystemInRascal.ts
@@ -46,23 +46,23 @@ interface VSCodeResolverServer extends ISourceLocationCommon, ISourceLocationInp
 function connectHandlers(connection: rpc.MessageConnection, handler: VSCodeResolverServer, disposables: Disposable[], logger: vscode.LogOutputChannel) {
     disposables.push(connection.onRequest((request, arg, _token) => {
         const [rascal, vfs, direction, method] = request.split("/");
-        if (rascal !== "rascal" || vfs !== "vfs" || !direction || !method) {
+        if (rascal !== "rascal" || vfs !== "vfs" || !direction || (!method && direction !== "getCharset" && direction !== "serverCapabilities")) {
             logger.error(`[VSCodeFileSystemInRascal] Incorrect request: [${rascal},${vfs},${direction},${method}]`);
             throw new rpc.ResponseError(RemoteIOError.unknown, `Unknown request ${request}`);
         }
-        if (typeof arg !== "object") {
+        if (typeof arg !== "object" && direction !== "serverCapabilities") {
             logger.error(`[VSCodeFileSystemInRascal] Incorrect argument type: ${typeof arg}`);
             throw new rpc.ResponseError(RemoteIOError.notSupported, `Unexpected argument type ${typeof arg}`);
         }
         switch (direction) {
             case "input":
-                return handleInputRequest(method, handler, arg);
+                return handleInputRequest(method!, handler, arg!);
             case "output":
-                return handleOutputRequest(method, handler, arg);
+                return handleOutputRequest(method!, handler, arg!);
             case "watcher":
-                return handleWatchRequest(method, handler, arg);
+                return handleWatchRequest(method!, handler, arg!);
             case "logical":
-                return handleLogicalRequest(method, handler, arg);
+                return handleLogicalRequest(method!, handler, arg!);
             // common ones aren't prefixed:
             case "getCharset":
                 return handler.getCharset(arg as ISourceLocationRequest);

--- a/rascal-vscode-extension/src/fs/VSCodeFileSystemInRascal.ts
+++ b/rascal-vscode-extension/src/fs/VSCodeFileSystemInRascal.ts
@@ -391,7 +391,7 @@ class ResolverClient implements VSCodeResolverServer, Disposable  {
         }
     }
 
-    async resolveLocation(_req: ISourceLocationRequest): Promise<SourceLocationResponse> {
+    async resolve(_req: ISourceLocationRequest): Promise<SourceLocationResponse> {
         throw new rpc.ResponseError(RemoteIOError.notSupported, "resolving logical requests is not supported, as VS Code does not have this feature");
     }
 

--- a/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
@@ -81,7 +81,7 @@ export class ParameterizedLanguageServer implements vscode.Disposable {
             devPort: 9999,
             dedicated: this.dedicatedLanguage !== undefined,
             lspArg: JSON.stringify(this.dedicatedLanguage)
-        });
+        }).then(([c, _]) => c);
     }
 
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -38,7 +38,7 @@ import { JsonParserOutputChannel } from './JsonOutputChannel';
 export async function activateLanguageClient(
     { language, title, jarPath, vfsServer, isParametricServer = false, deployMode = true, devPort = -1, dedicated = false, lspArg = "" } :
     {language: string, title: string, jarPath: string, vfsServer: VSCodeFileSystemInRascal, isParametricServer: boolean, deployMode: boolean, devPort: integer, dedicated: boolean, lspArg: string | undefined} )
-    : Promise<LanguageClient> {
+    : Promise<[LanguageClient, RascalFileSystemInVSCode]> {
     const logger = new JsonParserOutputChannel(title);
     const serverOptions: ServerOptions = deployMode
         ? await buildRascalServerOptions(jarPath, isParametricServer, dedicated, lspArg, await vfsServer.serverPort, logger)
@@ -65,14 +65,17 @@ export async function activateLanguageClient(
         void openEditor(uri, range, viewColumn);
     });
 
+
     const schemesReply = client.sendRequest<string[]>("rascal/vfs/schemes");
+
+    const rascalVFS = new RascalFileSystemInVSCode(client, logger);
 
     void schemesReply.then( schemes => {
         vfsServer.ignoreSchemes(schemes);
-        new RascalFileSystemInVSCode(client, logger).tryRegisterSchemes(schemes);
+        void rascalVFS.tryRegisterSchemes(schemes);
     });
 
-    return client;
+    return [client, rascalVFS];
 }
 
 const contentPanels: Map<string, vscode.WebviewPanel> = new Map();

--- a/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLanguageServer.ts
@@ -33,11 +33,13 @@ import { ParameterizedLanguageServer } from './ParameterizedLanguageServer';
 import { RascalDebugClient } from '../dap/RascalDebugClient';
 import { RASCAL_LANGUAGE_ID } from '../Identifiers';
 import { LanguageRegistry } from './LanguageRegistry';
+import { RascalFileSystemInVSCode } from '../fs/RascalFileSystemInVSCode';
 
 export class RascalLanguageServer implements vscode.Disposable {
     public readonly rascalClient: Promise<BaseLanguageClient>;
     public readonly rascalDebugClient: RascalDebugClient;
     public readonly languageRegistry: LanguageRegistry;
+    public readonly rascalVFS: Promise<RascalFileSystemInVSCode>;
 
     constructor(
         _context: vscode.ExtensionContext,
@@ -46,7 +48,7 @@ export class RascalLanguageServer implements vscode.Disposable {
         dslLSP: ParameterizedLanguageServer,
         logger: vscode.LogOutputChannel,
         deployMode = true) {
-        this.rascalClient = activateLanguageClient({
+        const client = activateLanguageClient({
             deployMode: deployMode,
             devPort: 8888,
             isParametricServer: false,
@@ -57,6 +59,8 @@ export class RascalLanguageServer implements vscode.Disposable {
             dedicated: false,
             lspArg: undefined
         });
+        this.rascalClient = client.then(c => c[0]);
+        this.rascalVFS = client.then(c => c[1]);
 
         this.rascalDebugClient = new RascalDebugClient();
 

--- a/rascal-vscode-extension/src/test/vscode-suite/remotefs.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/remotefs.test.ts
@@ -153,7 +153,7 @@ describe('RemoteFS', function () {
         expect(repl.lastOutput).is.equal("bool: true", "Writing Rascal Code fs works");
     });
 
-    it("resolveLocation from Rascal file system", async () => {
+    it("resolve from Rascal file system", async () => {
         const repl = new RascalREPL(bench, driver);
         await repl.start();
         await repl.execute(":edit IO", true, Delays.extremelySlow);


### PR DESCRIPTION
This PR adds support for capabilities (companiont to usethesource/rascal#2792), and thus also marks our server as not supporting logical URIs, which improves the performance of rascal.


During the testing I also noticed the hyperlink detector didn't work anymore after the #967 changes.