### PR TITLE
Bootstrap Rascal LSP for VS Code tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,9 +104,13 @@ jobs:
           cache-dependency-path: rascal-vscode-extension/package-lock.json
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Package & compile rascal-lsp
+      - name: Package & install rascal-lsp
         working-directory: ./rascal-lsp
-        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' -DskipTests clean package
+        run: mvn -B '-Drascal.compile.skip' '-Drascal.tutor.skip' -DskipTests clean install
+
+      - name: Set LSP dependency version in tests
+        shell: bash
+        run: ./update-test-dependencies.sh
 
       - name: Package & compile extension 
         working-directory: ./rascal-vscode-extension

--- a/build.sh
+++ b/build.sh
@@ -4,13 +4,15 @@ set -euo pipefail
 
 extra_flags=''
 lint=0
+goal='package'
 
 clean="clean"
-while getopts 'lfd' flag; do
+while getopts 'lfdi' flag; do
   case "${flag}" in
     f) extra_flags='-Drascal.compile.skip -Drascal.tutor.skip -DskipTests -Drascal.package.skip' ;;
     l) lint=1 ;;
     d) clean='' ;;
+    i) goal='install' ;;
     *) printf "incorrect param, valid params:
     Use -f to skip rascal-compile and tests
     Use -d to skip cleaning the target folder
@@ -26,7 +28,7 @@ rm -f rascal-lsp/target/*.jar
 if (( $lint == 1 )); then
    (cd rascal-lsp && mvn -B checkstyle:checkstyle  checkstyle:check )
 fi
-(cd rascal-lsp && mvn $clean package -Drascal.monitor.batch $extra_flags )
+(cd rascal-lsp && mvn $clean $goal -Drascal.monitor.batch $extra_flags )
 if (( $lint == 1 )); then
    (cd rascal-vscode-extension && npm run lint )
 fi

--- a/rascal-vscode-extension/test-workspace/test-project/pom.xml
+++ b/rascal-vscode-extension/test-workspace/test-project/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <lsp.version>2.22.6-SNAPSHOT</lsp.version>
+    <lsp.version>2.22.5</lsp.version>
   </properties>
 
   <repositories>

--- a/rascal-vscode-extension/test-workspace/test-project/pom.xml
+++ b/rascal-vscode-extension/test-workspace/test-project/pom.xml
@@ -9,6 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <lsp.version>2.22.6-SNAPSHOT</lsp.version>
   </properties>
 
   <repositories>
@@ -39,7 +40,7 @@
     <dependency>
       <groupId>org.rascalmpl</groupId>
       <artifactId>rascal-lsp</artifactId>
-      <version>2.22.6-RC1</version>
+      <version>${lsp.version}</version>
     </dependency>
   </dependencies>
 

--- a/runUItests.sh
+++ b/runUItests.sh
@@ -7,16 +7,24 @@
 set -e;
 set -x;
 
-cd rascal-vscode-extension
+# Find the current Rascal LSP version in the POM, and restore it when this script exits
+RESTORE_LSP_VERSION=$( ( cd rascal-vscode-extension/test-workspace/test-project && mvn dependency:tree -Dincludes=org.rascalmpl:rascal-lsp | grep rascal-lsp | cut -d ':' -f 4 ) )
+restore_versions() {
+    cd .. && ./update-test-dependencies.sh "$RESTORE_LSP_VERSION"
+}
+trap "restore_versions" EXIT
 
-UITESTS=/tmp/vscode-uitests
+# Bootstrap LSP version
+./update-test-dependencies.sh
+
 
 # cleanup to avoid contamination with previous runs
-
+UITESTS=/tmp/vscode-uitests
 rm -rf $UITESTS || true
 
 # compiling the TS code as well as the test TS code at least once is required before execution
 # this assumes you have run `npm ci` at least once since a large update
+cd rascal-vscode-extension
 npm run compile:tests
 
 # test what was compiled

--- a/update-test-dependencies.sh
+++ b/update-test-dependencies.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Sets the version of Rascal LSP in the test project(s) to the first argument of this script. If no argument is given, it uses the current version of Rascal LSP from the POM.
+
+# Find the current version of Rascal LSP
+LSP_VERSION=${1:-$( ( cd rascal-lsp && mvn help:evaluate -Dexpression=project.version -q -DforceStdout ) )}
+
+# Set the version of Rascal LSP in the test project
+( cd rascal-vscode-extension/test-workspace/test-project && mvn versions:use-dep-version -q -Dincludes=org.rascalmpl:rascal-lsp -DdepVersion=$LSP_VERSION -DprocessProperties )


### PR DESCRIPTION
Preliminary work to properly test language projects, since https://github.com/usethesource/rascal-language-servers/pull/1159 requires language projects to have an explicit LSP dependency.