### PR TITLE
LSP Open File resolvers needs to be writeable (but throw errors on write)

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentState.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.library.util.ParseErrorRecovery;
+import org.rascalmpl.uri.FileAttributes;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.vscode.lsp.parametric.NoContributions.NoContributionException;
@@ -64,6 +65,7 @@ public class TextDocumentState {
     private final BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser;
     private final ISourceLocation location;
     private final ExecutorService exec;
+    private final FileAttributes attributesOnDisk;
 
     private final AtomicReference<Versioned<Update>> current;
     private final AtomicReference<@Nullable Versioned<ITree>> lastWithoutErrors;
@@ -73,10 +75,11 @@ public class TextDocumentState {
             BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parser,
             ISourceLocation location,
             int initialVersion, String initialContent, long initialTimestamp,
-            ExecutorService exec) {
+            ExecutorService exec, FileAttributes attributesOnDisk) {
 
         this.parser = parser;
         this.location = location;
+        this.attributesOnDisk = attributesOnDisk;
         this.lastWithoutErrors = new AtomicReference<>();
         this.last = new AtomicReference<>();
         this.exec = exec;
@@ -87,6 +90,13 @@ public class TextDocumentState {
 
     public ISourceLocation getLocation() {
         return location;
+    }
+
+    /**
+     * The file attributes (aka stat) of the location on disk, before it was opened by VS Code
+     */
+    public FileAttributes getAttributesOnDisk() {
+        return attributesOnDisk;
     }
 
     public CompletableFuture<Versioned<List<Diagnostics.Template>>> update(int version, String content, long timestamp) {
@@ -266,6 +276,6 @@ public class TextDocumentState {
 
     public TextDocumentState changeParser(BiFunction<ISourceLocation, String, CompletableFuture<ITree>> parsing) {
         var c = getCurrentContent();
-        return new TextDocumentState(parsing, this.location, c.version(), c.get(), getLastModified(), exec);
+        return new TextDocumentState(parsing, this.location, c.version(), c.get(), getLastModified(), exec, getAttributesOnDisk());
     }
 }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -49,6 +49,7 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.rascalmpl.uri.FileAttributes;
 import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.util.locations.ColumnMaps;
 import org.rascalmpl.util.locations.LineColumnOffsetMap;
@@ -58,7 +59,6 @@ import org.rascalmpl.vscode.lsp.rascal.conversion.Diagnostics;
 import org.rascalmpl.vscode.lsp.util.Lists;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 import org.rascalmpl.vscode.lsp.util.locations.Locations;
-
 import io.usethesource.vallang.ISourceLocation;
 
 /**
@@ -153,15 +153,25 @@ public abstract class TextDocumentStateManager implements ITextDocumentStateMana
         }
     }
 
+    private FileAttributes safeStat(ISourceLocation loc, long timestamp) {
+        try {
+            return URIResolverRegistry.getInstance().stat(loc);
+        } catch (IOException e) {
+            // generate a fallback
+            // for example for untitled files, text document content provided,
+            // or other files that are not accessible to our VFS
+            return new FileAttributes(
+                true, true,
+                timestamp, timestamp,
+                true, false,
+                0
+            );
+        }
+
+    }
+
     protected TextDocumentState openFile(TextDocumentItem doc, Function<ISourceLocation, BiFunction<ISourceLocation, String, CompletableFuture<ITree>>> parserGetter, long timestamp, ExecutorService exec)  {
-        return files.computeIfAbsent(Locations.toLoc(doc),
-            l -> {
-                try {
-                    return new TextDocumentState(parserGetter.apply(l), l, doc.getVersion(), doc.getText(), timestamp, exec, URIResolverRegistry.getInstance().stat(l));
-                } catch (IOException e) {
-                    throw new RuntimeException("Could not calculate stat of opened file", e);
-                }
-            });
+        return files.computeIfAbsent(Locations.toLoc(doc), l -> new TextDocumentState(parserGetter.apply(l), l, doc.getVersion(), doc.getText(), timestamp, exec, safeStat(l, timestamp)));
     }
 
     private void invalidateColumnMaps(ISourceLocation loc) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/TextDocumentStateManager.java
@@ -155,7 +155,13 @@ public abstract class TextDocumentStateManager implements ITextDocumentStateMana
 
     protected TextDocumentState openFile(TextDocumentItem doc, Function<ISourceLocation, BiFunction<ISourceLocation, String, CompletableFuture<ITree>>> parserGetter, long timestamp, ExecutorService exec)  {
         return files.computeIfAbsent(Locations.toLoc(doc),
-            l -> new TextDocumentState(parserGetter.apply(l), l, doc.getVersion(), doc.getText(), timestamp, exec));
+            l -> {
+                try {
+                    return new TextDocumentState(parserGetter.apply(l), l, doc.getVersion(), doc.getText(), timestamp, exec, URIResolverRegistry.getInstance().stat(l));
+                } catch (IOException e) {
+                    throw new RuntimeException("Could not calculate stat of opened file", e);
+                }
+            });
     }
 
     private void invalidateColumnMaps(ISourceLocation loc) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileResolver.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileResolver.java
@@ -133,7 +133,7 @@ public class LSPOpenFileResolver implements ISourceLocationInputOutput {
         var current = state.getCurrentContent();
         return new FileAttributes(
             true, true,
-            current.getTimestamp(), onDiskStat.created(), //We fix the creation timestamp to be equal to the last modified time
+            onDiskStat.created(), current.getTimestamp(),
             true, onDiskStat.isWritable(),
             size(current)
         );
@@ -150,7 +150,7 @@ public class LSPOpenFileResolver implements ISourceLocationInputOutput {
 
     @Override
     public boolean isWritable(ISourceLocation uri) throws IOException {
-        // this communicates that yes, it's a writeable file system
+        // this communicates that yes, it's a writable file system
         // so if you indeed use `applyFileSystemEdits` it should succeed.
         return getEditorState(uri).getAttributesOnDisk().isWritable();
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileResolver.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileResolver.java
@@ -28,19 +28,18 @@ package org.rascalmpl.vscode.lsp.uri;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
 import org.rascalmpl.uri.FileAttributes;
-import org.rascalmpl.uri.ISourceLocationInput;
-import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.ISourceLocationInputOutput;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
 import org.rascalmpl.vscode.lsp.util.Versioned;
 import io.usethesource.vallang.ISourceLocation;
 
-public class LSPOpenFileResolver implements ISourceLocationInput {
+public class LSPOpenFileResolver implements ISourceLocationInputOutput {
 
     public static final String LSP_OPEN_SCHEME = "lsp";
     private static final String LSP_SCHEME_PREFIX = LSP_OPEN_SCHEME + "+";
@@ -57,6 +56,11 @@ public class LSPOpenFileResolver implements ISourceLocationInput {
     @Override
     public Charset getCharset(ISourceLocation uri) throws IOException {
         return StandardCharsets.UTF_16;
+    }
+
+    @Override
+    public long created(ISourceLocation uri) throws IOException {
+        return getEditorState(uri).getAttributesOnDisk().created();
     }
 
     @Override
@@ -116,7 +120,7 @@ public class LSPOpenFileResolver implements ISourceLocationInput {
 
     @Override
     public boolean isReadable(ISourceLocation uri) throws IOException {
-        return LSPOpenFileRedirector.getInstance().isFileManaged(stripLspPrefix(uri));
+        return exists(uri);
     }
 
     @Override
@@ -124,15 +128,45 @@ public class LSPOpenFileResolver implements ISourceLocationInput {
         if (!exists(uri)) {
             return new FileAttributes(false, false, -1, -1, false, false, 0);
         }
-        var current = getEditorState(uri).getCurrentContent();
-        var modified = current.getTimestamp();
-        var isWritable = URIResolverRegistry.getInstance().isWritable(stripLspPrefix(uri));
+        var state = getEditorState(uri);
+        var onDiskStat = state.getAttributesOnDisk();
+        var current = state.getCurrentContent();
         return new FileAttributes(
             true, true,
-            modified, modified, //We fix the creation timestamp to be equal to the last modified time
-            true, isWritable,
+            current.getTimestamp(), onDiskStat.created(), //We fix the creation timestamp to be equal to the last modified time
+            true, onDiskStat.isWritable(),
             size(current)
         );
     }
 
+    private static IOException buildError(ISourceLocation loc) {
+        return new IOException("lsp+ is not a writable scheme. If you want to write to an file open in the editor use IDEServices::applyFileSystemEdits. Loc: " + loc);
+    }
+
+    @Override
+    public OutputStream getOutputStream(ISourceLocation uri, boolean append) throws IOException {
+        throw buildError(uri);
+    }
+
+    @Override
+    public boolean isWritable(ISourceLocation uri) throws IOException {
+        // this communicates that yes, it's a writeable file system
+        // so if you indeed use `applyFileSystemEdits` it should succeed.
+        return getEditorState(uri).getAttributesOnDisk().isWritable();
+    }
+
+    @Override
+    public void mkDirectory(ISourceLocation uri) throws IOException {
+        throw buildError(uri);
+    }
+
+    @Override
+    public void remove(ISourceLocation uri) throws IOException {
+        throw buildError(uri);
+    }
+
+    @Override
+    public void setLastModified(ISourceLocation uri, long timestamp) throws IOException {
+        throw buildError(uri);
+    }
 }


### PR DESCRIPTION
While implementing a few rascal features (namely #1122 ) we figured out the `lsp+` scheme needed a bit more features to correctly work with.