### PR TITLE
Document selectors for capabilities

### DIFF
--- a/rascal-lsp/src/main/checkerframework/lsp4j.astub
+++ b/rascal-lsp/src/main/checkerframework/lsp4j.astub
@@ -451,3 +451,20 @@ public class SemanticTokensCapabilities extends DynamicRegistrationCapabilities 
   public @Nullable Boolean getServerCancelSupport() {}
   public @Nullable Boolean getAugmentsSyntaxTokens() {}
 }
+
+package org.eclipse.lsp4j;
+
+import org.checkerframework.checker.nullness.qual.*;
+
+public class DocumentFilter {
+  public DocumentFilter(@Nullable String language, @Nullable String scheme, @Nullable Either<String, RelativePattern> pattern) {}
+}
+
+package org.eclipse.lsp4j;
+
+import org.checkerframework.checker.nullness.qual.*;
+
+public class Registration {
+  public Registration(String id, String method) {}
+  public Registration(String id, String method, @Nullable Object registerOptions) {}
+}

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -244,7 +244,7 @@ public class TextDocumentState {
                         }
                     }, exec);
             } catch (NoContributionException e) {
-                logger.debug("Ignoring missing parser for {}", location, e);
+                logger.debug("Ignoring missing parser for {}", location);
                 treeAsync.completeOnTimeout(new Versioned<>(version, IRascalValueFactory.getInstance().character(0), timestamp), 60, TimeUnit.SECONDS);
             }
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/NoContributions.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/NoContributions.java
@@ -87,7 +87,7 @@ public class NoContributions implements ILanguageContributions {
 
     @Override
     public CompletableFuture<ITree> parsing(ISourceLocation loc, String input) {
-        return CompletableFuture.failedFuture(new NoContributionException("parsing"));
+        throw new NoContributionException("parsing");
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -321,6 +321,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         var ext = URIUtil.getExtension(Locations.toLoc(uri));
         // We want the original scheme, not the one possibly modified when converting URI -> loc
         if (ext.equals("") && extensionLessSchemes.add(uri.getScheme())) {
+            // Should be called from the main, single-threaded request pool
             updateCapabilities();
         }
     }
@@ -956,6 +957,9 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
 
         // Do this last, after the parser for open editors has been updated,
         // since this might trigger new requests on the editor contents.
+        // `updateCapabilities`/`CapabilityRegistration::update` should never be called asynchronously, since that might re-order incoming updates.
+        // Since `registerLanguage` is called from a single-threaded pool, calling it here is safe.
+        // Note: `updateCapabilities` returns a void future, which we do not have to wait on.
         updateCapabilities();
     }
 
@@ -973,9 +977,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     }
 
     private synchronized CompletableFuture<Void> updateCapabilities() {
-        // `CapabilityRegistration::update` should never be called asynchronously, since that might re-order incoming updates.
-        // Since `registerLanguage` is called from a single-threaded pool, calling it here is safe.
-        // Note: `CapabilityRegistration::update` returns a void future, which we do not have to wait on.
         return availableCapabilities()
             .update(buildLanguageParams())
             .thenCompose(v -> refreshEditors());
@@ -1051,6 +1052,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             contributions.remove(lang.getName());
         }
 
+        // Should be called from the main, single-threaded request pool
         updateCapabilities();
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -138,6 +138,7 @@ import org.rascalmpl.vscode.lsp.parametric.capabilities.CapabilityRegistration;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.CompletionCapability;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.FileOperationCapability;
 import org.rascalmpl.vscode.lsp.parametric.capabilities.ICapabilityParams;
+import org.rascalmpl.vscode.lsp.parametric.capabilities.SemanticTokensCapability;
 import org.rascalmpl.vscode.lsp.parametric.model.ParametricFileFacts;
 import org.rascalmpl.vscode.lsp.parametric.model.ParametricSummary;
 import org.rascalmpl.vscode.lsp.parametric.model.ParametricSummary.SummaryLookup;
