### PR TITLE
Fit command on single line

### DIFF
--- a/rascal-vscode-extension/src/test/vscode-suite/remotefs.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/remotefs.test.ts
@@ -107,7 +107,8 @@ describe('RemoteFS', function () {
         await repl.execute("import IO;");
         await repl.execute("l = |compressed+tmp:///rascal-remotefs-test/rascal-test-file.gz|;");
         await repl.execute('writeFile(l, "hi")');
-        await repl.execute('readFile(|rascal-vscode-test:///remotefs-api-test/test-rascalfs-read|) == "hi"');
+        await repl.execute("l2 = |rascal-vscode-test:///remotefs-api-test/test-rascalfs-read|;");
+        await repl.execute('readFile(l2) == "hi"');
         expect(repl.lastOutput).is.equal("bool: true", "Reading from Rascal fs works");
     });
 


### PR DESCRIPTION
Due to limitations in our test framework, we can only reliably read the REPL output for commands that span a single line. This test [was](https://github.com/usethesource/rascal-language-servers/actions/runs/28891687914/job/85705741576?pr=1134) [failing](https://github.com/usethesource/rascal-language-servers/actions/runs/28782558986/job/85352899516) on Windows sometimes on unrelated PRs. This PR fixes this.