### PR TITLE
Wait for diagnostics to clear in tests

### DIFF
--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -550,12 +550,10 @@ export function printRascalOutputOnFailure(channel: 'Language Parametric Rascal'
 }
 
 export async function expectCompletions(driver: WebDriver, editor: TextEditor, expectedLabels: string[]) {
-    const completions = await driver.wait(async () => {
+    await driver.wait(async () => {
         const completionMenu = new ContentAssist(editor);
-        return await ignoreFails(completionMenu.getItems());
-    }, Delays.fast, "Completion items not found");
-
-    expect(completions).to.have.length(expectedLabels.length);
-    const labels: string[] = await Promise.all(completions!.map(c => c.getLabel()));
-    expect(labels).deep.equal(expectedLabels);
+        const completions = await ignoreFails(completionMenu.getItems());
+        const labels = await Promise.all(completions!.map(c => c.getLabel()));
+        return labels === expectedLabels;
+    }, Delays.normal, "Completion items not found");
 }

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -244,8 +244,10 @@ export class IDEOperations {
         // There should be no more error diagnostics
         const bottomBar = new Workbench().getBottomBar();
         const problemsView = await bottomBar.openProblemsView();
-        const allVisibleMarkers = await problemsView.getAllVisibleMarkers(MarkerType.Error);
-        expect(allVisibleMarkers.length, "Not all error diagnostics have been cleared").to.equal(0);
+        await this.driver.wait(async () => {
+            const allVisibleMarkers = await problemsView.getAllVisibleMarkers(MarkerType.Error);
+            return allVisibleMarkers.length === 0;
+        }, Delays.normal, "Not all error diagnostics have been cleared");
     }
 
     assertLineBecomes(editor: TextEditor, lineNumber: number, lineContents: string, msg: string, wait = Delays.verySlow) : Promise<boolean> {


### PR DESCRIPTION
This PR attempts to fix flaky tests when diagnostics are not (yet) cleared when the `afterEach` hook runs.