@@ -224,6 +225,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         // Since the initialize request is the very first request after connecting, we can initialize the capabilities here
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
         dynamicCapabilities = new CapabilityRegistration(availableClient(), exec, clientCapabilities
+            , new SemanticTokensCapability()
             , new CompletionCapability()
             , /* new FileOperationCapability.DidCreateFiles(exec), */ new FileOperationCapability.DidRenameFiles(exec), new FileOperationCapability.DidDeleteFiles(exec)
         );
@@ -235,7 +237,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         result.setReferencesProvider(true);
         result.setDocumentSymbolProvider(true);
         result.setImplementationProvider(true);
-        result.setSemanticTokensProvider(tokenizer.options());
         result.setCodeActionProvider(true);
         result.setCodeLensProvider(new CodeLensOptions(false));
         result.setRenameProvider(new RenameOptions(true));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -945,8 +945,6 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             this.registeredExtensions.put(extension, lang.getName());
         }
 
-        updateCapabilities();
-
         // If we opened any files with this extension before, now associate them with contributions
         var extensions = Arrays.asList(lang.getExtensions());
         for (var f : getOpenFiles()) {
@@ -955,13 +953,30 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
                 refreshFileState(f);
             }
         }
+
+        // Do this last, after the parser for open editors has been updated,
+        // since this might trigger new requests on the editor contents.
+        updateCapabilities();
+    }
+
+    private CompletableFuture<Void> refreshEditors() {
+        return CompletableFutureUtils.reduce(List.of(
+            availableClient().refreshCodeLenses(),
+            availableClient().refreshDiagnostics(),
+            availableClient().refreshFoldingRanges(),
+            availableClient().refreshInlayHints(),
+            availableClient().refreshInlineValues(),
+            availableClient().refreshSemanticTokens()
+        ), (v1, v2) -> null);
     }
 
     private synchronized CompletableFuture<Void> updateCapabilities() {
         // `CapabilityRegistration::update` should never be called asynchronously, since that might re-order incoming updates.
         // Since `registerLanguage` is called from a single-threaded pool, calling it here is safe.
         // Note: `CapabilityRegistration::update` returns a void future, which we do not have to wait on.
-        return availableCapabilities().update(buildLanguageParams());
+        return availableCapabilities()
+            .update(buildLanguageParams())
+            .thenCompose(v -> refreshEditors());
     }
 
     /**

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -26,12 +26,14 @@
  */
 package org.rascalmpl.vscode.lsp.parametric;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -181,6 +183,8 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
 
     private final String dedicatedLanguageName;
     private final SemanticTokenizer tokenizer = new SemanticTokenizer();
+    private final Set<String> extensionLessSchemes = new HashSet<>();
+
     private @MonotonicNonNull LanguageClient client;
     private @MonotonicNonNull BaseWorkspaceService workspaceService;
     private @MonotonicNonNull CapabilityRegistration dynamicCapabilities;
@@ -304,6 +308,21 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
         TextDocumentState file = open(params.getTextDocument(), timestamp);
         handleParsingErrors(file, file.getCurrentDiagnosticsAsync());
         triggerAnalyzer(params.getTextDocument(), NORMAL_DEBOUNCE);
+
+        // Discover capabilities
+        discoverExtensionLessScheme(URIUtil.assumeCorrect(params.getTextDocument().getUri()));
+    }
+
+    /**
+     * Captures extensions-less schemes and updates dynamic capabilities to apply to them.
+     * @param uri A URI that should be associated with the parametric server.
+     */
+    private void discoverExtensionLessScheme(URI uri) {
+        var ext = URIUtil.getExtension(Locations.toLoc(uri));
+        // We want the original scheme, not the one possibly modified when converting URI -> loc
+        if (ext.equals("") && extensionLessSchemes.add(uri.getScheme())) {
+            updateCapabilities();
+        }
     }
 
     @Override
@@ -926,10 +945,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             this.registeredExtensions.put(extension, lang.getName());
         }
 
-        // `CapabilityRegistration::update` should never be called asynchronously, since that might re-order incoming updates.
-        // Since `registerLanguage` is called from a single-threaded pool, calling it here is safe.
-        // Note: `CapabilityRegistration::update` returns a void future, which we do not have to wait on.
-        availableCapabilities().update(buildLanguageParams());
+        updateCapabilities();
 
         // If we opened any files with this extension before, now associate them with contributions
         var extensions = Arrays.asList(lang.getExtensions());
