### PR TITLE
Only run the analyzer on files open in the workspace

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalTextDocumentService.java
@@ -105,6 +105,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.rascalmpl.library.util.PathConfig;
 import org.rascalmpl.uri.URIResolverRegistry;
+import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.values.IRascalValueFactory;
 import org.rascalmpl.values.parsetrees.ITree;
 import org.rascalmpl.values.parsetrees.ProductionAdapter;
@@ -245,8 +246,17 @@ public class RascalTextDocumentService extends TextDocumentStateManager implemen
         triggerAnalyzer(changed, NORMAL_DEBOUNCE);
     }
 
+    private boolean isOpenInWorkspace(ISourceLocation loc) {
+        return availableWorkspaceServices().workspaceFolders()
+            .stream()
+            .map(f -> URIUtil.assumeCorrectLocation(f.getUri()))
+            .anyMatch(f -> URIUtil.isParentOf(f, loc));
+    }
+
     private void triggerAnalyzer(TextDocumentState state, Duration delay) {
-        availableFacts().triggerAnalyzer(state.getLocation(), state.getCurrentTreeAsync(true), state.getCurrentContent(), delay);
+        if (isOpenInWorkspace(state.getLocation())) {
+            availableFacts().triggerAnalyzer(state.getLocation(), state.getCurrentTreeAsync(true), state.getCurrentContent(), delay);
+        }
     }
 
 

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Actions.rsc
@@ -47,7 +47,7 @@ The commands must be evaluated by ((evaluateRascalCommand))
 data Command
     = visualImportGraphCommand(PathConfig pcfg)
     | sortImportsAndExtends(Header h)
-    | upgradeAnnotations(PathConfig pcfg) // reported by the analyzer itself
+    | upgradeAnnotations(PathConfig pcfg)
     ;
 
 

--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Analyzer.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/Analyzer.rsc
@@ -44,18 +44,15 @@ list[Message] analyze(start[Module] tree, PathConfig(loc file) getPathConfig) {
     void reportAnnotationDeprecation(Tree t) {
         if (!annotationAlreadyReported) {
             annotationAlreadyReported = true;
-            if (isWritable(t.src.top)) {
-                // only reporting issues for code we can rewrite
-                result += warning(
-                    "Annotations are no longer supported and will soon be removed, please use our build-in Quick Fix to refactor them into keyword parameters",
-                    t.src, fixes=[
-                        action(
-                            command=upgradeAnnotations(getPathConfig(t.src.top)),
-                            title="Upgrade all annotations to keyword fields in this project (annotation syntax is no longer supported)."
-                        )
-                    ]
-                );
-            }
+            result += warning(
+                "Annotations are no longer supported and will soon be removed, please use our build-in Quick Fix to refactor all of them into keyword parameters",
+                t.src, fixes=[
+                    action(
+                        command=upgradeAnnotations(getPathConfig(t.src.top)),
+                        title="Upgrade all annotations to keyword fields in this project (annotation syntax is no longer supported)."
+                    )
+                ]
+            );
         }
         // since the single Quick Fix fixes the whole project, it's not useful to report it multiple times
         // especially since a user might click "fix all" and then the upgrade would be run several times.


### PR DESCRIPTION
To avoid issues getting rapported on files we cannot rewrite/fix for a whole bunch of reasons

This is based on a review by @jurgenvinju (after #1122 was already merged) that remarked that using `isWritable` might not be the best heuristic.


