### PR TITLE
Changed catch clause after changes in Rascal

### DIFF
--- a/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
+++ b/rascal-lsp/src/main/rascal/lsp/lang/rascal/lsp/refactor/rename/Modules.rsc
@@ -206,8 +206,7 @@ list[TextEdit] getChanges(loc f, PathConfig wsProject, lrel[str oldName, str new
         }
         return edits;
     }
-    catch Java("ParseError", str msg): return getChangesByContents(f, contents, wsProject, qualifiedNameChanges, registerMessage);
-    catch JavaException("ParseError", str msg): return getChangesByContents(f, contents, wsProject, qualifiedNameChanges, registerMessage);
+    catch ParseError(loc at): return getChangesByContents(f, contents, wsProject, qualifiedNameChanges, registerMessage);
     // Catch all
     catch e: registerMessage(error("<e>", f));
     return [];


### PR DESCRIPTION
In [this PR](https://github.com/usethesource/rascal/pull/2815), `parseModuleWithSpaces` was improved by throwing a `ParseError` instead of a `Java` error. The change in this PR reflects this change.