@@ -939,6 +955,13 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
                 refreshFileState(f);
             }
         }
+    }
+
+    private synchronized CompletableFuture<Void> updateCapabilities() {
+        // `CapabilityRegistration::update` should never be called asynchronously, since that might re-order incoming updates.
+        // Since `registerLanguage` is called from a single-threaded pool, calling it here is safe.
+        // Note: `CapabilityRegistration::update` returns a void future, which we do not have to wait on.
+        return availableCapabilities().update(buildLanguageParams());
     }
 
     /**
@@ -956,6 +979,11 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             @Override
             public Set<String> fileExtensions() {
                 return extensionsByLang.getOrDefault(e.getKey(), Collections.emptySet());
+            }
+
+            @Override
+            public Set<String> extensionLessSchemes() {
+                return extensionLessSchemes;
             }
         }).collect(Collectors.toSet());
     }
@@ -1006,7 +1034,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
             contributions.remove(lang.getName());
         }
 
-        availableCapabilities().update(buildLanguageParams());
+        updateCapabilities();
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +40,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -183,7 +183,7 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
 
     private final String dedicatedLanguageName;
     private final SemanticTokenizer tokenizer = new SemanticTokenizer();
-    private final Set<String> extensionLessSchemes = new HashSet<>();
+    private final Set<String> extensionLessSchemes = new CopyOnWriteArraySet<>();
 
     private @MonotonicNonNull LanguageClient client;
     private @MonotonicNonNull BaseWorkspaceService workspaceService;

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/ParametricTextDocumentService.java
@@ -960,13 +960,15 @@ public class ParametricTextDocumentService extends TextDocumentStateManager impl
     }
 
     private CompletableFuture<Void> refreshEditors() {
+        var client = availableClient();
+        // Do all in parallel, and return a future that completes when each of these completes
         return CompletableFutureUtils.reduce(List.of(
-            availableClient().refreshCodeLenses(),
-            availableClient().refreshDiagnostics(),
-            availableClient().refreshFoldingRanges(),
-            availableClient().refreshInlayHints(),
-            availableClient().refreshInlineValues(),
-            availableClient().refreshSemanticTokens()
+            client.refreshCodeLenses(),
+            client.refreshDiagnostics(),
+            client.refreshFoldingRanges(),
+            client.refreshInlayHints(),
+            client.refreshInlineValues(),
+            client.refreshSemanticTokens()
         ), (v1, v2) -> null);
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -313,6 +313,7 @@ public class CapabilityRegistration {
         if (opts.getDocumentSelector() == null || opts.getDocumentSelector().isEmpty()) {
             opts.setDocumentSelector(params.stream()
                 .flatMap(c -> c.fileExtensions().stream())
+                .distinct()
                 .map(ext -> {
                     var filter = new DocumentFilter();
                     filter.setPattern(String.format("**/*.%s", ext));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -44,11 +44,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DocumentFilter;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentRegistrationOptions;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
