### PR TITLE
Debug icons in Terminal view

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -61,6 +61,11 @@
         "icon": "$(debug)"
       },
       {
+        "command": "rascalmpl.stopDebuggerForRepl",
+        "title": "Stop Rascal debugger for REPL",
+        "icon": "$(debug-disconnect-compact)"
+      },
+      {
         "command": "rascalmpl.copySourceLocation",
         "title": "Copy Path as Rascal Location",
         "icon": "$(copy)"
@@ -82,6 +87,23 @@
           "command": "rascalmpl.startDebuggerForRepl",
           "when": "view == rascalmpl-debugger-view && viewItem == 'canStartDebugging'",
           "group": "inline"
+        },
+        {
+          "command": "rascalmpl.stopDebuggerForRepl",
+          "when": "view == rascalmpl-debugger-view && viewItem == 'canStopDebugging'",
+          "group": "inline"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "rascalmpl.startDebuggerForRepl",
+          "when": "view == terminal && rascalmpl.isRascalTerminalActive == true && rascalmpl.activeRascalTerminalIsDebugging == false",
+          "group": "navigation@1"
+        },
+        {
+          "command": "rascalmpl.stopDebuggerForRepl",
+          "when": "view == terminal && rascalmpl.isRascalTerminalActive == true && rascalmpl.activeRascalTerminalIsDebugging == true",
+          "group": "navigation@1"
         }
       ],
       "explorer/context": [

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -72,7 +72,7 @@ export class RascalDebugClient {
             await this.updateTerminalViewButton();
         });
 
