### PR TITLE
Only open the REPL in a project when a Rascal editor is open.

### DIFF
--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -195,13 +195,19 @@ export class RascalExtension implements vscode.Disposable {
                 }
 
                 progress.report({increment: 50, message: "Creating terminal"});
-                const terminal = vscode.window.createTerminal({
+
+                const options: vscode.TerminalOptions = {
                     iconPath: this.icon,
                     shellPath: await getJavaExecutable(this.log),
                     shellArgs: await this.buildShellArgs(remoteIDEServicesConfiguration, rascalClasses),
                     isTransient: false, // right now we don't support transient terminals yet
                     name: `Rascal terminal (${this.getTerminalOrigin(uri, command??"")})`,
-                });
+                };
+                if (!uri) {
+                    // Make sure the REPL does not open in a project if no editor is open
+                    options.cwd = os.homedir();
+                }
+                const terminal = vscode.window.createTerminal(options);
 
                 terminal.show(false);
                 if (command) {

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -29,8 +29,6 @@ import { expect } from 'chai';
 import { TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, getArtifactVersion, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, TestWorkspace } from './utils';
 import { fail } from 'assert';
-import * as os from 'os';
-import * as path from 'path/posix';
 
 describe('REPL', function () {
     let browser: VSBrowser;
@@ -68,7 +66,8 @@ describe('REPL', function () {
         if (!match || !match[1]) {
             fail(`No project root found in ${text}`);
         }
-        expect(path.resolve(match[1])).to.equal(path.resolve(os.homedir()));
+        // Expect home (or something that looks like home), but definitely not within the project
+        expect(match[1]).not.to.include('rascal-language-servers');
     }).retries(2);
 
     it("uses the standard library from the extension", async () => {

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -28,6 +28,9 @@
 import { expect } from 'chai';
 import { TextEditor, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
 import { Delays, getArtifactVersion, IDEOperations, ignoreFails, printRascalOutputOnFailure, RascalREPL, TestWorkspace } from './utils';
+import { fail } from 'assert';
+import * as os from 'os';
+import * as path from 'path/posix';
 
 describe('REPL', function () {
     let browser: VSBrowser;
@@ -58,10 +61,15 @@ describe('REPL', function () {
     });
 
     it("opens without a project", async () => {
-        await new RascalREPL(bench, driver).start();
+        const repl = new RascalREPL(bench, driver);
+        await repl.start();
+        const text = await repl.getText();
+        const match = text.match(/Project root is \|file:\/\/\/([^|]+)\|/);
+        if (!match || !match[1]) {
+            fail(`No project root found in ${text}`);
+        }
+        expect(path.resolve(match[1])).to.equal(path.resolve(os.homedir()));
     }).retries(2);
-
-    // TODO Add test for default REPL root
 
     it("uses the standard library from the extension", async () => {
         // Find Rascal version in POM


### PR DESCRIPTION
Predictably open REPLs inside or outside workspace projects