@@ -62,6 +64,8 @@ import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
 public class CapabilityRegistration {
 
     private static final Logger logger = LogManager.getLogger(CapabilityRegistration.class);
+
+    private static final DocumentFilter UNTITLED_FILES = new DocumentFilter(null, "untitled", null);
 
     private final LanguageClient client;
     private final Executor exec;
@@ -287,15 +291,37 @@ public class CapabilityRegistration {
         }
 
         // Filter contributions by providing this capability
-        return CompletableFutureUtils.filter(languages, cap::isProvidedBy).<@Nullable Registration>thenCompose(cs -> {
-            if (cs.isEmpty()) {
+        return CompletableFutureUtils.filter(languages, cap::isProvidedBy).<@Nullable Registration>thenCompose(providingLanguages -> {
+            if (providingLanguages.isEmpty()) {
                 return CompletableFutureUtils.completedFuture(null, exec);
             }
 
-            var allOpts = cs.stream().<CompletableFuture<@Nullable T>>map(cap::options).collect(Collectors.toList());
+            var allOpts = providingLanguages.stream().<CompletableFuture<@Nullable T>>map(cap::options).collect(Collectors.toList());
             return CompletableFutureUtils.reduce(allOpts, cap::mergeNullableOptions) // non-empty, so no need to provide a reduction identity
+                .<@Nullable T>thenApply(opts -> {
+                    if (opts instanceof TextDocumentRegistrationOptions) {
+                        setDocumentSelector((TextDocumentRegistrationOptions) opts, providingLanguages);
+                    }
+                    return opts;
+                })
                 .thenApply(opts -> new Registration(cap.id(), cap.methodName(), opts));
         });
+    }
+
+    private void setDocumentSelector(TextDocumentRegistrationOptions opts, Collection<ICapabilityParams> params) {
+        // If the document selector is set already by the capability implementation, we do not touch it.
+        if (opts.getDocumentSelector() == null || opts.getDocumentSelector().isEmpty()) {
+            opts.setDocumentSelector(params.stream()
+                .flatMap(c -> c.fileExtensions().stream())
+                .map(ext -> {
+                    var filter = new DocumentFilter();
+                    filter.setPattern(String.format("**/*.%s", ext));
+                    return filter;
+                }).collect(Collectors.toList()));
+
+            // Always support untitled files, since those can belong to any language
+            opts.getDocumentSelector().add(UNTITLED_FILES);
+        }
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -314,14 +314,14 @@ public class CapabilityRegistration {
             var filters = params.stream()
                 .flatMap(c -> c.fileExtensions().stream())
                 .distinct()
-                .map(ext -> new DocumentFilter(null, null, Either.forLeft(String.format("**/*.%s", ext))))
+                .map(ext -> new DocumentFilter("parametric-rascalmpl", null, Either.forLeft(String.format("**/*.%s", ext))))
                 .collect(Collectors.toList());
 
             // scheme filters
             filters.addAll(params.stream()
                 .flatMap(c -> c.extensionLessSchemes().stream())
                 .distinct()
-                .map(scheme -> new DocumentFilter(null, scheme, null))
+                .map(scheme -> new DocumentFilter("parametric-rascalmpl", scheme, null))
                 .collect(Collectors.toList()));
 
             opts.setDocumentSelector(filters);

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -307,26 +308,26 @@ public class CapabilityRegistration {
         });
     }
 
+    /**
+     * Add document selectors for extensions and schemes if not already present
+     */
     private void setDocumentSelector(TextDocumentRegistrationOptions opts, Collection<ICapabilityParams> params) {
-        // If the document selector is set already by the capability implementation, we do not touch it.
-        // This allows specific capabilities to add specific selectors if needed.
-        if (opts.getDocumentSelector() == null || opts.getDocumentSelector().isEmpty()) {
-            // extension filters
-            var filters = params.stream()
-                .flatMap(c -> c.fileExtensions().stream())
-                .distinct()
-                .map(ext -> new DocumentFilter("parametric-rascalmpl", null, Either.forLeft(String.format("**/*.%s", ext))))
-                .collect(Collectors.toList());
+        // extension & scheme selectors
+        var additionalSelectors = params.stream()
+            .flatMap(c -> {
+                var extSelectors = c.fileExtensions().stream().map(ext -> new DocumentFilter("parametric-rascalmpl", null, Either.forLeft(String.format("**/*.%s", ext))));
+                var schemeSelectors = c.extensionLessSchemes().stream().map(scheme -> new DocumentFilter("parametric-rascalmpl", scheme, null));
+                return Stream.concat(extSelectors, schemeSelectors);
+            })
+            .distinct();
 
-            // scheme filters
-            filters.addAll(params.stream()
-                .flatMap(c -> c.extensionLessSchemes().stream())
-                .distinct()
-                .map(scheme -> new DocumentFilter("parametric-rascalmpl", scheme, null))
-                .collect(Collectors.toList()));
-
-            opts.setDocumentSelector(filters);
+        if (opts.getDocumentSelector() == null) {
+            // No need to concatenate anything
+            opts.setDocumentSelector(additionalSelectors.collect(Collectors.toList()));
+            return;
         }
+
+        opts.setDocumentSelector(Stream.concat(opts.getDocumentSelector().stream(), additionalSelectors).distinct().collect(Collectors.toList()));
     }
 
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -309,6 +309,7 @@ public class CapabilityRegistration {
 
     private void setDocumentSelector(TextDocumentRegistrationOptions opts, Collection<ICapabilityParams> params) {
         // If the document selector is set already by the capability implementation, we do not touch it.
+        // This allows specific capabilities to add specific selectors if needed.
         if (opts.getDocumentSelector() == null || opts.getDocumentSelector().isEmpty()) {
             // extension filters
             var filters = params.stream()

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -65,8 +65,6 @@ public class CapabilityRegistration {
 
     private static final Logger logger = LogManager.getLogger(CapabilityRegistration.class);
 
-    private static final DocumentFilter UNTITLED_FILES = new DocumentFilter(null, "untitled", null);
-
     private final LanguageClient client;
     private final Executor exec;
     private final CompletableFuture<Void> noop;
@@ -311,17 +309,27 @@ public class CapabilityRegistration {
     private void setDocumentSelector(TextDocumentRegistrationOptions opts, Collection<ICapabilityParams> params) {
         // If the document selector is set already by the capability implementation, we do not touch it.
         if (opts.getDocumentSelector() == null || opts.getDocumentSelector().isEmpty()) {
-            opts.setDocumentSelector(params.stream()
+            // extension filters
+            var filters = params.stream()
                 .flatMap(c -> c.fileExtensions().stream())
                 .distinct()
                 .map(ext -> {
                     var filter = new DocumentFilter();
                     filter.setPattern(String.format("**/*.%s", ext));
                     return filter;
+                }).collect(Collectors.toList());
+
+            // scheme filters
+            filters.addAll(params.stream()
+                .flatMap(c -> c.extensionLessSchemes().stream())
+                .distinct()
+                .map(scheme -> {
+                    var filter = new DocumentFilter();
+                    filter.setScheme(scheme);
+                    return filter;
                 }).collect(Collectors.toList()));
 
-            // Always support untitled files, since those can belong to any language
-            opts.getDocumentSelector().add(UNTITLED_FILES);
+            opts.setDocumentSelector(filters);
         }
     }
 

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistration.java
@@ -54,6 +54,7 @@ import org.eclipse.lsp4j.TextDocumentRegistrationOptions;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.rascalmpl.vscode.lsp.util.concurrent.CompletableFutureUtils;
 
@@ -313,21 +314,15 @@ public class CapabilityRegistration {
             var filters = params.stream()
                 .flatMap(c -> c.fileExtensions().stream())
                 .distinct()
-                .map(ext -> {
-                    var filter = new DocumentFilter();
-                    filter.setPattern(String.format("**/*.%s", ext));
-                    return filter;
-                }).collect(Collectors.toList());
+                .map(ext -> new DocumentFilter(null, null, Either.forLeft(String.format("**/*.%s", ext))))
+                .collect(Collectors.toList());
 
             // scheme filters
             filters.addAll(params.stream()
                 .flatMap(c -> c.extensionLessSchemes().stream())
                 .distinct()
-                .map(scheme -> {
-                    var filter = new DocumentFilter();
-                    filter.setScheme(scheme);
-                    return filter;
-                }).collect(Collectors.toList()));
+                .map(scheme -> new DocumentFilter(null, scheme, null))
+                .collect(Collectors.toList()));
 
             opts.setDocumentSelector(filters);
         }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/ICapabilityParams.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/ICapabilityParams.java
@@ -35,4 +35,5 @@ import org.rascalmpl.vscode.lsp.parametric.ILanguageContributions;
 public interface ICapabilityParams {
     ILanguageContributions contributions();
     Set<String> fileExtensions();
+    Set<String> extensionLessSchemes();
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/SemanticTokensCapability.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/SemanticTokensCapability.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018-2025, NWO-I CWI and Swat.engineering
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.rascalmpl.vscode.lsp.parametric.capabilities;
+
+import java.util.concurrent.CompletableFuture;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.SemanticTokensCapabilities;
+import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.rascalmpl.vscode.lsp.rascal.conversion.SemanticTokenizer;
+import org.rascalmpl.vscode.lsp.util.Nullables;
+
+public class SemanticTokensCapability extends AbstractDynamicCapability<SemanticTokensWithRegistrationOptions> {
+
+    public SemanticTokensCapability() {
+        super("textDocument/semanticTokens");
+    }
+
+    @Override
+    protected CompletableFuture<@Nullable SemanticTokensWithRegistrationOptions> options(ICapabilityParams language) {
+        return CompletableFuture.completedFuture(SemanticTokenizer.options());
+    }
+
+    @Override
+    protected CompletableFuture<Boolean> isProvidedBy(ICapabilityParams params) {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    protected SemanticTokensWithRegistrationOptions mergeOptions(SemanticTokensWithRegistrationOptions o1,
+            SemanticTokensWithRegistrationOptions o2) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'mergeOptions'");
+    }
+
+    @Override
+    protected boolean isDynamicallySupportedBy(ClientCapabilities clientCapabilities) {
+        return Nullables.has(clientCapabilities.getTextDocument(), TextDocumentClientCapabilities::getSemanticTokens, SemanticTokensCapabilities::getDynamicRegistration);
+    }
+
+    @Override
+    protected void registerStatically(ServerCapabilities capabilities) {
+        capabilities.setSemanticTokensProvider(SemanticTokenizer.options());
+    }
+
+}
+
+

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/SemanticTokensCapability.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/parametric/capabilities/SemanticTokensCapability.java
@@ -44,6 +44,7 @@ public class SemanticTokensCapability extends AbstractDynamicCapability<Semantic
 
     @Override
     protected CompletableFuture<@Nullable SemanticTokensWithRegistrationOptions> options(ICapabilityParams language) {
+        // Note: `mergeOptions` is implemented based on the assumptions that we return a constant here.
         return CompletableFuture.completedFuture(SemanticTokenizer.options());
     }
 
@@ -53,10 +54,9 @@ public class SemanticTokensCapability extends AbstractDynamicCapability<Semantic
     }
 
     @Override
-    protected SemanticTokensWithRegistrationOptions mergeOptions(SemanticTokensWithRegistrationOptions o1,
-            SemanticTokensWithRegistrationOptions o2) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'mergeOptions'");
+    protected SemanticTokensWithRegistrationOptions mergeOptions(SemanticTokensWithRegistrationOptions o1, SemanticTokensWithRegistrationOptions o2) {
+        // Since `SemanticTokenCapability::options` always returns this, we don't need to do a smart merge here.
+        return SemanticTokenizer.options();
     }
 
     @Override

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -189,7 +189,7 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         result.setTextDocumentSync(TextDocumentSyncKind.Full);
         result.setDocumentSymbolProvider(true);
         result.setHoverProvider(true);
-        result.setSemanticTokensProvider(tokenizer.options());
+        result.setSemanticTokensProvider(SemanticTokenizer.options());
         result.setCodeLensProvider(new CodeLensOptions(false));
         result.setFoldingRangeProvider(true);
         result.setRenameProvider(new RenameOptions(true));

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/SemanticTokenizer.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/conversion/SemanticTokenizer.java
@@ -76,7 +76,7 @@ public class SemanticTokenizer {
         return new SemanticTokens(tokens.getTheList());
     }
 
-    public SemanticTokensWithRegistrationOptions options() {
+    public static SemanticTokensWithRegistrationOptions options() {
         SemanticTokensWithRegistrationOptions result = new SemanticTokensWithRegistrationOptions();
         SemanticTokensLegend legend = new SemanticTokensLegend(TokenTypes.getTokenTypes(), TokenTypes.getTokenModifiers());
 

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistrationTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistrationTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -271,9 +272,8 @@ public class CapabilityRegistrationTest {
     public void registerIdenticalContribution() throws InterruptedException, ExecutionException {
         registerSequentially(List.of(".", "::"), List.of(".", "::"));
 
-        InOrder inOrder = inOrder(client);
-        inOrder.verify(client).registerCapability(registrationCaptor.capture());
-        inOrder.verifyNoMoreInteractions();
+        verify(client).registerCapability(registrationCaptor.capture());
+        verifyNoMoreInteractions(client);
 
         assertSingleRegistration("textDocument/completion", new CompletionRegistrationOptions(List.of(".", "::"), false), registrationCaptor.getAllValues().get(0));
     }

--- a/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistrationTest.java
+++ b/rascal-lsp/src/test/java/org/rascalmpl/vscode/lsp/parametric/capabilities/CapabilityRegistrationTest.java
@@ -193,6 +193,11 @@ public class CapabilityRegistrationTest {
             public Set<String> fileExtensions() {
                 return Set.of(lang.getExtensions());
             }
+
+            @Override
+            public Set<String> extensionLessSchemes() {
+                return Set.of();
+            }
         };
     }
 

--- a/rascal-vscode-extension/license-config.json
+++ b/rascal-vscode-extension/license-config.json
@@ -3,7 +3,7 @@
   "ignoreFile": ".gitignore",
   "ignore": ["**/.DS_Store",".vscode-test","**/*.jar", "**/*.vsix", "**/*.md", ".editorconfig", ".vscodeignore", "**/*.gitignore", "**/*.svg", "webpack.config.js", "test-workspace/**/*", "**/.npmignore", ".node-version"],
   "licenseFormats": {
-      "js|ts": {
+      "js|ts|mjs": {
           "prepend": "/*",
           "append": " */",
           "eachLine": {

--- a/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
+++ b/rascal-vscode-extension/src/lsp/ParameterizedLanguageServer.ts
@@ -102,8 +102,7 @@ export class ParameterizedLanguageServer implements vscode.Disposable {
             for (const doc of vscode.workspace.textDocuments) {
                 const ext = path.extname(doc.uri.path);
                 if (ext !== "" && lang.extensions.includes(ext.substring(1))) {
-                    // (Re)set the language ID to re-trigger contribution requests
-                    await vscode.languages.setTextDocumentLanguage(doc, "plaintext");
+                    // Associate open editors with the given extensions with this language server
                     await vscode.languages.setTextDocumentLanguage(doc, this.languageId);
                 }
             }

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -49,6 +49,14 @@ parameterizedDescribe(function (errorRecovery: boolean) {
 
     printRascalOutputOnFailure('Language Parametric Rascal');
 
+    async function unloadPico(repl: RascalREPL) {
+        await repl.execute("import util::LanguageServer;");
+        await repl.execute('unregisterLanguage("Pico", {"pico", "pico-new"});');
+
+        // Since we cannot know when exactly unregistration is done, it is followed by a suitably long sleep.
+        await sleep(Delays.normal);
+    }
+
     async function loadPico() {
         const repl = new RascalREPL(bench, driver);
         await repl.start();
@@ -59,11 +67,8 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         // en/disabledness affects which contributors to use). Until issue #630
         // is fixed (race between `unregister` and `register`), the
         // unregistration can't reliably be done as part of `main` (tried in
-        // commit `a955a05`). Instead, it's done here and followed by a suitably
-        // long sleep.
-        await repl.execute("import util::LanguageServer;");
-        await repl.execute('unregisterLanguage("Pico", {"pico", "pico-new"});');
-        await sleep(Delays.normal);
+        // commit `a955a05`). Instead, it's done here.
+        await unloadPico(repl);
 
         const replExecuteMain = repl.execute(`register(errorRecovery=${errorRecovery});`); // we don't wait yet, because we might miss pico loading window
         const ide = new IDEOperations(browser);
@@ -73,6 +78,14 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         await driver.wait(async () => !(await isPicoLoading()), Delays.extremelySlow, "Pico DSL should be finished starting", 100);
         await replExecuteMain;
         await repl.terminate();
+    }
+
+    async function setParametricLanguage(editor: TextEditor) {
+        await (await editor.getTab()).select();
+        await bench.executeCommand("workbench.action.editor.changeLanguageMode");
+        const inputBox = new InputBox();
+        await inputBox.setText("parametric-rascalmpl");
+        await inputBox.confirm();
     }
 
     before(async () => {
@@ -140,11 +153,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         const editor = await ide.newUntitledFile(bench, driver, 1);
         expect(editor).to.not.be.undefined;
 
-        await bench.executeCommand("workbench.action.editor.changeLanguageMode");
-
-        const inputBox = new InputBox();
-        await inputBox.setText("parametric-rascalmpl");
-        await inputBox.confirm();
+        await setParametricLanguage(editor);
 
         await editor.setText(`begin
   declare
@@ -440,4 +449,18 @@ end
         }, Delays.normal, "Static content should be shown");
     });
 
+    it("updates open editors on registration", async function() {
+        if (errorRecovery) { this.skip(); }
+
+        const repl = new RascalREPL(bench, driver);
+        await repl.start();
+        await unloadPico(repl);
+        await repl.terminate();
+
+        const editor = await ide.openModule(TestWorkspace.picoFile);
+        await setParametricLanguage(editor);
+
+        await loadPico();
+        await ide.hasSyntaxHighlighting(editor, Delays.slow);
+    });
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -31,7 +31,7 @@ import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutpu
 import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import { Suite } from 'mocha';
-import * as path from 'path';
+import * as path from 'path/posix';
 
 function parameterizedDescribe(body: (this: Suite, errorRecovery: boolean) => void) {
     describe('DSL', function() { body.apply(this, [false]); });
@@ -274,8 +274,8 @@ end
         await ide.moveFile("testing.pico", "dest", bench);
 
         await driver.wait(async() => {
-            const text = await testFile.getText();
-            return text.indexOf("%% File moved from") !== -1;
+            const text = await ignoreFails(testFile.getText());
+            return text?.indexOf("%% File moved from") !== -1;
         }, Delays.extremelySlow, "Pico file should contain evidence of move", Delays.normal);
 
         await fs.rm(newDir, {recursive: true, force: true});

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -57,7 +57,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         await sleep(Delays.normal);
     }
 
-    async function loadPico() {
+    async function loadPico(unregisterFirst = true) {
         const repl = new RascalREPL(bench, driver);
         await repl.start();
         await repl.execute("import testing::lang::pico::LanguageServer;", false, Delays.extremelySlow);
@@ -68,7 +68,9 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         // is fixed (race between `unregister` and `register`), the
         // unregistration can't reliably be done as part of `main` (tried in
         // commit `a955a05`). Instead, it's done here.
-        await unloadPico(repl);
+        if (unregisterFirst) {
+            await unloadPico(repl);
+        }
 
         const replExecuteMain = repl.execute(`register(errorRecovery=${errorRecovery});`); // we don't wait yet, because we might miss pico loading window
         const ide = new IDEOperations(browser);
@@ -460,7 +462,9 @@ end
         const editor = await ide.openModule(TestWorkspace.picoFile);
         await setParametricLanguage(editor);
 
-        await loadPico();
+        await loadPico(false);
+
+        // Dynamically registered capability
         await ide.hasSyntaxHighlighting(editor, Delays.slow);
     });
 });

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -338,7 +338,7 @@ export class IDEOperations {
                 return result;
             }
             return undefined;
-        }, Delays.normal, "Could not open file") as Promise<TextEditor>;
+        }, Delays.normal, `Could not open file: ${file}`) as Promise<TextEditor>;
     }
 
     async appendSpace(editor: TextEditor, line = 1) {

--- a/runUItests.sh
+++ b/runUItests.sh
@@ -17,7 +17,7 @@ rm -rf $UITESTS || true
 
 # compiling the TS code as well as the test TS code at least once is required before execution
 # this assumes you have run `npm ci` at least once since a large update
-npm run compile-tests
+npm run compile:tests
 
 # test what was compiled
 VSCODE_VERSION=$(grep '"vscode":' package.json | awk -F^ '{ print $2 }' | awk -F\" '{ print $1 }')


### PR DESCRIPTION
1. Set document selectors for capabilities, such that capabilities can only be triggered on documents that support them. Especially useful when registering multiple languages.
2. Dynamically register semantic highlighting capability (to test the former change, and make a start with registering all capabilities dynamically).
3. Instead of toggling the language for open editors, request a refresh of the open editors via LSP. This prevents races where requests can come in while the file is 'closed'.

This PR is a preparation to easily enable #1117.