### PR TITLE
Fix ESlint command line options.

### DIFF
--- a/rascal-vscode-extension/package.json
+++ b/rascal-vscode-extension/package.json
@@ -299,7 +299,7 @@
     "compile:tests": "npm run esbuild -- --tests",
     "pretest:ui": "npm run compile:tests",
     "pretest:normal": "npm run compile:tests",
-    "lint": "npx eslint",
+    "lint": "npx eslint src",
 
     "test:ui": "npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests",
     "test:normal": "npx mocha ./out/test/normal-suite/",


### PR DESCRIPTION
In #1129, `npm run lint` was accidentally disabled by removing all command line options to `npx eslint`. This PR reinstates the folder option to run ESlint on all sources again. We do not need an extension filter, since that is taken care of in the ESlint config:
https://github.com/usethesource/rascal-language-servers/blob/ec5a0ad1017b20e4ce36ca5e20efd21fda808fd0/rascal-vscode-extension/.eslintrc.json#L18