### PR TITLE
Protect files, but avoid rewriting them when they have not changed

### DIFF
--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { InputBox, MarkerType, SideBarView, TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
-import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, TestWorkspace } from './utils';
+import { Delays, expectCompletions, IDEOperations, ignoreFails, printRascalOutputOnFailure, ProtectedFiles, RascalREPL, TestWorkspace } from './utils';
 
 import { expect } from 'chai';
 import * as fs from 'fs/promises';
@@ -43,7 +43,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
     let driver: WebDriver;
     let bench: Workbench;
     let ide : IDEOperations;
-    let picoFileBackup: Buffer;
+    let protectedFiles : ProtectedFiles;
 
     this.timeout(Delays.extremelySlow * 2);
 
@@ -71,7 +71,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         ide = new IDEOperations(browser);
         await ide.load();
         await loadPico();
-        picoFileBackup = await fs.readFile(TestWorkspace.picoFile);
+        protectedFiles = await ProtectedFiles.protect(TestWorkspace.picoFile);
         ide = new IDEOperations(browser);
         await ide.load();
     });
@@ -87,7 +87,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
             await ide.screenshot(`DSL-${errorRecovery}-`+ this.test?.title);
         }
         await ide.cleanup();
-        await fs.writeFile(TestWorkspace.picoFile, picoFileBackup);
+        await protectedFiles.restore();
     });
 
     it("has highlighting and parse errors", async function () {

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -29,32 +29,33 @@ import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { TextEditor, until, ViewSection, VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
-import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, sleep, TestWorkspace } from './utils';
-
-const protectFiles = [TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile, TestWorkspace.manifest, TestWorkspace.importeeFile, TestWorkspace.importerFile];
+import { Delays, IDEOperations, ignoreFails, printRascalOutputOnFailure, ProtectedFiles, sleep, TestWorkspace } from './utils';
 
 describe('IDE', function () {
     let browser: VSBrowser;
     let driver: WebDriver;
     let bench: Workbench;
     let ide: IDEOperations;
-    const originalFiles = new Map<string, Buffer>();
+    let protectedFiles : ProtectedFiles;
 
     this.timeout(Delays.extremelySlow * 2);
 
     printRascalOutputOnFailure('Rascal MPL');
 
     before(async () => {
+        const files = ProtectedFiles.protect(
+            TestWorkspace.mainFile, TestWorkspace.libFile, TestWorkspace.libCallFile,
+            TestWorkspace.manifest, TestWorkspace.importeeFile, TestWorkspace.importerFile
+        );
         browser = VSBrowser.instance;
         driver = browser.driver;
         bench = new Workbench();
         await browser.waitForWorkbench();
         ide = new IDEOperations(browser);
         await ide.load();
-        // trigger rascal type checker to be sure
-        for (const f of protectFiles) {
-            originalFiles.set(f, await fs.readFile(f));
-        }
+
+        protectedFiles = await files;
+
         await makeSureRascalModulesAreLoaded();
     });
 
@@ -63,9 +64,7 @@ describe('IDE', function () {
             await ide.screenshot("IDE-" + this.test?.title);
         }
         // make sure we always reset, so errors don't propagate (since sometimes an afterEach is not run)
-        for (const [f, b] of originalFiles) {
-            await fs.writeFile(f, b);
-        }
+        await protectedFiles.restore();
     });
 
     afterEach(async function () {
@@ -76,9 +75,7 @@ describe('IDE', function () {
             await ide.cleanup();
         }
         finally {
-            for (const [f, b] of originalFiles) {
-                await fs.writeFile(f, b);
-            }
+            await protectedFiles.restore();
         }
 
     });

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -602,11 +602,20 @@ class ProtectedFile {
     }
 
     async restore() {
-        const newHash = calcHash(await readFile(this.filename));
-        if (!newHash.equals(this.hash)) {
+        if (!(await exists(this.filename)) || !calcHash(await readFile(this.filename)).equals(this.hash)) {
             await writeFile(this.filename, this.content);
         }
     }
+}
+
+async function exists(file: string) {
+    try {
+        return await stat(file) !== undefined;
+    }
+    catch (_ignored) {
+        return false;
+    }
+
 }
 
 function calcHash(content: Buffer<ArrayBuffer>): Buffer<ArrayBuffer> {

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -26,7 +26,8 @@
  */
 
 import { assert, expect } from "chai";
-import { stat, unlink } from "fs/promises";
+import { createHash } from "crypto";
+import { readFile, stat, unlink, writeFile } from "fs/promises";
 import * as os from 'os';
 import { env } from "process";
 import { BottomBarPanel, By, ContentAssist, EditorView, Key, Locator, MarkerType, TerminalView, TextEditor, VSBrowser, WebDriver, WebElement, WebElementCondition, Workbench, until } from "vscode-extension-tester";
@@ -569,4 +570,47 @@ export async function expectCompletions(driver: WebDriver, editor: TextEditor, e
     expect(completions).to.have.length(expectedLabels.length);
     const labels: string[] = await Promise.all(completions!.map(c => c.getLabel()));
     expect(labels).deep.equal(expectedLabels);
+}
+
+
+export class ProtectedFiles {
+    private constructor(private readonly files: readonly ProtectedFile[]) {
+    }
+
+    public static async protect(...files: string[]) {
+        return new ProtectedFiles(await Promise.all(files.map(f => ProtectedFile.build(f))));
+    }
+
+    public async restore() {
+        return Promise.all(this.files.map(f => f.restore()));
+    }
+}
+
+class ProtectedFile {
+
+    constructor(
+        private readonly filename: string,
+        private readonly content: Buffer<ArrayBuffer>,
+        private readonly hash: Buffer<ArrayBuffer>
+    ) {
+    }
+
+    static async build(filename: string) {
+        const content = await readFile(filename);
+        const hash = calcHash(content);
+        return new ProtectedFile(filename, content, hash);
+    }
+
+    async restore() {
+        const newHash = calcHash(await readFile(this.filename));
+        if (!newHash.equals(this.hash)) {
+            await writeFile(this.filename, this.content);
+        }
+    }
+}
+
+function calcHash(content: Buffer<ArrayBuffer>): Buffer<ArrayBuffer> {
+    const hasher = createHash('sha256');
+    hasher.update(content);
+    return hasher.digest();
 }


### PR DESCRIPTION
This should reduce the changes of the race with the rascal.mf diagnostics