### PR TITLE
Improved REPL handling in tests

### DIFF
--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -55,11 +55,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
     }
 
     async function loadPico() {
-        // Make sure REPL opens on project with LSP dependency
-        await ide.openModule(TestWorkspace.libCallFile);
-
-        const repl = new RascalREPL(bench, driver);
-        await repl.start();
+        const repl = await RascalREPL.startWithLSP(ide, bench, driver);
         await repl.execute("import testing::lang::pico::LanguageServer;", false, Delays.extremelySlow);
         const replExecuteMain = repl.execute(`register(errorRecovery=${errorRecovery});`); // we don't wait yet, because we might miss pico loading window
         await startsAndStopsLoading(driver, bench, "Pico");
@@ -406,10 +402,7 @@ end
         });
 
         it("updates open editors on registration", async function() {
-            // Make sure REPL opens on project with LSP dependency
-            await ide.openModule(TestWorkspace.libCallFile);
-
-            const repl = new RascalREPL(bench, driver);
+            const repl = await RascalREPL.startWithLSP(ide, bench, driver);
             await repl.start();
             await unloadPico(repl);
             await repl.terminate();

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -43,24 +43,22 @@ parameterizedDescribe(function (errorRecovery: boolean) {
     let driver: WebDriver;
     let bench: Workbench;
     let ide : IDEOperations;
+    let repl: RascalREPL;
     let protectedFiles : ProtectedFiles;
 
     this.timeout(Delays.extremelySlow * 2);
 
     printRascalOutputOnFailure('Language Parametric Rascal Language Server');
 
-    async function unloadPico(repl: RascalREPL) {
-        await repl.execute("import util::LanguageServer;");
+    async function unloadPico() {
         await repl.execute('unregisterLanguage("Pico", {"pico", "pico-new"});');
     }
 
     async function loadPico() {
-        const repl = await RascalREPL.startWithLSP(ide, bench, driver);
         await repl.execute("import testing::lang::pico::LanguageServer;", false, Delays.extremelySlow);
         const replExecuteMain = repl.execute(`register(errorRecovery=${errorRecovery});`); // we don't wait yet, because we might miss pico loading window
         await startsAndStopsLoading(driver, bench, "Pico");
         await replExecuteMain;
-        await repl.terminate();
     }
 
     async function setParametricLanguage(editor: TextEditor) {
@@ -78,6 +76,7 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         await ignoreFails(browser.waitForWorkbench());
         ide = new IDEOperations(browser);
         await ide.load();
+        repl = await RascalREPL.startWithLSP(ide, bench, driver);
         await loadPico();
         protectedFiles = await ProtectedFiles.protect(TestWorkspace.picoFile);
     });
@@ -402,10 +401,7 @@ end
         });
 
         it("updates open editors on registration", async function() {
-            const repl = await RascalREPL.startWithLSP(ide, bench, driver);
-            await repl.start();
-            await unloadPico(repl);
-            await repl.terminate();
+            await unloadPico();
 
             const editor = await ide.openModule(TestWorkspace.picoFile);
             await setParametricLanguage(editor);

--- a/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/dsl.test.ts
@@ -81,6 +81,11 @@ parameterizedDescribe(function (errorRecovery: boolean) {
         protectedFiles = await ProtectedFiles.protect(TestWorkspace.picoFile);
     });
 
+    after(async () => {
+        await unloadPico();
+        await repl.terminate();
+    });
+
     beforeEach(async function () {
         if (this.test?.title) {
             await ide.screenshot(`DSL-${errorRecovery}-` + this.test?.title);

--- a/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/ide.test.ts
@@ -138,11 +138,7 @@ describe('IDE', function () {
     });
 
     it("opens a REPL in the root of the project", async function () {
-        // Open a module so the REPL associates with this project
-        await ide.openModule(TestWorkspace.libCallFile);
-
-        const repl = new RascalREPL(bench, driver);
-        await repl.start();
+        const repl = await RascalREPL.startFor(TestWorkspace.libCallFile, ide, bench, driver);
         const root = await repl.getProjectRoot();
         await repl.terminate();
 
@@ -150,11 +146,7 @@ describe('IDE', function () {
     });
 
     it("opens a REPL in the root of the library project", async function () {
-        // Open a module so the REPL associates with this project
-        await ide.openModule(TestWorkspace.libFile);
-
-        const repl = new RascalREPL(bench, driver);
-        await repl.start();
+        const repl = await RascalREPL.startFor(TestWorkspace.libFile, ide, bench, driver);
         const root = await repl.getProjectRoot();
         await repl.terminate();
 
@@ -162,15 +154,11 @@ describe('IDE', function () {
     });
 
     it("REPL uses the standard library from the project POM", async () => {
-        // Open a module so the REPL associates with this project
-        await ide.openModule(TestWorkspace.libCallFile);
-
         // Find Rascal version in POM
         const pomRascalVersion = await getArtifactVersion("org.rascalmpl", "rascal", TestWorkspace.testProjectPom, false);
 
         // Query Rascal version from stdlib
-        const repl = new RascalREPL(bench, driver);
-        await repl.start();
+        const repl = await RascalREPL.startFor(TestWorkspace.libCallFile, ide, bench, driver);
         await repl.execute("import IO;");
         await repl.execute("import util::Reflective;");
         await repl.execute("println(getRascalVersion());");

--- a/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/repl.test.ts
@@ -100,11 +100,7 @@ describe('REPL', function () {
     }).timeout(Delays.extremelySlow * 3);
 
     it("open module editor via repl", async() => {
-        // Make sure REPL opens on project with LSP dependency
-        await ide.openModule(TestWorkspace.libCallFile);
-
-        const repl = new RascalREPL(bench, driver);
-        await repl.start();
+        const repl = await RascalREPL.startFor(TestWorkspace.libCallFile, ide, bench, driver);
         await repl.execute(":edit demo::lang::pico::LanguageServer", true, Delays.extremelySlow);
 
         await driver.wait(async () => await (await bench.getEditorView().getActiveTab())?.getTitle() === "LanguageServer.rsc", Delays.slow, "LanguageServer should be opened");

--- a/rascal-vscode-extension/src/test/vscode-suite/utils.ts
+++ b/rascal-vscode-extension/src/test/vscode-suite/utils.ts
@@ -147,6 +147,20 @@ export class RascalREPL {
         }
     }
 
+    static async startFor(file: string, ide: IDEOperations, bench: Workbench, driver: WebDriver) {
+        await ide.openModule(file);
+        const repl = new RascalREPL(bench, driver);
+        await repl.start();
+        return repl;
+    }
+
+    static async startWithLSP(ide: IDEOperations, bench: Workbench, driver: WebDriver): Promise<RascalREPL> {
+        // Open a file from a project with a dependency on LSP, so we can use modules from LSP
+        const repl = await this.startFor(TestWorkspace.libCallFile, ide, bench, driver);
+        await repl.execute("import util::LanguageServer;");
+        return repl;
+    }
+
     async start() {
         await new Workbench().executeCommand("rascalmpl.createTerminal");
         return this.connect();


### PR DESCRIPTION
1. Utilities to open a REPL on a certain project, or with LSP available.
2. Keep alive the REPL used to (un)register languages in the DSL tests, and save time by importing necessary modules just once.
3. Clean up DSL test by unregistering language before moving to the next test suite.