### PR TITLE
Added cache storing schemes and authorities of incoming URIs in VS Code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
           DELAY_FACTOR: 10
           RASCAL_LSP_DEV_DEPLOY: true
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (mac)"
         shell: bash
@@ -138,7 +138,7 @@ jobs:
           DELAY_FACTOR: 15
           RASCAL_LSP_DEV_DEPLOY: true
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: "UI test (ubuntu)"
         shell: bash
@@ -150,7 +150,7 @@ jobs:
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
         run: |
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 # workaround for issue with Ubuntu 24.04 https://github.com/redhat-developer/vscode-extension-tester/blob/main/KNOWN_ISSUES.md#openresources-not-working-with-apparmor-2404
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
           DELAY_FACTOR: 10
           RASCAL_LSP_DEV_DEPLOY: true
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
 
       - name: "UI test (mac)"
         shell: bash
@@ -138,7 +138,7 @@ jobs:
           DELAY_FACTOR: 15
           RASCAL_LSP_DEV_DEPLOY: true
           _JAVA_OPTIONS: '-Xmx5G'
-        run: npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
+        run: npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
 
       - name: "UI test (ubuntu)"
         shell: bash
@@ -150,7 +150,7 @@ jobs:
           _JAVA_OPTIONS: '-Xmx5G' # we have 16gb of memory, make sure LSP, REPL & DSL-LSP can start
         run: |
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 # workaround for issue with Ubuntu 24.04 https://github.com/redhat-developer/vscode-extension-tester/blob/main/KNOWN_ISSUES.md#openresources-not-working-with-apparmor-2404
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/*.test.js --storage uitests
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npx extest setup-and-run out/test/vscode-suite/ide.test.js --storage uitests
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7

--- a/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/SummaryBridge.java
+++ b/rascal-lsp/src/main/java/org/rascalmpl/vscode/lsp/rascal/model/SummaryBridge.java
@@ -91,7 +91,7 @@ public class SummaryBridge {
         for (IValue v: binaryRel) {
             ITuple row = (ITuple)v;
             ISourceLocation fromLoc = (ISourceLocation)row.get(0);
-            if (!fromLoc.top().toString().equalsIgnoreCase(self.toString())) {
+            if (!fromLoc.top().equals(self)) {
                 // ignore rascal-core giving us entries that are not starting with our own base
                 continue;
             }

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -95,8 +95,10 @@ export async function activateLanguageClient(
 
                 if (parsed.scheme !== "file" && parsed.authority !== "") {
                     const cachedCasing = getCachedCasing(parsed);
-                    if (cachedCasing && !(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
-                        logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
+                    if (cachedCasing) {
+                        if (!(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
+                            logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
+                        }
                     } else {
                         storeCasing(parsed);
                     }

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -62,7 +62,7 @@ export async function activateLanguageClient(
         return `${normalizedScheme}/${normalizedAuthority}`;
     }
 
-    const uriMatcher = /^[^:]*:\/\/[^/]*\/(.*)&/;
+    const uriMatcher = /^[^:]*:\/\/[^/]*\/(.*)$/;
 
     const clientOptions = <LanguageClientOptions>{
         documentSelector: [{ scheme: '*', language: language }],

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -44,9 +44,54 @@ export async function activateLanguageClient(
         : () => connectToRascalLanguageServerSocket(devPort) // we assume a server is running in debug mode
             .then((socket) => <StreamInfo> { writer: socket, reader: socket});
 
+    const schemeAuthorityCasing: Map<string, [string, string]> = new Map();
+
+    function getCachedCasing(uri: vscode.Uri) : [string, string] | undefined {
+        return schemeAuthorityCasing.get(casingMapKey(uri));
+    }
+
+    function storeCasing(uri: vscode.Uri): void {
+        schemeAuthorityCasing.set(casingMapKey(uri), [uri.scheme, uri.authority]);
+    }
+
+    function casingMapKey(uri: vscode.Uri): string {
+        const normalizedScheme = uri.scheme.toLowerCase();
+        const normalizedAuthority = uri.authority.toLowerCase();
+        return `${normalizedScheme}/${normalizedAuthority}`;
+    }
+
     const clientOptions = <LanguageClientOptions>{
         documentSelector: [{ scheme: '*', language: language }],
         outputChannel: logger,
+        middleware: {
+            uriConverters: {
+                // VS Code may convert schemes and authorities to lower case (which is allowed by the standard).
+                // Some Rascal locations have schemes and/or authorities for which the casing does matter (e.g., |mvn:///| or |project:///|).
+                // The casing of the schemes and autorities of incoming URIs is therefore stored, so the original casing
+                // can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
+                code2Protocol: (uri: vscode.Uri) : string => {
+                    const cachedCasing = getCachedCasing(uri);
+
+                    if (cachedCasing) {
+                        uri = uri.with({ scheme: cachedCasing[0], authority: cachedCasing[1] });
+                    }
+
+                    return uri.toString();
+                },
+                protocol2Code: (uriString: string): vscode.Uri => {
+                    const parsed = vscode.Uri.parse(uriString);
+                    const cachedCasing = getCachedCasing(parsed);
+
+                    if (cachedCasing && !(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
+                        logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
+                    } else {
+                        storeCasing(parsed);
+                    }
+
+                    return parsed;
+                }
+            }
+        }
     };
 
     const client = new LanguageClient(language, title, serverOptions, clientOptions, !deployMode);

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -65,37 +65,35 @@ export async function activateLanguageClient(
     const clientOptions = <LanguageClientOptions>{
         documentSelector: [{ scheme: '*', language: language }],
         outputChannel: logger,
-        middleware: {
-            uriConverters: {
-                // VS Code may convert schemes and authorities to lower case (which is allowed by the standard).
-                // Some Rascal locations have schemes and/or authorities for which the casing does matter (e.g., |mvn:///| or |project:///|).
-                // The casing of the schemes and autorities of incoming URIs is therefore stored, so the original casing
-                // can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
-                code2Protocol: (uri: vscode.Uri) : string => {
-                    const uriString = uri.toString();
-                    const cachedCasing = getCachedCasing(uri);
+        uriConverters: {
+            // VS Code may convert schemes and authorities to lower case (which is allowed by the standard).
+            // Some Rascal locations have schemes and/or authorities for which the casing does matter (e.g., |mvn:///| or |project:///|).
+            // The casing of the schemes and autorities of incoming URIs is therefore stored, so the original casing
+            // can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
+            code2Protocol: (uri: vscode.Uri) : string => {
+                const uriString = uri.toString();
+                const cachedCasing = getCachedCasing(uri);
 
-                    if (cachedCasing) {
-                        const match = uriMatcher.exec(uriString);
-                        if (match) {
-                            return `${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`;
-                        }
+                if (cachedCasing) {
+                    const match = uriMatcher.exec(uriString);
+                    if (match) {
+                        return `${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`;
                     }
-
-                    return uriString;
-                },
-                protocol2Code: (uriString: string): vscode.Uri => {
-                    const parsed = vscode.Uri.parse(uriString);
-                    const cachedCasing = getCachedCasing(parsed);
-
-                    if (cachedCasing && !(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
-                        logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
-                    } else {
-                        storeCasing(parsed);
-                    }
-
-                    return parsed;
                 }
+
+                return uriString;
+            },
+            protocol2Code: (uriString: string): vscode.Uri => {
+                const parsed = vscode.Uri.parse(uriString);
+                const cachedCasing = getCachedCasing(parsed);
+
+                if (cachedCasing && !(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
+                    logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
+                } else {
+                    storeCasing(parsed);
+                }
+
+                return parsed;
             }
         }
     };

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -47,12 +47,11 @@ export async function activateLanguageClient(
     const schemeAuthorityCasing: Map<string, [string, string]> = new Map();
 
     function getCachedCasing(uri: vscode.Uri) : [string, string] | undefined {
-        logger.info(`[RascalLSPConnection] Retrieving casing of ${uri} (${casingMapKey(uri)} => [${schemeAuthorityCasing.get(casingMapKey(uri))})}])`);
         return schemeAuthorityCasing.get(casingMapKey(uri));
     }
 
     function storeCasing(uri: vscode.Uri): void {
-        logger.info(`[RascalLSPConnection] Storing casing of ${uri} (${casingMapKey(uri)} => [${uri.scheme}, ${uri.authority}])`);
+        logger.debug(`[RascalLSPConnection] Storing casing of ${uri} (${casingMapKey(uri)} => [${uri.scheme}, ${uri.authority}])`);
         schemeAuthorityCasing.set(casingMapKey(uri), [uri.scheme, uri.authority]);
     }
 
@@ -82,8 +81,9 @@ export async function activateLanguageClient(
                         // `Uri.with` followed by `Uri.toString` is not an option, as the latter performs the case normalization
                         const match = uriMatcher.exec(uriString);
                         if (match) {
-                            logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${match[1]}://${cachedCasing[1]}/${match[2]}`}`);
-                            return `${match[1]}://${cachedCasing[1]}/${match[2]}`;
+                            const denormalized = `${match[1]}://${cachedCasing[1]}/${match[2]}`;
+                            logger.debug(`[RascalLSPConnection] Changed ${uriString} into ${denormalized}`);
+                            return denormalized;
                         }
                     }
                 }

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -62,6 +62,7 @@ export async function activateLanguageClient(
         return `${normalizedScheme}/${normalizedAuthority}`;
     }
 
+    // This regular expression does not match opaque URIs. That is not a problem, since those never have an authority to correct
     const uriMatcher = /^[^:]*:\/\/[^/]*\/(.*)$/;
 
     const clientOptions = <LanguageClientOptions>{
@@ -77,6 +78,7 @@ export async function activateLanguageClient(
                 const cachedCasing = getCachedCasing(uri);
 
                 if (cachedCasing) {
+                    // `Uri.with` followed by `Uri.toString` is not an option, as the latter performs the case normalization
                     const match = uriMatcher.exec(uriString);
                     if (match) {
                         logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`}`);

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -51,6 +51,7 @@ export async function activateLanguageClient(
     }
 
     function storeCasing(uri: vscode.Uri): void {
+        logger.info(`[RascalLSPConnection] Storing casing of uriString (${casingMapKey(uri)} => [${uri.scheme}, ${uri.authority}])`);
         schemeAuthorityCasing.set(casingMapKey(uri), [uri.scheme, uri.authority]);
     }
 
@@ -77,6 +78,7 @@ export async function activateLanguageClient(
                 if (cachedCasing) {
                     const match = uriMatcher.exec(uriString);
                     if (match) {
+                        logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`}`);
                         return `${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`;
                     }
                 }

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -47,11 +47,12 @@ export async function activateLanguageClient(
     const schemeAuthorityCasing: Map<string, [string, string]> = new Map();
 
     function getCachedCasing(uri: vscode.Uri) : [string, string] | undefined {
+        logger.info(`[RascalLSPConnection] Retrieving casing of ${uri} (${casingMapKey(uri)} => [${schemeAuthorityCasing.get(casingMapKey(uri))})}])`);
         return schemeAuthorityCasing.get(casingMapKey(uri));
     }
 
     function storeCasing(uri: vscode.Uri): void {
-        logger.info(`[RascalLSPConnection] Storing casing of uriString (${casingMapKey(uri)} => [${uri.scheme}, ${uri.authority}])`);
+        logger.info(`[RascalLSPConnection] Storing casing of ${uri} (${casingMapKey(uri)} => [${uri.scheme}, ${uri.authority}])`);
         schemeAuthorityCasing.set(casingMapKey(uri), [uri.scheme, uri.authority]);
     }
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -75,7 +75,7 @@ export async function activateLanguageClient(
             code2Protocol: (uri: vscode.Uri) : string => {
                 const uriString = uri.toString();
 
-                if (uri.scheme !== "file" && uri.authority !== "") {
+                if (uri.authority !== "") {
                     const cachedCasing = getCachedCasing(uri);
                     if (cachedCasing) {
                         // `Uri.with` followed by `Uri.toString` is not an option, as the latter performs the case normalization
@@ -93,7 +93,7 @@ export async function activateLanguageClient(
             protocol2Code: (uriString: string): vscode.Uri => {
                 const parsed = vscode.Uri.parse(uriString);
 
-                if (parsed.scheme !== "file" && parsed.authority !== "") {
+                if (parsed.authority !== "") {
                     const cachedCasing = getCachedCasing(parsed);
                     if (cachedCasing) {
                         if (!(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -63,16 +63,16 @@ export async function activateLanguageClient(
     }
 
     // This regular expression does not match opaque URIs. That is not a problem, since those never have an authority to correct
-    const uriMatcher = /^[^:]*:\/\/[^/]*\/(.*)$/;
+    const uriMatcher = /^([^:]*):\/\/[^/]*\/(.*)$/;
 
     const clientOptions = <LanguageClientOptions>{
         documentSelector: [{ scheme: '*', language: language }],
         outputChannel: logger,
         uriConverters: {
             // VS Code may convert schemes and authorities to lower case (which is allowed by the standard).
-            // Some Rascal locations have schemes and/or authorities for which the casing does matter (e.g., |mvn:///| or |project:///|).
+            // Some Rascal locations have authorities for which the casing does matter (e.g., |mvn:///| or |project:///|).
             // The casing of the schemes and autorities of incoming URIs is therefore stored, so the original casing
-            // can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
+            // of the authority can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
             code2Protocol: (uri: vscode.Uri) : string => {
                 const uriString = uri.toString();
                 const cachedCasing = getCachedCasing(uri);
@@ -81,8 +81,8 @@ export async function activateLanguageClient(
                     // `Uri.with` followed by `Uri.toString` is not an option, as the latter performs the case normalization
                     const match = uriMatcher.exec(uriString);
                     if (match) {
-                        logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`}`);
-                        return `${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`;
+                        logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${match[1]}://${cachedCasing[1]}/${match[2]}`}`);
+                        return `${match[1]}://${cachedCasing[1]}/${match[2]}`;
                     }
                 }
 

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -60,6 +60,8 @@ export async function activateLanguageClient(
         return `${normalizedScheme}/${normalizedAuthority}`;
     }
 
+    const uriMatcher = /^[^:]*:\/\/[^/]*\/(.*)&/;
+
     const clientOptions = <LanguageClientOptions>{
         documentSelector: [{ scheme: '*', language: language }],
         outputChannel: logger,
@@ -70,13 +72,17 @@ export async function activateLanguageClient(
                 // The casing of the schemes and autorities of incoming URIs is therefore stored, so the original casing
                 // can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
                 code2Protocol: (uri: vscode.Uri) : string => {
+                    const uriString = uri.toString();
                     const cachedCasing = getCachedCasing(uri);
 
                     if (cachedCasing) {
-                        uri = uri.with({ scheme: cachedCasing[0], authority: cachedCasing[1] });
+                        const match = uriMatcher.exec(uriString);
+                        if (match) {
+                            return `${cachedCasing[0]}://${cachedCasing[1]}/${match[1]}`;
+                        }
                     }
 
-                    return uri.toString();
+                    return uriString;
                 },
                 protocol2Code: (uriString: string): vscode.Uri => {
                     const parsed = vscode.Uri.parse(uriString);

--- a/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
+++ b/rascal-vscode-extension/src/lsp/RascalLSPConnection.ts
@@ -75,14 +75,16 @@ export async function activateLanguageClient(
             // of the authority can be restored when round-tripping (i.e., Rascal => VS Code => Rascal).
             code2Protocol: (uri: vscode.Uri) : string => {
                 const uriString = uri.toString();
-                const cachedCasing = getCachedCasing(uri);
 
-                if (cachedCasing) {
-                    // `Uri.with` followed by `Uri.toString` is not an option, as the latter performs the case normalization
-                    const match = uriMatcher.exec(uriString);
-                    if (match) {
-                        logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${match[1]}://${cachedCasing[1]}/${match[2]}`}`);
-                        return `${match[1]}://${cachedCasing[1]}/${match[2]}`;
+                if (uri.scheme !== "file" && uri.authority !== "") {
+                    const cachedCasing = getCachedCasing(uri);
+                    if (cachedCasing) {
+                        // `Uri.with` followed by `Uri.toString` is not an option, as the latter performs the case normalization
+                        const match = uriMatcher.exec(uriString);
+                        if (match) {
+                            logger.info(`[RascalLSPConnection] Changed ${uriString} into ${`${match[1]}://${cachedCasing[1]}/${match[2]}`}`);
+                            return `${match[1]}://${cachedCasing[1]}/${match[2]}`;
+                        }
                     }
                 }
 
@@ -90,12 +92,14 @@ export async function activateLanguageClient(
             },
             protocol2Code: (uriString: string): vscode.Uri => {
                 const parsed = vscode.Uri.parse(uriString);
-                const cachedCasing = getCachedCasing(parsed);
 
-                if (cachedCasing && !(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
-                    logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
-                } else {
-                    storeCasing(parsed);
+                if (parsed.scheme !== "file" && parsed.authority !== "") {
+                    const cachedCasing = getCachedCasing(parsed);
+                    if (cachedCasing && !(cachedCasing[0] === parsed.scheme && cachedCasing[1] === parsed.authority)) {
+                        logger.warn(`Received scheme/authority casing |${parsed.scheme}://${parsed.authority}/| that is inconsistent with earlier |${cachedCasing[0]}://${cachedCasing[1]}/|. Round-tripping locations correctly is likely not possible`);
+                    } else {
+                        storeCasing(parsed);
+                    }
                 }
 
                 return parsed;


### PR DESCRIPTION
VS Code may convert schemes and authorities to lower case (which is allowed by the standard). For some Rascal locations (`|mvn://|` and `|project://|` come to mind) this is problematic, since during resolution the authority is used as a part of the path; this is problematic on case-sensitive file systems.

This PR adds a cache storing the casing of schemes and authorities, and reinstates this casing for the authority when serializing URIs to string.

h/t @toinehartman 