### PR TITLE
Fix JSON logging from standard error

### DIFF
--- a/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
+++ b/rascal-vscode-extension/src/lsp/JsonOutputChannel.ts
@@ -146,7 +146,7 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
         }
     }
 
-    private printPayloads(payload: string): void {
+    private tryLogJsonMessage(payload: string, fallbackLogger: (message: string) => void): void {
         for (const line of payload.trim().split("\n")) {
             try {
                 const log = JSON.parse(line);
@@ -160,7 +160,9 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
             } catch (e) {
                 if (e instanceof SyntaxError) {
                     // Regular, non-JSON log from somewhere
-                    this.logChannel.appendLine(line);
+                    fallbackLogger(line);
+                } else {
+                    throw e;
                 }
             }
         }
@@ -179,7 +181,7 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
 
     // This is called from the server side, a.k.a. with JSON payloads (possibly multiple, one per line)
     append(payload: string): void {
-        this.printPayloads(payload);
+        this.tryLogJsonMessage(payload, this.logChannel.append);
     }
 
     // This is called from the client with straight info messages
@@ -232,6 +234,11 @@ export class JsonParserOutputChannel implements vscode.LogOutputChannel {
     }
 
     error(error: string | Error, ...args: unknown[]): void {
-        this.logChannel.error(error, args);
+        // Since the language server logs to stderr, logs come in as errors. We try to log them as JSON payloads.
+        if (args.length === 0 && typeof(error) === 'string') {
+            this.tryLogJsonMessage(error, this.logChannel.error);
+        } else {
+            this.logChannel.error(error, args);
+        }
     }
 }


### PR DESCRIPTION
The update of `vscode-languageclient` to `10.x` in #1114 changed logging behaviour, since the logger is now a `LogOutputChannel` by default (instead of an `OutputChannel` - https://github.com/microsoft/vscode-languageserver-node/pull/1630).

Where before, we received `OuptuChannel::append` calls for LOG4J messages from the language server, this has changed to `LogOutputChannel::error` calls, enabled by the more refined logger type in the client. This is probably because LOG4J uses the standard error stream.