### PR TITLE
Make sure path configs are not build on URIs we know are not legal

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/PathConfigs.java
@@ -132,9 +132,15 @@ public class PathConfigs {
         }
     }
 
+
     private Pair<PathConfig, Instant> buildPathConfig(ISourceLocation projectRoot) {
         try {
             logger.debug("Building path config for: {}", projectRoot);
+            var scheme = projectRoot.getScheme();
+            if (scheme.startsWith("jar+") || scheme.equals("std") || scheme.equals("mvn")) {
+                logger.error("We're asked to build a path config for {} which is not something that is possible", projectRoot);
+                return Pair.of(new PathConfig(projectRoot), Instant.now());
+            }
             ISourceLocation manifest = URIUtil.getChildLocation(projectRoot, "META-INF/RASCAL.MF");
             if (reg.exists(manifest)) {
                 updater.watchFile(projectRoot, manifest);


### PR DESCRIPTION
Sometimes (primarily caused by the `codeActions`) we get an request to build a `PathConfig` for a location where it's not legal to build a path config.

This PR at least stops the error messages that come up for the user by generating an empy path config.

Note that in the future we should change the actions code to maybe only run on workspace files.