### PR TITLE
Setting property for the REPL processes to prevent log4j from complaining about a missing logging provider

### DIFF
--- a/rascal-vscode-extension/src/RascalExtension.ts
+++ b/rascal-vscode-extension/src/RascalExtension.ts
@@ -335,6 +335,7 @@ export class RascalExtension implements vscode.Disposable {
             '-Dfile.encoding=UTF8'
             , `-Drascal.languageRegistryPort=${await this.rascal.languageRegistry.serverPort}`
             , `-Drascal.remoteResolverRegistryPort=${vfsServerPort}`
+            , '-Dlog4j.provider=org.apache.logging.log4j.simple.internal.SimpleProvider'
             , 'org.rascalmpl.shell.RascalShell'
             , '--remoteIDEServicesPort'
             , '' + remoteIDEServicesConfiguration.port


### PR DESCRIPTION
Partial fix for https://github.com/usethesource/rascal/issues/2436