### PR TITLE
Redirect resolved URI to LSP based on original and resolved URIs

### DIFF
--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/RascalLanguageServices.java
@@ -70,6 +70,7 @@ import org.rascalmpl.values.parsetrees.TreeAdapter;
 import org.rascalmpl.vscode.lsp.BaseWorkspaceService;
 import org.rascalmpl.vscode.lsp.IBaseLanguageClient;
 import org.rascalmpl.vscode.lsp.RascalLSPMonitor;
+import org.rascalmpl.vscode.lsp.uri.LSPOpenFileResolver;
 import org.rascalmpl.vscode.lsp.util.EvaluatorUtil;
 import org.rascalmpl.vscode.lsp.util.EvaluatorUtil.LSPContext;
 import org.rascalmpl.vscode.lsp.util.RascalServices;
@@ -161,7 +162,8 @@ public class RascalLanguageServices {
     }
 
     private static @Nullable ISourceLocation libraryTplRoot(ISourceLocation modPath) throws URISyntaxException {
-        modPath = Locations.toPhysicalIfPossible(modPath); // resolve logical paths like `std:///`
+        // Resolve logical paths, but get rid of the `lsp+` prefix, since we do not care about file contents
+        modPath = LSPOpenFileResolver.stripLspPrefix(Locations.toPhysicalIfPossible(modPath));
         if (isInsideJar(modPath)) {
             return URIUtil.getChildLocation(jarBasePath(modPath), "rascal");
         } else if ("mvn".equals(modPath.getScheme())) {

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileRedirector.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileRedirector.java
@@ -31,9 +31,9 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.rascalmpl.uri.URIResolverRegistry;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
@@ -66,15 +66,16 @@ public class LSPOpenFileRedirector {
     }
 
     public ISourceLocation resolve(ISourceLocation input) {
-        if (isFileManaged(input)) {
-            try {
+        try {
+            // If the file is currently open and can be modified, redirect to the contents in LSP.
+            if (isFileManaged(input) && URIResolverRegistry.getInstance().isWritable(input)) {
                 // The offset/length part of the source location is stripped off here.
                 // This is reinstated by `URIResolverRegistry::resolveAndFixOffsets`
                 // during logical resolution
                 return URIUtil.changeScheme(input.top(), "lsp+" + input.getScheme());
-            } catch (URISyntaxException e) {
-                // fall through
             }
+        } catch (URISyntaxException | IOException e) {
+            // fall through
         }
         return input;
     }

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileRedirector.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileRedirector.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.rascalmpl.uri.URIResolverRegistry;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.rascalmpl.uri.URIUtil;
 import org.rascalmpl.vscode.lsp.IBaseTextDocumentService;
 import org.rascalmpl.vscode.lsp.TextDocumentState;
@@ -65,19 +65,26 @@ public class LSPOpenFileRedirector {
         return false;
     }
 
-    public ISourceLocation resolve(ISourceLocation input) {
+    /**
+     * Redirect a URI to it's LSP-managed counterpart. Considers both the original and resolved URI.
+     * @param resolved The resolution of the original URI.
+     * @param original The URI as it came in from VS Code (possibly logical). This is the one that will often be registered as the 'managed' file.
+     * @return A redirected URI if the file is open in LSP. If not return the resolved URI if non-null, and the original otherwise.
+     */
+    public ISourceLocation redirect(@Nullable ISourceLocation resolved, ISourceLocation original) {
+        var r = resolved != null ? resolved : original;
         try {
-            // If the file is currently open and can be modified, redirect to the contents in LSP.
-            if (isFileManaged(input) && URIResolverRegistry.getInstance().isWritable(input)) {
+            // If the file is currently open, redirect to the contents in LSP.
+            if ((resolved != null && isFileManaged(resolved)) || isFileManaged(original)) {
                 // The offset/length part of the source location is stripped off here.
                 // This is reinstated by `URIResolverRegistry::resolveAndFixOffsets`
                 // during logical resolution
-                return URIUtil.changeScheme(input.top(), "lsp+" + input.getScheme());
+                return URIUtil.changeScheme(r.top(), "lsp+" + r.getScheme());
             }
-        } catch (URISyntaxException | IOException e) {
+        } catch (URISyntaxException e) {
             // fall through
         }
-        return input;
+        return r;
     }
 
     private final List<IBaseTextDocumentService> textDocumentServices = new CopyOnWriteArrayList<>();

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileRedirector.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/LSPOpenFileRedirector.java
@@ -66,7 +66,7 @@ public class LSPOpenFileRedirector {
     }
 
     /**
-     * Redirect a URI to it's LSP-managed counterpart. Considers both the original and resolved URI.
+     * Redirect a URI to its LSP-managed counterpart. Considers both the original and resolved URI.
      * @param resolved The resolution of the original URI.
      * @param original The URI as it came in from VS Code (possibly logical). This is the one that will often be registered as the 'managed' file.
      * @return A redirected URI if the file is open in LSP. If not return the resolved URI if non-null, and the original otherwise.

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/uri/jsonrpc/VSCodeFileSystemInRascal.java
@@ -27,7 +27,6 @@
 package org.rascalmpl.vscode.lsp.uri.jsonrpc;
 
 import java.io.IOException;
-
 import org.rascalmpl.uri.remote.RemoteExternalResolverRegistry;
 import org.rascalmpl.vscode.lsp.uri.LSPOpenFileRedirector;
 
@@ -50,13 +49,10 @@ public class VSCodeFileSystemInRascal extends RemoteExternalResolverRegistry {
 
     @Override
     public ISourceLocation resolve(ISourceLocation input) throws IOException {
-        ISourceLocation resolved;
+        ISourceLocation resolved = null;
         if (super.supportsLogical(input.getScheme())) {
             resolved = super.resolve(input);
         }
-        else {
-            resolved = input;
-        }
-        return LSPOpenFileRedirector.getInstance().resolve(resolved == null ? input : resolved);
+        return LSPOpenFileRedirector.getInstance().redirect(resolved, input);
     }
 }


### PR DESCRIPTION
Fixes a bug where `std://` would not be redirected to LSP, but `mvn://` would.

Since `std://` is resolved to `jar+file://` (in most cases) before checking if the file is managed by LSP, the `isFileManaged` check alway returns false: the open file key is `std://`, not `jar+file://`. This fix makes sure that both the original URI (as coming in from VS Code) as well as the resolved URI are checked for the need of redirecting to LSP.