-        window.onDidChangeActiveTerminal(async _ => this.updateTerminalViewButton());
+        window.onDidChangeActiveTerminal(_ => this.updateTerminalViewButton());
     }
 
     async updateTerminalViewButton() {

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -33,17 +33,17 @@ import { RascalDebugConfigurationProvider } from "./RascalDebugConfigurationProv
  * Debug Client that stores running debug sessions and available REPL ports for debug sessions.
  */
 export class RascalDebugClient {
-    rascalDescriptorFactory: RascalDebugAdapterDescriptorFactory;
-    debugSocketServersPorts: Map<number, number>; // Terminal processID -> socket server port for debug
-    runningDebugSessions: Map<number, DebugSession>; // Debug server port -> DebugSession
+    readonly rascalDescriptorFactory: RascalDebugAdapterDescriptorFactory;
+    readonly debugSocketServersPorts: Map<number, number>; // Terminal processID -> socket server port for debug
+    readonly runningDebugSessions: Map<number, DebugSession>; // Debug server port -> DebugSession
 
     private portEventEmitter = new EventEmitter<{processId: number, serverPort: number}>();
     readonly portRegistrationEvent = this.portEventEmitter.event;
 
     constructor(){
         this.rascalDescriptorFactory = new RascalDebugAdapterDescriptorFactory();
-        this.debugSocketServersPorts = new Map<number, number>();
-        this.runningDebugSessions = new Map<number, DebugSession>();
+        this.debugSocketServersPorts = new Map();
+        this.runningDebugSessions = new Map();
 
         debug.registerDebugConfigurationProvider("rascalmpl", new RascalDebugConfigurationProvider(this));
         debug.registerDebugAdapterDescriptorFactory("rascalmpl", this.rascalDescriptorFactory);
@@ -72,9 +72,7 @@ export class RascalDebugClient {
             await this.updateTerminalViewButton();
         });
 
-        window.onDidChangeActiveTerminal(async _ => {
-            await this.updateTerminalViewButton();
-        });
+        window.onDidChangeActiveTerminal(async _ => this.updateTerminalViewButton());
     }
 
     async updateTerminalViewButton() {
@@ -95,6 +93,13 @@ export class RascalDebugClient {
     async startDebuggingSession(serverPort: number){
         const conf: DebugConfiguration = {type: "rascalmpl", name: "Rascal debugger", request: "attach", serverPort: serverPort};
         await debug.startDebugging(undefined, conf);
+    }
+
+    async startDebuggingSessionFromProcessId(processId: number) {
+        const serverPort = this.debugSocketServersPorts.get(processId);
+        if (serverPort) {
+            await this.startDebuggingSession(serverPort);
+        }
     }
 
     async stopDebuggingSession(processId: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -35,7 +35,7 @@ import { RascalDebugConfigurationProvider } from "./RascalDebugConfigurationProv
 export class RascalDebugClient {
     rascalDescriptorFactory: RascalDebugAdapterDescriptorFactory;
     debugSocketServersPorts: Map<number, number>; // Terminal processID -> socket server port for debug
-    runningDebugSessionsPorts: Set<number>; // Stores all running debug session server ports
+    runningDebugSessions: Map<number, DebugSession>; // Debug server port -> DebugSession
 
     private portEventEmitter = new EventEmitter<{processId: number, serverPort: number}>();
     readonly portRegistrationEvent = this.portEventEmitter.event;
@@ -43,7 +43,7 @@ export class RascalDebugClient {
     constructor(){
         this.rascalDescriptorFactory = new RascalDebugAdapterDescriptorFactory();
         this.debugSocketServersPorts = new Map<number, number>();
-        this.runningDebugSessionsPorts = new Set<number>();
+        this.runningDebugSessions = new Map<number, DebugSession>();
 
         debug.registerDebugConfigurationProvider("rascalmpl", new RascalDebugConfigurationProvider(this));
         debug.registerDebugAdapterDescriptorFactory("rascalmpl", this.rascalDescriptorFactory);
@@ -59,7 +59,7 @@ export class RascalDebugClient {
         debug.onDidStartDebugSession(async (debugsession: DebugSession) => {
             const port = getDebugPort(debugsession);
             if(port !== undefined){
-                this.runningDebugSessionsPorts.add(port);
+                this.runningDebugSessions.set(port, debugsession);
             }
             await this.updateTerminalViewButton();
         });
@@ -67,7 +67,7 @@ export class RascalDebugClient {
         debug.onDidTerminateDebugSession(async (debugsession: DebugSession) => {
             const port = getDebugPort(debugsession);
             if(port !== undefined){
-                this.runningDebugSessionsPorts.delete(port);
+                this.runningDebugSessions.delete(port);
             }
             await this.updateTerminalViewButton();
         });
@@ -85,10 +85,7 @@ export class RascalDebugClient {
             isRascalTerminal = activeTerminal.name.includes("Rascal terminal");
             const processId = await activeTerminal.processId;
             if (isRascalTerminal && processId) {
-                const serverPort = this.debugSocketServersPorts.get(processId);
-                if (serverPort) {
-                    isRascalTerminalDebugging = this.runningDebugSessionsPorts.has(serverPort);
-                }
+                isRascalTerminalDebugging = this.isConnectedToDebugServer(processId);
             }
         }
         await commands.executeCommand('setContext', 'rascalmpl.isRascalTerminalActive', isRascalTerminal);
@@ -100,6 +97,10 @@ export class RascalDebugClient {
         await debug.startDebugging(undefined, conf);
     }
 
+    async stopDebuggingSession(processId: number){
+        await debug.stopDebugging(this.runningDebugSessions.get(processId));
+    }
+
     registerDebugServerPort(processID: number, serverPort: number){
         this.debugSocketServersPorts.set(processID, serverPort);
         this.portEventEmitter.fire({"processId": processID, "serverPort": serverPort});
@@ -109,8 +110,9 @@ export class RascalDebugClient {
         return this.debugSocketServersPorts.get(processId);
     }
 
-    isConnectedToDebugServer(serverPort: number){
-        return this.runningDebugSessionsPorts.has(serverPort);
+    isConnectedToDebugServer(processId: number): boolean{
+        const serverPort = this.debugSocketServersPorts.get(processId);
+        return serverPort !== undefined && this.runningDebugSessions.has(serverPort);
     }
 
 }

--- a/rascal-vscode-extension/src/dap/RascalDebugClient.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugClient.ts
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-import { debug, DebugConfiguration, DebugSession, Terminal, window, EventEmitter } from "vscode";
+import { debug, DebugConfiguration, DebugSession, Terminal, window, EventEmitter, commands } from "vscode";
 import { RascalDebugAdapterDescriptorFactory } from "./RascalDebugAdapterDescriptorFactory";
 import { RascalDebugConfigurationProvider } from "./RascalDebugConfigurationProvider";
 
@@ -53,6 +53,7 @@ export class RascalDebugClient {
             if(processId !== undefined && this.debugSocketServersPorts.has(processId)){
                 this.debugSocketServersPorts.delete(processId);
             }
+            await this.updateTerminalViewButton();
         });
 
         debug.onDidStartDebugSession(async (debugsession: DebugSession) => {
@@ -60,6 +61,7 @@ export class RascalDebugClient {
             if(port !== undefined){
                 this.runningDebugSessionsPorts.add(port);
             }
+            await this.updateTerminalViewButton();
         });
 
         debug.onDidTerminateDebugSession(async (debugsession: DebugSession) => {
@@ -67,8 +69,30 @@ export class RascalDebugClient {
             if(port !== undefined){
                 this.runningDebugSessionsPorts.delete(port);
             }
+            await this.updateTerminalViewButton();
         });
 
+        window.onDidChangeActiveTerminal(async _ => {
+            await this.updateTerminalViewButton();
+        });
+    }
+
+    async updateTerminalViewButton() {
+        let isRascalTerminal = false;
+        let isRascalTerminalDebugging = false;
+        const activeTerminal = window.activeTerminal;
+        if (activeTerminal) {
+            isRascalTerminal = activeTerminal.name.includes("Rascal terminal");
+            const processId = await activeTerminal.processId;
+            if (isRascalTerminal && processId) {
+                const serverPort = this.debugSocketServersPorts.get(processId);
+                if (serverPort) {
+                    isRascalTerminalDebugging = this.runningDebugSessionsPorts.has(serverPort);
+                }
+            }
+        }
+        await commands.executeCommand('setContext', 'rascalmpl.isRascalTerminalActive', isRascalTerminal);
+        await commands.executeCommand('setContext', 'rascalmpl.activeRascalTerminalIsDebugging', isRascalTerminalDebugging);
     }
 
     async startDebuggingSession(serverPort: number){

--- a/rascal-vscode-extension/src/dap/RascalDebugConfigurationProvider.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugConfigurationProvider.ts
@@ -64,10 +64,10 @@ export class RascalDebugConfigurationProvider implements DebugConfigurationProvi
             }
             const port = this.debugClient.getServerPort(terminalProcessID);
             if(port === undefined) {
-                throw Error("Active terminal has not a debug server port registered !");
+                throw Error("Active terminal does not have a debug server port registered!");
             } else {
                 if(this.debugClient.isConnectedToDebugServer(port)){
-                    throw Error("This REPL has already a running debug session !");
+                    throw Error("This REPL already has a running debug session!");
                 } else {
                     debugConfiguration['serverPort'] = port;
                 }

--- a/rascal-vscode-extension/src/dap/RascalDebugConfigurationProvider.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugConfigurationProvider.ts
@@ -64,10 +64,10 @@ export class RascalDebugConfigurationProvider implements DebugConfigurationProvi
             }
             const port = this.debugClient.getServerPort(terminalProcessID);
             if(port === undefined) {
-                throw Error("Active terminal does not have a debug server port registered!");
+                throw Error("This terminal is not fully initialized yet. Please try again shortly.");
             } else {
                 if(this.debugClient.isConnectedToDebugServer(port)){
-                    throw Error("This REPL already has a running debug session!");
+                    throw Error("Debugging is already enabled for this terminal.");
                 } else {
                     debugConfiguration['serverPort'] = port;
                 }

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -96,21 +96,19 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         const activeTerminalProcessId = await vscode.window.activeTerminal?.processId;
         for (const terminal of vscode.window.terminals) {
             const processId = await terminal.processId;
-            if (processId === undefined) {
+            if (processId === undefined || !terminal.name.includes("Rascal terminal")) {
                 continue;
             }
-            if (terminal.name.includes("Rascal terminal")) {
-                const label = this.makeLabel(terminal.name, processId === activeTerminalProcessId);
-                const serverPort = this.rascalDebugClient.getServerPort(processId);
-                const isDebugging = this.rascalDebugClient.isConnectedToDebugServer(processId);
-                const replNode = new RascalReplNode(label, processId, serverPort, isDebugging);
-                if (serverPort !== undefined && !isDebugging) {
-                    replNode.contextValue = "canStartDebugging";
-                } else if (serverPort !== undefined && isDebugging) {
-                    replNode.contextValue = "canStopDebugging";
-                }
-                result.push(replNode);
+            const label = this.makeLabel(terminal.name, processId === activeTerminalProcessId);
+            const serverPort = this.rascalDebugClient.getServerPort(processId);
+            const isDebugging = this.rascalDebugClient.isConnectedToDebugServer(processId);
+            const replNode = new RascalReplNode(label, processId, serverPort, isDebugging);
+            if (serverPort !== undefined && !isDebugging) {
+                replNode.contextValue = "canStartDebugging";
+            } else if (serverPort !== undefined && isDebugging) {
+                replNode.contextValue = "canStopDebugging";
             }
+            result.push(replNode);
         }
         return result;
     }

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -44,35 +44,23 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 
         this.rascalDebugClient.portRegistrationEvent(fireEmitter, this, context.subscriptions);
 
+        this.registerDebugCommand("rascalmpl.startDebuggerForRepl", n => this.rascalDebugClient.startDebuggingSessionFromProcessId(n));
+        this.registerDebugCommand("rascalmpl.stopDebuggerForRepl", n => this.rascalDebugClient.stopDebuggingSession(n));
+    }
+
+    registerDebugCommand(command: string, debugCommand: (n: number) => Promise<void>) {
         this.context.subscriptions.push(
-            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", async (element: RascalReplNode | undefined) => {
-                if (element instanceof RascalReplNode) {
-                    // Clicked button of an entry in the "Debug Rascal Terminal" view
-                    if (element.serverPort) {
-                        await this.rascalDebugClient.startDebuggingSession(element.serverPort);
-                    }
-                } else {
-                    // Clicked button in the Terminal view
-                    const processId = await vscode.window.activeTerminal?.processId;
-                    if (processId) {
-                        const serverPort = this.rascalDebugClient.getServerPort(processId);
-                        await this.rascalDebugClient.startDebuggingSession(serverPort!);
-                    }
-                }
-            }, this)
-        );
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand("rascalmpl.stopDebuggerForRepl", async (element: RascalReplNode | undefined) => {
+            vscode.commands.registerCommand(command, async (element: RascalReplNode | undefined) => {
                 if (element instanceof RascalReplNode) {
                     // Clicked button of an entry in the "Debug Rascal Terminal" view
                     if (element.processId) {
-                        await this.rascalDebugClient.stopDebuggingSession(element.processId);
+                        await debugCommand(element.processId);
                     }
                 } else {
                     // Clicked button in the Terminal view
                     const processId = await vscode.window.activeTerminal?.processId;
                     if (processId) {
-                        await this.rascalDebugClient.stopDebuggingSession(processId);
+                        await debugCommand(processId);
                     }
                 }
             }, this)

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -45,9 +45,18 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         this.rascalDebugClient.portRegistrationEvent(fireEmitter, this, context.subscriptions);
 
         this.context.subscriptions.push(
-            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (replNode: RascalReplNode) => {
-                if (replNode.serverPort !== undefined) {
-                    void this.rascalDebugClient.startDebuggingSession(replNode.serverPort);
+            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (element: RascalReplNode | undefined) => {
+                if (element instanceof RascalReplNode) {
+                    // Clicked button of an entry in the "Debug Rascal Terminal" view
+                    if (element.serverPort) {
+                        void this.rascalDebugClient.startDebuggingSession(element.serverPort);
+                    }
+                } else {
+                    // Clicked button in the Terminal view
+                    void vscode.window.activeTerminal?.processId.then(id => {
+                        const serverPort = this.rascalDebugClient.getServerPort(<number> id);
+                        void this.rascalDebugClient.startDebuggingSession(serverPort!);
+                    });
                 }
             }, this)
         );

--- a/rascal-vscode-extension/src/dap/RascalDebugView.ts
+++ b/rascal-vscode-extension/src/dap/RascalDebugView.ts
@@ -45,18 +45,35 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
         this.rascalDebugClient.portRegistrationEvent(fireEmitter, this, context.subscriptions);
 
         this.context.subscriptions.push(
-            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", (element: RascalReplNode | undefined) => {
+            vscode.commands.registerCommand("rascalmpl.startDebuggerForRepl", async (element: RascalReplNode | undefined) => {
                 if (element instanceof RascalReplNode) {
                     // Clicked button of an entry in the "Debug Rascal Terminal" view
                     if (element.serverPort) {
-                        void this.rascalDebugClient.startDebuggingSession(element.serverPort);
+                        await this.rascalDebugClient.startDebuggingSession(element.serverPort);
                     }
                 } else {
                     // Clicked button in the Terminal view
-                    void vscode.window.activeTerminal?.processId.then(id => {
-                        const serverPort = this.rascalDebugClient.getServerPort(<number> id);
-                        void this.rascalDebugClient.startDebuggingSession(serverPort!);
-                    });
+                    const processId = await vscode.window.activeTerminal?.processId;
+                    if (processId) {
+                        const serverPort = this.rascalDebugClient.getServerPort(processId);
+                        await this.rascalDebugClient.startDebuggingSession(serverPort!);
+                    }
+                }
+            }, this)
+        );
+        this.context.subscriptions.push(
+            vscode.commands.registerCommand("rascalmpl.stopDebuggerForRepl", async (element: RascalReplNode | undefined) => {
+                if (element instanceof RascalReplNode) {
+                    // Clicked button of an entry in the "Debug Rascal Terminal" view
+                    if (element.processId) {
+                        await this.rascalDebugClient.stopDebuggingSession(element.processId);
+                    }
+                } else {
+                    // Clicked button in the Terminal view
+                    const processId = await vscode.window.activeTerminal?.processId;
+                    if (processId) {
+                        await this.rascalDebugClient.stopDebuggingSession(processId);
+                    }
                 }
             }, this)
         );
@@ -97,10 +114,12 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
             if (terminal.name.includes("Rascal terminal")) {
                 const label = this.makeLabel(terminal.name, processId === activeTerminalProcessId);
                 const serverPort = this.rascalDebugClient.getServerPort(processId);
-                const isDebugging = serverPort !== undefined && this.rascalDebugClient.isConnectedToDebugServer(serverPort);
-                const replNode = new RascalReplNode(label, serverPort, isDebugging);
+                const isDebugging = this.rascalDebugClient.isConnectedToDebugServer(processId);
+                const replNode = new RascalReplNode(label, processId, serverPort, isDebugging);
                 if (serverPort !== undefined && !isDebugging) {
                     replNode.contextValue = "canStartDebugging";
+                } else if (serverPort !== undefined && isDebugging) {
+                    replNode.contextValue = "canStopDebugging";
                 }
                 result.push(replNode);
             }
@@ -111,7 +130,7 @@ export class RascalDebugViewProvider implements vscode.TreeDataProvider<RascalRe
 }
 
 export class RascalReplNode extends vscode.TreeItem {
-    constructor(label : string | vscode.TreeItemLabel, readonly serverPort : number | undefined, isDebugging : boolean) {
+    constructor(label : string | vscode.TreeItemLabel, readonly processId : number | undefined, readonly serverPort : number | undefined, isDebugging : boolean) {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.iconPath = new vscode.ThemeIcon(isDebugging ? "debug" : "terminal");
     }


### PR DESCRIPTION
This PR adds:
* A button to the Terminal view to start a debug session when a Rascal REPL is the active terminal
* A button to the Terminal view to stop a running debug session when a Rascal REPL is the active terminal
* A button to the Debug Rascal Terminal view to stop a running debug session for any active Rascal terminal (a button to start a debug session was already present)

<img width="258" height="144" alt="image" src="https://github.com/user-attachments/assets/3bd6fb93-a788-449a-b391-ee873a359a80" />
<img width="242" height="100" alt="image" src="https://github.com/user-attachments/assets/4f95f43a-a5af-43f9-9de3-9dd115c3be29" />
<img width="582" height="72" alt="image" src="https://github.com/user-attachments/assets/7f02a7ce-7166-4c1f-96af-f6407dc84016" />


Closes #568 